### PR TITLE
Add Dream Router 7 (UDR7) model detection and gateway layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### ✨ Improvements
+- Added model detection and dedicated gateway layout support for Dream Router 7 (`UDR7`)
+
 ## [v0.4.1] - 2026-04-09
 
 ### ✨ Improvements

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ If you see improvements, issues, or fixes, feel free to open an issue or create 
 | USW Ultra (`USWULTRA`) | 8 | White |
 | USW Ultra 60W (`USWULTRA60W`) | 8 | White |
 | USW Ultra 210W (`USWULTRA210W`) | 8 | White |
+| Dream Router 7 (`UDR7`) | 4 + WAN | White |
 | Cloud Gateway Ultra (`UCGULTRA`, `UDRULT`) | 4 + WAN | White |
 | Cloud Gateway Max (`UCGMAX`) | 4 + WAN | White |
 | Cloud Gateway Fiber (`UCGFIBER`) | 4 + WAN + 2 SFP+ | White |

--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.4b900f1 */
+/* UniFi Device Card 0.0.0-dev.954f713 */
 
 // src/model-registry.js
 function range(start, end) {
@@ -440,6 +440,15 @@ var MODEL_REGISTRY = {
     theme: "white",
     specialSlots: [{ key: "wan", label: "WAN", port: 5 }]
   },
+  UDR7: {
+    kind: "gateway",
+    frontStyle: "gateway-single-row",
+    rows: [[1, 2, 3, 4]],
+    portCount: 5,
+    displayModel: "Dream Router 7",
+    theme: "white",
+    specialSlots: [{ key: "wan", label: "WAN", port: 5 }]
+  },
   UCGMAX: {
     kind: "gateway",
     frontStyle: "gateway-single-row",
@@ -547,6 +556,8 @@ function resolveModelKey(device) {
     if (candidate.includes("UDMPRO")) return "UDMPRO";
     if (candidate.includes("UCGFIBER")) return "UCGFIBER";
     if (candidate.includes("CLOUDGATEWAYFIBER")) return "UCGFIBER";
+    if (candidate.includes("UDR7")) return "UDR7";
+    if (candidate.includes("DREAMROUTER7")) return "UDR7";
     if (candidate.includes("UDRULT")) return "UDRULT";
     if (candidate.includes("UCGULTRA")) return "UCGULTRA";
     if (candidate.includes("CLOUDGATEWAYULTRA")) return "UCGULTRA";
@@ -647,6 +658,7 @@ function inferPortCountFromModel(device) {
   if (text.includes("UDMPROSE") || text.includes("UDMSE")) return 11;
   if (text.includes("UDMPRO")) return 11;
   if (text.includes("UCGFIBER") || text.includes("CLOUDGATEWAYFIBER")) return 7;
+  if (text.includes("UDR7") || text.includes("DREAMROUTER7")) return 5;
   if (text.includes("UCGULTRA") || text.includes("CLOUDGATEWAYULTRA") || text.includes("UDRULT")) return 5;
   if (text.includes("UCGMAX") || text.includes("CLOUDGATEWAYMAX")) return 5;
   if (text.includes("UXGPRO")) return 4;
@@ -738,6 +750,7 @@ var GATEWAY_MODEL_PREFIXES = [
   "UCG",
   "UXG",
   "UGW",
+  "UDR7",
   "UDRULT",
   "UDMPRO",
   "UDMPROSE"
@@ -759,6 +772,7 @@ function getDeviceType(device, entities = []) {
   if (modelKey) {
     if ([
       "UCGULTRA",
+      "UDR7",
       "UDRULT",
       "UCGMAX",
       "UCGFIBER",
@@ -2488,7 +2502,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.4b900f1";
+var VERSION = "0.0.0-dev.954f713";
 var UnifiDeviceCard = class extends HTMLElement {
   static getConfigElement() {
     return document.createElement("unifi-device-card-editor");

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -76,6 +76,7 @@ const GATEWAY_MODEL_PREFIXES = [
   "UCG",
   "UXG",
   "UGW",
+  "UDR7",
   "UDRULT",
   "UDMPRO",
   "UDMPROSE",
@@ -107,6 +108,7 @@ export function getDeviceType(device, entities = []) {
     if (
       [
         "UCGULTRA",
+        "UDR7",
         "UDRULT",
         "UCGMAX",
         "UCGFIBER",

--- a/src/model-registry.js
+++ b/src/model-registry.js
@@ -380,6 +380,11 @@ export const MODEL_REGISTRY = {
     portCount: 5, displayModel: "Cloud Gateway Ultra", theme: "white",
     specialSlots: [{ key: "wan", label: "WAN", port: 5 }],
   },
+  UDR7: {
+    kind: "gateway", frontStyle: "gateway-single-row", rows: [[1, 2, 3, 4]],
+    portCount: 5, displayModel: "Dream Router 7", theme: "white",
+    specialSlots: [{ key: "wan", label: "WAN", port: 5 }],
+  },
   UCGMAX: {
     kind: "gateway", frontStyle: "gateway-single-row", rows: [[1, 2, 3, 4]],
     portCount: 5, displayModel: "Cloud Gateway Max", theme: "white",
@@ -514,6 +519,8 @@ export function resolveModelKey(device) {
     if (candidate.includes("UDMPRO"))             return "UDMPRO";
     if (candidate.includes("UCGFIBER"))           return "UCGFIBER";
     if (candidate.includes("CLOUDGATEWAYFIBER"))  return "UCGFIBER";
+    if (candidate.includes("UDR7"))               return "UDR7";
+    if (candidate.includes("DREAMROUTER7"))       return "UDR7";
     if (candidate.includes("UDRULT"))             return "UDRULT";
     if (candidate.includes("UCGULTRA"))           return "UCGULTRA";
     if (candidate.includes("CLOUDGATEWAYULTRA"))  return "UCGULTRA";
@@ -630,6 +637,7 @@ export function inferPortCountFromModel(device) {
   if (text.includes("UDMPROSE") || text.includes("UDMSE"))                           return 11;
   if (text.includes("UDMPRO"))                                                        return 11;
   if (text.includes("UCGFIBER") || text.includes("CLOUDGATEWAYFIBER"))               return 7;
+  if (text.includes("UDR7") || text.includes("DREAMROUTER7"))                         return 5;
   if (text.includes("UCGULTRA") || text.includes("CLOUDGATEWAYULTRA") || text.includes("UDRULT")) return 5;
   if (text.includes("UCGMAX")   || text.includes("CLOUDGATEWAYMAX"))                 return 5;
   if (text.includes("UXGPRO"))                                                        return 4;


### PR DESCRIPTION
### Motivation
- Ensure the Ubiquiti Dream Router 7 is recognized and shown with a proper gateway layout instead of falling back to a generic/inferred layout. 
- Improve model-key and port-count inference so devices reported as `UDR7`/`Dream Router 7` behave consistently with other gateways.

### Description
- Added a `UDR7` registry entry in `src/model-registry.js` with a gateway single-row layout (4 LAN + WAN), `portCount: 5`, and a WAN special slot at port 5. 
- Added `UDR7` and `DREAMROUTER7` alias checks in `resolveModelKey` and added `UDR7` to `inferPortCountFromModel` so the model resolves reliably and infers 5 ports. 
- Updated gateway detection in `src/helpers.js` by adding `UDR7` to `GATEWAY_MODEL_PREFIXES` and including it in the known gateways list returned by `getDeviceType`. 
- Updated user-facing docs and release notes by adding `Dream Router 7 (UDR7)` to `README.md` and an `Unreleased` entry in `CHANGELOG.md`, and rebuilt `dist/unifi-device-card.js` from the updated `/src` files (the `dist` changes are generated output).

### Testing
- Ran `npm run build` which completed successfully and produced an updated `dist/unifi-device-card.js`.
- Attempted `npm run lint` but the project has no `lint` script so linting was not run. 
- Attempted `npm test` but the project has no `test` script so no automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8c28077308333b161fb79627e4757)