### PR TITLE
Apply card chrome background to AP panel and format timestamp uptime

### DIFF
--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -137,6 +137,21 @@ class UnifiDeviceCard extends HTMLElement {
     const obj = stateObj(this._hass, entityId);
     if (!obj) return "—";
 
+    const rawState = String(obj.state ?? "").trim();
+    const deviceClass = String(obj.attributes?.device_class || "").toLowerCase().trim();
+    if (deviceClass === "timestamp") {
+      const parsed = new Date(rawState);
+      if (!Number.isNaN(parsed.getTime())) {
+        return parsed.toLocaleString(this._hass?.locale?.language || undefined, {
+          year: "numeric",
+          month: "2-digit",
+          day: "2-digit",
+          hour: "2-digit",
+          minute: "2-digit",
+        });
+      }
+    }
+
     const raw = Number.parseFloat(String(obj.state ?? "").replace(",", "."));
     if (!Number.isFinite(raw)) return formatState(this._hass, entityId);
 
@@ -642,7 +657,7 @@ class UnifiDeviceCard extends HTMLElement {
       }
 
       .frontpanel.ap-disc {
-        background: linear-gradient(160deg, var(--udc-surface) 0%, var(--udc-bg) 100%);
+        background: var(--udc-chrome-bg, linear-gradient(160deg, var(--udc-surface) 0%, var(--udc-bg) 100%));
         display: grid;
         place-items: center;
         min-height: 305px;


### PR DESCRIPTION
### Motivation
- Ensure the AP center panel uses the same configurable chrome background so color + transparency settings apply consistently across the card's top, middle and bottom areas. 
- Display AP uptime sensors with `device_class: timestamp` as a localized date and time instead of incorrectly parsing them as numeric durations.

### Description
- Update `src/unifi-device-card.js` to make `.frontpanel.ap-disc` use `--udc-chrome-bg` for its background so the background color and opacity settings are applied consistently. 
- Add detection for `device_class: timestamp` in `_apUptimeState` and parse/format the timestamp using `toLocaleString` with date and time components to show localized date and time. 
- Built artifacts were regenerated with `npm run build`, producing an updated `dist/unifi-device-card.js` as a build output.

### Testing
- Ran `npm run build` which completed successfully and produced updated files in `dist`.
- Attempted `npm run lint` but the project does not define a `lint` script so linting was not run (no `lint` script present).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d904f7ecb483338cd354806535d036)