### PR TITLE
feat: add USW Flex Mini 2.5G (USW-Flex-2.5G-5) model support

### DIFF
--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.03825ce */
+/* UniFi Device Card 0.0.0-dev.480e31a */
 
 // src/model-registry.js
 function range(start, end) {
@@ -154,6 +154,16 @@ var MODEL_REGISTRY = {
     displayModel: "USW Flex",
     theme: "white",
     poePortRange: [1, 4],
+    specialSlots: [{ key: "uplink", label: "Uplink", port: 5 }]
+  },
+  // USW Flex Mini 2.5G  — 4× 2.5G RJ45 LAN (1-4), Port 5 uplink / PoE-in
+  USWFLEX25G5: {
+    kind: "switch",
+    frontStyle: "single-row",
+    rows: [range(1, 4)],
+    portCount: 5,
+    displayModel: "USW Flex Mini 2.5G",
+    theme: "white",
     specialSlots: [{ key: "uplink", label: "Uplink", port: 5 }]
   },
   // USW Flex 2.5G 8 PoE  — 9× RJ45, 1× SFP uplink
@@ -718,6 +728,10 @@ function resolveModelKey(device) {
     if (candidate.includes("USMINI")) return "USMINI";
     if (candidate.includes("FLEXMINI")) return "USMINI";
     if (candidate.includes("USWFLEXMINI")) return "USMINI";
+    if (candidate === "USWFLEX25G5") return "USWFLEX25G5";
+    if (candidate.includes("USWFLEX25G5")) return "USWFLEX25G5";
+    if (candidate.includes("FLEX25G5")) return "USWFLEX25G5";
+    if (candidate.includes("SWITCHFLEXMINI25G")) return "USWFLEX25G5";
     if (candidate === "USWFLEX25G8POE") return "USWFLEX25G8POE";
     if (candidate.includes("FLEX25G8POE")) return "USWFLEX25G8POE";
     if (candidate.includes("USWFLEX25G8")) return "USWFLEX25G8POE";
@@ -771,6 +785,7 @@ function inferPortCountFromModel(device) {
   if (text.includes("US8P60") || text.includes("US860W") || text.includes("USC8")) return 8;
   if (text.includes("US8P150")) return 10;
   if (text.includes("USMINI") || text.includes("FLEXMINI")) return 5;
+  if (text.includes("USWFLEX25G5") || text.includes("FLEX25G5") || text.includes("SWITCHFLEXMINI25G")) return 5;
   if (text.includes("USWFLEX25G8POE") || text.includes("FLEX25G8POE") || text.includes("USWFLEX25G8")) return 10;
   if (text.includes("USF5P") || text.includes("USWFLEX")) return 5;
   if (text.includes("US16P150") || text.includes("US16P")) return 18;
@@ -925,6 +940,7 @@ function getDeviceType(device, entities = []) {
       "US16P150",
       "USMINI",
       "USF5P",
+      "USWFLEX25G5",
       "USL8LP",
       "USL8LPB",
       "USL16LP",
@@ -2811,7 +2827,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.03825ce";
+var VERSION = "0.0.0-dev.480e31a";
 var UnifiDeviceCard = class extends HTMLElement {
   static getConfigElement() {
     return document.createElement("unifi-device-card-editor");

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -169,6 +169,7 @@ export function getDeviceType(device, entities = []) {
         "US16P150",
         "USMINI",
         "USF5P",
+        "USWFLEX25G5",
         "USL8LP",
         "USL8LPB",
         "USL16LP",

--- a/src/model-registry.js
+++ b/src/model-registry.js
@@ -167,6 +167,13 @@ export const MODEL_REGISTRY = {
     specialSlots: [{ key: "uplink", label: "Uplink", port: 5 }],
   },
 
+  // USW Flex Mini 2.5G  — 4× 2.5G RJ45 LAN (1-4), Port 5 uplink / PoE-in
+  USWFLEX25G5: {
+    kind: "switch", frontStyle: "single-row", rows: [range(1, 4)],
+    portCount: 5, displayModel: "USW Flex Mini 2.5G", theme: "white",
+    specialSlots: [{ key: "uplink", label: "Uplink", port: 5 }],
+  },
+
   // USW Flex 2.5G 8 PoE  — 9× RJ45, 1× SFP uplink
   USWFLEX25G8POE: {
     kind: "switch", frontStyle: "single-row", rows: [range(1, 9)],
@@ -693,6 +700,10 @@ export function resolveModelKey(device) {
     if (candidate.includes("USMINI"))             return "USMINI";
     if (candidate.includes("FLEXMINI"))           return "USMINI";
     if (candidate.includes("USWFLEXMINI"))        return "USMINI";
+    if (candidate === "USWFLEX25G5")              return "USWFLEX25G5";
+    if (candidate.includes("USWFLEX25G5"))        return "USWFLEX25G5";
+    if (candidate.includes("FLEX25G5"))           return "USWFLEX25G5";
+    if (candidate.includes("SWITCHFLEXMINI25G"))  return "USWFLEX25G5";
     if (candidate === "USWFLEX25G8POE")           return "USWFLEX25G8POE";
     if (candidate.includes("FLEX25G8POE"))        return "USWFLEX25G8POE";
     if (candidate.includes("USWFLEX25G8"))        return "USWFLEX25G8POE";
@@ -756,6 +767,7 @@ export function inferPortCountFromModel(device) {
   if (text.includes("US8P60")   || text.includes("US860W")  || text.includes("USC8")) return 8;
   if (text.includes("US8P150"))                                                       return 10;
   if (text.includes("USMINI")   || text.includes("FLEXMINI"))                        return 5;
+  if (text.includes("USWFLEX25G5") || text.includes("FLEX25G5") || text.includes("SWITCHFLEXMINI25G")) return 5;
   if (text.includes("USWFLEX25G8POE") || text.includes("FLEX25G8POE") || text.includes("USWFLEX25G8")) return 10;
   if (text.includes("USF5P")    || text.includes("USWFLEX"))                         return 5;
 


### PR DESCRIPTION
### Motivation
- Support the USW Flex Mini 2.5G (model `USW-Flex-2.5G-5`) so the card renders correct port layout and treats it as a switch. 
- Ensure correct port semantics: ports 1–4 are LAN, port 5 is uplink / PoE-in (rendered as a special slot). 
- Keep model resolution robust by adding common alias patterns used in device strings.

### Description
- Added `USWFLEX25G5` entry to `/src/model-registry.js` describing a 5-port switch with `rows: [1..4]` and a `specialSlots` uplink at port `5` and `displayModel: "USW Flex Mini 2.5G"`.
- Extended `resolveModelKey` aliases in `/src/model-registry.js` to map `USWFLEX25G5`, `FLEX25G5`, and `SWITCHFLEXMINI25G` (and related variants) to the new model key.
- Updated `inferPortCountFromModel` logic to return `5` for the new model aliases so fallback layouts behave correctly.
- Included `USWFLEX25G5` in `/src/helpers.js` switch-classification list so `getDeviceType` treats the model as a `switch`.
- Rebuilt the distribution bundle `dist/unifi-device-card.js` from the updated sources to include the changes.

### Testing
- Ran `npm run build` and the build completed successfully and produced an updated `dist/unifi-device-card.js`.
- Attempted `npm run lint` and `npm test` but the repository does not define `lint` or `test` scripts, so those checks are not present (reported as missing).
- External verification against `aiounifi` upstream could not be performed due to blocked outbound access (HTTP 403 via proxy), so aliases were added following existing registry naming conventions and the requested model information.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9508a1cac83338f6473c58c5254d2)