### PR TITLE
docs: document USW Flex 2.5G 5 support for v0.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v0.4.7] - 2026-04-10
+
+### ✨ Improvements
+- Added dedicated model support for USW Flex 2.5G 5 (`USWFLEX25G5`) in the card layouts and device detection
+
 ## [v0.4.6] - 2026-04-10
 
 ### ✨ Improvements

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ If you see improvements, issues, or fixes, feel free to open an issue or create 
 | UniFi Switch 16 PoE 150W (`US16P150`) | 16 + 2 SFP | Silver |
 | USW Flex Mini (`USMINI`) | 5 | White |
 | USW Flex (`USF5P`) | 4 + Uplink | White |
+| USW Flex 2.5G 5 (`USWFLEX25G5`) | 5 | White |
 | USW Flex 2.5G 8 PoE (`USWFLEX25G8POE`) | 8 + 2 SFP+ | White |
 | USW Lite 8 PoE (`USL8LP`, `USL8LPB`) | 8 | White |
 | USW Lite 16 PoE (`USL16LP`, `USL16LPB`) | 16 | White |


### PR DESCRIPTION
### Motivation
- Dokumentieren des neuen Geräte-Supports für `USW Flex 2.5G 5` als Teil des kommenden Releases `v0.4.7` so dass Nutzer und Release-Notes den neuen Modell-Support sehen.

### Description
- Ergänzt die `Supported Devices`-Tabelle in `README.md` um `USW Flex 2.5G 5 (USWFLEX25G5)` und fügt in `CHANGELOG.md` eine `v0.4.7`-Eintrag mit Hinweis auf den hinzugefügten Modell-Support hinzu, es wurden keine Änderungen in `/src` oder `/dist` vorgenommen.

### Testing
- Automatisierte Tests und Lint wurden nicht ausgeführt, da dies ausschließlich Dokumentationsänderungen sind; die Einträge wurden lokal per `rg` und `nl -ba` verifiziert, um die korrekte Einfügung in `README.md` und `CHANGELOG.md` zu bestätigen.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d952a6ef3c83339846f1669c047c4d)