### PR TITLE
fix: make hidden frontpanel background follow card chrome and opacity

### DIFF
--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.d229a88 */
+/* UniFi Device Card 0.0.0-dev.9aa0ec4 */
 
 // src/model-registry.js
 function range(start, end) {
@@ -2957,7 +2957,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.d229a88";
+var VERSION = "0.0.0-dev.9aa0ec4";
 var UnifiDeviceCard = class extends HTMLElement {
   static getConfigElement() {
     return document.createElement("unifi-device-card-editor");
@@ -3509,7 +3509,7 @@ var UnifiDeviceCard = class extends HTMLElement {
       .frontpanel.theme-white { background: #d6d6d9; }
       .frontpanel.theme-silver { background: #c4c5c8; }
       .frontpanel.theme-dark { background: #d0d1d4; }
-      .frontpanel.no-panel-bg { background: transparent; }
+      .frontpanel.no-panel-bg { background: var(--udc-chrome-bg, transparent); }
 
       .panel-label {
         font-size: 0.63rem;

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -661,7 +661,7 @@ class UnifiDeviceCard extends HTMLElement {
       .frontpanel.theme-white { background: #d6d6d9; }
       .frontpanel.theme-silver { background: #c4c5c8; }
       .frontpanel.theme-dark { background: #d0d1d4; }
-      .frontpanel.no-panel-bg { background: transparent; }
+      .frontpanel.no-panel-bg { background: var(--udc-chrome-bg, transparent); }
 
       .panel-label {
         font-size: 0.63rem;


### PR DESCRIPTION
### Motivation
- When the hardware front panel is hidden it was forced to `transparent`, which caused a visual mismatch with the card header/footer and did not respect the configured `background_color` and `background_opacity` values.

### Description
- Update `.frontpanel.no-panel-bg` in `src/unifi-device-card.js` to `background: var(--udc-chrome-bg, transparent);` and rebuild `dist/unifi-device-card.js` so the hidden frontpanel uses the same chrome background (and thus follows color and opacity settings); README/CHANGELOG were not changed and screenshots were not updated.

### Testing
- Ran `npm run build` which completed successfully and produced an updated `dist/unifi-device-card.js`, and attempted `npm run lint` which reported no `lint` script is defined in `package.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da15f1a2288333834bf1f67309190f)