### PR TITLE
Improve AP model detection, device detection heuristics, and editor focus preservation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Added editor sliders for `port_size` (switch/gateway) and `ap_scale` (AP mode), both persisted to YAML config.
 - Unified special and numbered switch/gateway port visual size so both use the same base port size.
 - Reduced AP panel top/bottom spacing and kept AP visual centered with scalable AP size.
+- `show_panel: false` now renders switch/gateway frontpanel backgrounds transparent instead of retaining the device color.
+- Editor now shows the AP scale slider only for AP devices, and the port size slider only for switch/gateway devices.
+- AP panel height now scales with the configured AP size so changing `ap_scale` adjusts both device size and AP section height.
 
 ### 🐛 Bug Fixes
 - Fixed editor warning-message flicker by avoiding repeated warning checks on every Home Assistant state refresh when the selected device did not change.
@@ -18,9 +21,9 @@
 - Added model alias detection for `USWED35` so it resolves to `USW Flex Mini 2.5G` (`USWFLEX25G5`) instead of a generic switch.
 - Improved front-panel sizing behavior so default port size no longer forces overly wide layouts on narrow cards (auto-fit applies when `port_size` is not explicitly set; explicit slider/YAML values keep their exact size).
 - Added row-cap fallback on narrow cards: when configured columns do not fit, rows are repacked to the maximum visible column count so ports stay fully visible without horizontal scrolling.
-- Fixed `show_panel: false` rendering for switch/gateway so frontpanel background becomes transparent instead of staying in device color.
-- Editor now shows the AP scale slider only for AP devices, and the port size slider only for switch/gateway devices.
-- AP panel height now scales with the configured AP size so changing `ap_scale` adjusts both device size and AP section height.
+- Added additional AP model/alias detection for `U6 Extender` (`U6EXTENDER`), `U7 In-Wall` (`U7IW`), `U7 LR` (`U7LR`), and `U7 Lite` (`U7LITE`) to improve reliable AP recognition in Home Assistant naming variants.
+- Fixed UniFi device-list filtering so APs (including `U6 Pro`) are no longer dropped when they are linked to the UniFi config entry but expose only weak/partial entity signals.
+- Fixed editor focus handling so text fields and sliders keep focus while typing/dragging instead of losing focus after each config change.
 
 ## [v0.4.7] - 2026-04-10
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ If you see improvements, issues, or fixes, feel free to open an issue or create 
 | UAP AC Mesh (`UAPACM`) | AP panel | White |
 | U6+ (`U6PLUS`) | AP panel | White |
 | U6 Mesh (`U6MESH`) | AP panel | White |
+| U6 Extender (`U6EXTENDER`) | AP panel | White |
+| U7 In-Wall (`U7IW`) | AP panel | White |
+| U7 LR (`U7LR`) | AP panel | White |
+| U7 Lite (`U7LITE`) | AP panel | White |
 | Weitere AP-Familien (`UAP*`, `U6*`, `U7*`, `E7*`, `UWB*`) | AP panel | White |
 
 Unknown models are auto-detected by port count and fall back to a generic dark theme where possible.

--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.a1ba1a7 */
+/* UniFi Device Card 0.0.0-dev.d4b9ac2 */
 
 // src/model-registry.js
 function range(start, end) {
@@ -87,9 +87,13 @@ var MODEL_REGISTRY = {
   U6MESH: apModel("U6 Mesh"),
   U6IW: apModel("U6 In-Wall"),
   U6ENTERPRISE: apModel("U6 Enterprise"),
+  U6EXTENDER: apModel("U6 Extender"),
   U7PRO: apModel("U7 Pro"),
   U7PROMAX: apModel("U7 Pro Max"),
   U7PROWALL: apModel("U7 Pro Wall"),
+  U7IW: apModel("U7 In-Wall"),
+  U7LR: apModel("U7 LR"),
+  U7LITE: apModel("U7 Lite"),
   U7OUTDOOR: apModel("U7 Outdoor"),
   E7: apModel("E7"),
   UWBXG: apModel("UWB-XG"),
@@ -668,6 +672,13 @@ function resolveModelKey(device) {
     if (candidate.includes("U6LR")) return "U6LR";
     if (candidate.includes("U6LITE")) return "U6LITE";
     if (candidate.includes("U6IW")) return "U6IW";
+    if (candidate.includes("U6EXTENDER")) return "U6EXTENDER";
+    if (candidate.includes("U6EXT")) return "U6EXTENDER";
+    if (candidate.includes("U7IW")) return "U7IW";
+    if (candidate.includes("U7INWALL")) return "U7IW";
+    if (candidate.includes("U7LR")) return "U7LR";
+    if (candidate.includes("U7LITE")) return "U7LITE";
+    if (candidate.includes("U7ULTRA")) return "U7LITE";
     if (candidate.includes("U7PROWALL")) return "U7PROWALL";
     if (candidate.includes("U7PROMAX")) return "U7PROMAX";
     if (candidate.includes("U7PRO")) return "U7PRO";
@@ -1087,7 +1098,18 @@ function isUnifiDevice(device, unifiEntryIds, entities) {
   if (isVirtualControllerDevice(device)) return false;
   const hasInfraSignals = hasInfrastructureEntitySignals(entities);
   if (Array.isArray(device?.config_entries) && device.config_entries.some((id) => unifiEntryIds.has(id))) {
-    return hasInfraSignals || !!resolveModelKey(device);
+    if (hasInfraSignals || !!resolveModelKey(device)) return true;
+    if (modelStartsWith(device, [
+      ...SWITCH_MODEL_PREFIXES,
+      ...GATEWAY_MODEL_PREFIXES,
+      ...AP_MODEL_PREFIXES2
+    ])) {
+      return true;
+    }
+    if (hasUbiquitiManufacturer(device) && getDeviceType(device, entities) !== "unknown") {
+      return true;
+    }
+    return false;
   }
   if (resolveModelKey(device)) return true;
   if (modelStartsWith(device, [...SWITCH_MODEL_PREFIXES, ...GATEWAY_MODEL_PREFIXES, ...AP_MODEL_PREFIXES2])) {
@@ -2832,8 +2854,34 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
       }
     </style>`;
   }
+  _captureFocusState() {
+    if (!this.shadowRoot) return null;
+    const active = this.shadowRoot.activeElement;
+    if (!active || !active.id) return null;
+    const supportsSelection = typeof active.selectionStart === "number" && typeof active.selectionEnd === "number";
+    return {
+      id: active.id,
+      selectionStart: supportsSelection ? active.selectionStart : null,
+      selectionEnd: supportsSelection ? active.selectionEnd : null,
+      selectionDirection: supportsSelection ? active.selectionDirection : null
+    };
+  }
+  _restoreFocusState(focusState) {
+    if (!focusState || !this.shadowRoot) return;
+    const nextEl = this.shadowRoot.getElementById(focusState.id);
+    if (!nextEl || typeof nextEl.focus !== "function") return;
+    nextEl.focus({ preventScroll: true });
+    if (typeof nextEl.setSelectionRange === "function" && focusState.selectionStart != null && focusState.selectionEnd != null) {
+      nextEl.setSelectionRange(
+        focusState.selectionStart,
+        focusState.selectionEnd,
+        focusState.selectionDirection || "none"
+      );
+    }
+  }
   _render() {
     this._rendered = true;
+    const focusState = this._captureFocusState();
     const deviceValue = this._config?.device_id || "";
     const selectedDevice = this._devices.find((d) => d.id === deviceValue) || null;
     const selectedType = this._deviceCtx?.type || selectedDevice?.type || null;
@@ -2942,6 +2990,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
     this.shadowRoot.getElementById("background_opacity")?.addEventListener("input", (ev) => this._onBackgroundOpacityInput(ev));
     this.shadowRoot.getElementById("wan_port")?.addEventListener("change", (ev) => this._onWanPortChange(ev));
     this.shadowRoot.getElementById("wan2_port")?.addEventListener("change", (ev) => this._onWan2PortChange(ev));
+    this._restoreFocusState(focusState);
   }
   _patchWarning() {
     if (!this._rendered || !this.shadowRoot) return;
@@ -2957,7 +3006,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.a1ba1a7";
+var VERSION = "0.0.0-dev.d4b9ac2";
 var UnifiDeviceCard = class extends HTMLElement {
   static getConfigElement() {
     return document.createElement("unifi-device-card-editor");

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -385,7 +385,23 @@ function isUnifiDevice(device, unifiEntryIds, entities) {
     Array.isArray(device?.config_entries) &&
     device.config_entries.some((id) => unifiEntryIds.has(id))
   ) {
-    return hasInfraSignals || !!resolveModelKey(device);
+    if (hasInfraSignals || !!resolveModelKey(device)) return true;
+
+    if (
+      modelStartsWith(device, [
+        ...SWITCH_MODEL_PREFIXES,
+        ...GATEWAY_MODEL_PREFIXES,
+        ...AP_MODEL_PREFIXES,
+      ])
+    ) {
+      return true;
+    }
+
+    if (hasUbiquitiManufacturer(device) && getDeviceType(device, entities) !== "unknown") {
+      return true;
+    }
+
+    return false;
   }
 
   if (resolveModelKey(device)) return true;

--- a/src/model-registry.js
+++ b/src/model-registry.js
@@ -123,9 +123,13 @@ export const MODEL_REGISTRY = {
   U6MESH: apModel("U6 Mesh"),
   U6IW: apModel("U6 In-Wall"),
   U6ENTERPRISE: apModel("U6 Enterprise"),
+  U6EXTENDER: apModel("U6 Extender"),
   U7PRO: apModel("U7 Pro"),
   U7PROMAX: apModel("U7 Pro Max"),
   U7PROWALL: apModel("U7 Pro Wall"),
+  U7IW: apModel("U7 In-Wall"),
+  U7LR: apModel("U7 LR"),
+  U7LITE: apModel("U7 Lite"),
   U7OUTDOOR: apModel("U7 Outdoor"),
   E7: apModel("E7"),
   UWBXG: apModel("UWB-XG"),
@@ -642,6 +646,13 @@ export function resolveModelKey(device) {
     if (candidate.includes("U6LR"))               return "U6LR";
     if (candidate.includes("U6LITE"))             return "U6LITE";
     if (candidate.includes("U6IW"))               return "U6IW";
+    if (candidate.includes("U6EXTENDER"))         return "U6EXTENDER";
+    if (candidate.includes("U6EXT"))              return "U6EXTENDER";
+    if (candidate.includes("U7IW"))               return "U7IW";
+    if (candidate.includes("U7INWALL"))           return "U7IW";
+    if (candidate.includes("U7LR"))               return "U7LR";
+    if (candidate.includes("U7LITE"))             return "U7LITE";
+    if (candidate.includes("U7ULTRA"))            return "U7LITE";
     if (candidate.includes("U7PROWALL"))          return "U7PROWALL";
     if (candidate.includes("U7PROMAX"))           return "U7PROMAX";
     if (candidate.includes("U7PRO"))              return "U7PRO";

--- a/src/unifi-device-card-editor.js
+++ b/src/unifi-device-card-editor.js
@@ -592,8 +592,47 @@ class UnifiDeviceCardEditor extends HTMLElement {
     </style>`;
   }
 
+  _captureFocusState() {
+    if (!this.shadowRoot) return null;
+    const active = this.shadowRoot.activeElement;
+    if (!active || !active.id) return null;
+
+    const supportsSelection =
+      typeof active.selectionStart === "number" &&
+      typeof active.selectionEnd === "number";
+
+    return {
+      id: active.id,
+      selectionStart: supportsSelection ? active.selectionStart : null,
+      selectionEnd: supportsSelection ? active.selectionEnd : null,
+      selectionDirection: supportsSelection ? active.selectionDirection : null,
+    };
+  }
+
+  _restoreFocusState(focusState) {
+    if (!focusState || !this.shadowRoot) return;
+
+    const nextEl = this.shadowRoot.getElementById(focusState.id);
+    if (!nextEl || typeof nextEl.focus !== "function") return;
+
+    nextEl.focus({ preventScroll: true });
+
+    if (
+      typeof nextEl.setSelectionRange === "function" &&
+      focusState.selectionStart != null &&
+      focusState.selectionEnd != null
+    ) {
+      nextEl.setSelectionRange(
+        focusState.selectionStart,
+        focusState.selectionEnd,
+        focusState.selectionDirection || "none"
+      );
+    }
+  }
+
   _render() {
     this._rendered = true;
+    const focusState = this._captureFocusState();
 
     const deviceValue = this._config?.device_id || "";
     const selectedDevice = this._devices.find((d) => d.id === deviceValue) || null;
@@ -730,6 +769,8 @@ class UnifiDeviceCardEditor extends HTMLElement {
 
     this.shadowRoot.getElementById("wan2_port")
       ?.addEventListener("change", (ev) => this._onWan2PortChange(ev));
+
+    this._restoreFocusState(focusState);
   }
 
   _patchWarning() {


### PR DESCRIPTION
### Motivation
- Improve recognition of newer UniFi AP models and variants so devices are detected reliably from Home Assistant naming variants.
- Make device classification more robust when infra entities are missing by using model prefixes and manufacturer/type heuristics.
- Prevent editor form fields from losing focus during re-renders so typing and slider interactions are not interrupted.

### Description
- Added AP model entries for `U6EXTENDER`, `U7IW`, `U7LR`, and `U7LITE` in `MODEL_REGISTRY` and `dist` output so these models render as AP panels.  
- Extended `resolveModelKey` to recognize additional AP alias strings (`U6EXTENDER`, `U6EXT`, `U7IW`, `U7INWALL`, `U7LR`, `U7LITE`, `U7ULTRA`).  
- Relaxed `isUnifiDevice` heuristics in `src/helpers.js` to also accept devices when model prefixes match switch/gateway/AP sets or when the manufacturer and `getDeviceType` indicate a non-unknown device.  
- Implemented focus capture/restore helpers (`_captureFocusState`, `_restoreFocusState`) in the card editor (`src/unifi-device-card-editor.js` and compiled `dist/unifi-device-card.js`) and invoked them around `_render` so text inputs and sliders keep focus/selection across re-renders.  
- Updated version string in the built distribution and added related README/CHANGELOG entries describing the behavior and UI improvements.

### Testing
- Built the distribution bundle with the source changes and updated `dist/unifi-device-card.js` successfully (`npm run build` / bundling step completed).  
- Lint and basic build validations completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da1727ee008333bd800c45fadf8969)