### PR TITLE
fix: hide AP-only panel options and clip card chrome

### DIFF
--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.f8c4389 */
+/* UniFi Device Card 0.0.0-dev.98db8e1 */
 
 // src/model-registry.js
 function range(start, end) {
@@ -2926,6 +2926,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
           <div class="hint">${this._t("editor_name_hint")}</div>
         </div>
 
+        ${isSwitchOrGateway ? `
         <div class="field">
           <label>${this._t("editor_panel_toggle_label")}</label>
           <label class="checkbox-row">
@@ -2939,7 +2940,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
           <label>${this._t("editor_ports_per_row_label")}</label>
           <input id="ports_per_row" type="text" inputmode="numeric" value="${portsPerRow}">
           <div class="hint">${this._t("editor_ports_per_row_hint")}</div>
-        </div>
+        </div>` : ""}
 
         ${isSwitchOrGateway ? `
         <div class="field">
@@ -3006,7 +3007,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.f8c4389";
+var VERSION = "0.0.0-dev.98db8e1";
 var UnifiDeviceCard = class extends HTMLElement {
   static getConfigElement() {
     return document.createElement("unifi-device-card-editor");
@@ -3434,6 +3435,12 @@ var UnifiDeviceCard = class extends HTMLElement {
         --udc-rsm: 8px;
         --udc-port-size: 36px;
         --udc-ap-scale: 1;
+      }
+
+      ha-card {
+        background: var(--udc-card-bg, var(--ha-card-background, var(--card-background-color)));
+        border-radius: var(--ha-card-border-radius, 12px);
+        overflow: hidden;
       }
 
       .header {

--- a/src/unifi-device-card-editor.js
+++ b/src/unifi-device-card-editor.js
@@ -688,6 +688,7 @@ class UnifiDeviceCardEditor extends HTMLElement {
           <div class="hint">${this._t("editor_name_hint")}</div>
         </div>
 
+        ${isSwitchOrGateway ? `
         <div class="field">
           <label>${this._t("editor_panel_toggle_label")}</label>
           <label class="checkbox-row">
@@ -701,7 +702,7 @@ class UnifiDeviceCardEditor extends HTMLElement {
           <label>${this._t("editor_ports_per_row_label")}</label>
           <input id="ports_per_row" type="text" inputmode="numeric" value="${portsPerRow}">
           <div class="hint">${this._t("editor_ports_per_row_hint")}</div>
-        </div>
+        </div>` : ""}
 
         ${isSwitchOrGateway ? `
         <div class="field">

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -539,6 +539,12 @@ class UnifiDeviceCard extends HTMLElement {
         --udc-ap-scale: 1;
       }
 
+      ha-card {
+        background: var(--udc-card-bg, var(--ha-card-background, var(--card-background-color)));
+        border-radius: var(--ha-card-border-radius, 12px);
+        overflow: hidden;
+      }
+
       .header {
         padding: 16px 18px 13px;
         background: var(--udc-chrome-bg, linear-gradient(160deg, var(--udc-surface) 0%, var(--udc-bg) 100%));


### PR DESCRIPTION
### Motivation
- A screenshot showed a rectangular panel overlaying the card which prevented themes with rounded card corners from rendering cleanly, and the editor exposed fields that are not meaningful for AP devices.
- Reduce visual glitches and simplify the editor by hiding AP-irrelevant controls and ensuring inner panel chrome is clipped to the card's rounded corners.

### Description
- In `/src/unifi-device-card-editor.js` the `show_panel` (Frontpanel) and `ports_per_row` (Ports pro Zeile) editor fields are now only rendered when the selected device type is a switch or gateway (`isSwitchOrGateway`), so they are hidden for APs.
- In `/src/unifi-device-card.js` an explicit `ha-card` style block was added to set `background`, `border-radius`, and `overflow: hidden` so internal panel sections are clipped to the card's rounded corners and won't show an angular overlay.
- The distribution bundle `dist/unifi-device-card.js` was rebuilt to include the source changes as a generated artifact.

### Testing
- `npm run build` was executed and completed successfully, producing the updated `dist/unifi-device-card.js`.
- `npm run lint` was attempted but failed because no `lint` script is defined in `package.json`.
- `npm test` was attempted but failed because no `test` script is defined in `package.json`.
- A static review of the modified `/src` files and the generated `/dist` output was performed to confirm the intended changes are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da1f12ddd483338e4d18ff23f7e063)