### PR TITLE
Fix ports_per_row responsiveness when card width changes

### DIFF
--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.447fa3e */
+/* UniFi Device Card 0.0.0-dev.5d38bd1 */
 
 // src/model-registry.js
 function range(start, end) {
@@ -3047,7 +3047,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.447fa3e";
+var VERSION = "0.0.0-dev.5d38bd1";
 var UnifiDeviceCard = class extends HTMLElement {
   static getConfigElement() {
     return document.createElement("unifi-device-card-editor");
@@ -3064,6 +3064,22 @@ var UnifiDeviceCard = class extends HTMLElement {
     this._loading = false;
     this._loadToken = 0;
     this._loadedDeviceId = null;
+    this._resizeObserver = null;
+    this._lastMeasuredWidth = 0;
+  }
+  connectedCallback() {
+    if (this._resizeObserver) return;
+    this._resizeObserver = new ResizeObserver(() => {
+      const nextWidth = this._measuredCardWidth();
+      if (Math.abs(nextWidth - this._lastMeasuredWidth) < 1) return;
+      this._lastMeasuredWidth = nextWidth;
+      this._render();
+    });
+    this._resizeObserver.observe(this);
+  }
+  disconnectedCallback() {
+    this._resizeObserver?.disconnect();
+    this._resizeObserver = null;
   }
   setConfig(config) {
     const oldDeviceId = this._config?.device_id || null;
@@ -3132,8 +3148,15 @@ var UnifiDeviceCard = class extends HTMLElement {
     const configured = this._portSize();
     return configured;
   }
+  _measuredCardWidth() {
+    const hostWidth = this.getBoundingClientRect?.().width || this.offsetWidth || 0;
+    if (hostWidth > 0) return hostWidth;
+    const cardWidth = this.shadowRoot?.querySelector("ha-card")?.getBoundingClientRect?.().width || 0;
+    if (cardWidth > 0) return cardWidth;
+    return this.parentElement?.getBoundingClientRect?.().width || 0;
+  }
   _maxFittableColumns() {
-    const hostWidth = this.getBoundingClientRect?.().width || 0;
+    const hostWidth = this._measuredCardWidth();
     if (!hostWidth) return Infinity;
     const portSize = this._portSize();
     const horizontalPadding = 40;

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -35,6 +35,24 @@ class UnifiDeviceCard extends HTMLElement {
     this._loading = false;
     this._loadToken = 0;
     this._loadedDeviceId = null;
+    this._resizeObserver = null;
+    this._lastMeasuredWidth = 0;
+  }
+
+  connectedCallback() {
+    if (this._resizeObserver) return;
+    this._resizeObserver = new ResizeObserver(() => {
+      const nextWidth = this._measuredCardWidth();
+      if (Math.abs(nextWidth - this._lastMeasuredWidth) < 1) return;
+      this._lastMeasuredWidth = nextWidth;
+      this._render();
+    });
+    this._resizeObserver.observe(this);
+  }
+
+  disconnectedCallback() {
+    this._resizeObserver?.disconnect();
+    this._resizeObserver = null;
   }
 
   setConfig(config) {
@@ -118,8 +136,16 @@ class UnifiDeviceCard extends HTMLElement {
     return configured;
   }
 
+  _measuredCardWidth() {
+    const hostWidth = this.getBoundingClientRect?.().width || this.offsetWidth || 0;
+    if (hostWidth > 0) return hostWidth;
+    const cardWidth = this.shadowRoot?.querySelector("ha-card")?.getBoundingClientRect?.().width || 0;
+    if (cardWidth > 0) return cardWidth;
+    return this.parentElement?.getBoundingClientRect?.().width || 0;
+  }
+
   _maxFittableColumns() {
-    const hostWidth = this.getBoundingClientRect?.().width || 0;
+    const hostWidth = this._measuredCardWidth();
     if (!hostWidth) return Infinity;
 
     const portSize = this._portSize();


### PR DESCRIPTION
### Motivation
- Behebt ein Problem, bei dem `ports_per_row` nach einer Größenänderung der Karte nicht neu berechnet wurde und die Port-Anordnung dadurch nicht zur aktuellen Kartenbreite passte.
- Verbessert die Zuverlässigkeit der Layout-Berechnung bei initialen Rendern, wenn die Host-Breite noch `0` sein kann.

### Description
- Fügt einen `ResizeObserver` in `connectedCallback`/`disconnectedCallback` hinzu, damit die Karte bei Breitenänderungen neu gerendert wird und das Port-Layout sich anpasst.
- Implementiert die Hilfsfunktion `_measuredCardWidth()` mit Fallbacks auf Host-Breite, gerendertes `ha-card`-Element und Parent-Breite, um verlässlich eine nutzbare Breite zu liefern.
- Nutzt die gemessene Breite in `_maxFittableColumns()` damit `_buildEffectiveRows()` Reihen korrekt umpackt, wenn `ports_per_row` sonst überlaufen würde.
- Aktualisiert das generierte Build-Artefakt `dist/unifi-device-card.js` passend zu den Änderungen in `src/unifi-device-card.js`.

### Testing
- Ausgeführt: `npm run build` und der Build-Vorgang war erfolgreich.
- Ausgeführt: `node --check src/unifi-device-card.js` und es wurden keine Syntaxfehler gemeldet.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da29b7ffd48333b3fbc4162a22dda8)