### PR TITLE
Dynamic card sizing, default switch ports_per_row, and metadata/version bump

### DIFF
--- a/build.js
+++ b/build.js
@@ -2,7 +2,14 @@ import { execSync } from "node:child_process";
 import esbuild from "esbuild";
 
 function getVersion() {
+  const packageVersion = String(process.env.npm_package_version || "0.0.0").trim();
+
   try {
+    const explicitVersion = String(process.env.VERSION || "").trim();
+    if (explicitVersion) {
+      return explicitVersion.replace(/^v/, "");
+    }
+
     const eventName = process.env.GITHUB_EVENT_NAME || "";
     const refName = process.env.GITHUB_REF_NAME || "";
 
@@ -14,10 +21,10 @@ function getVersion() {
       .toString()
       .trim();
 
-    return `0.0.0-dev.${commit}`;
+    return `${packageVersion}-dev.${commit}`;
   } catch (err) {
     console.warn("[build] Failed to determine git version:", err);
-    return "0.0.0-dev";
+    return `${packageVersion}-dev`;
   }
 }
 

--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.64b3977 */
+/* UniFi Device Card 0.0.0-dev.498e628 */
 
 // src/model-registry.js
 function range(start, end) {
@@ -3051,7 +3051,8 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.64b3977";
+var VERSION = "0.0.0-dev.498e628";
+var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var UnifiDeviceCard = class extends HTMLElement {
   static getConfigElement() {
     return document.createElement("unifi-device-card-editor");
@@ -4382,3 +4383,7 @@ window.customCards.push({
   preview: true,
   documentationURL: "https://github.com/bacco007/unifi-device-card"
 });
+if (!window[DEV_LOG_FLAG]) {
+  window[DEV_LOG_FLAG] = true;
+  console.info(`[UNIFI-DEVICE-CARD] Version ${VERSION}`);
+}

--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.498e628 */
+/* UniFi Device Card 0.0.0-dev.04ba186 */
 
 // src/model-registry.js
 function range(start, end) {
@@ -3051,7 +3051,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.498e628";
+var VERSION = "0.0.0-dev.04ba186";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var UnifiDeviceCard = class extends HTMLElement {
   static getConfigElement() {
@@ -4381,7 +4381,7 @@ window.customCards.push({
   name: "UniFi Device Card",
   description: `Lovelace card for UniFi devices (v${VERSION}).`,
   preview: true,
-  documentationURL: "https://github.com/bacco007/unifi-device-card"
+  documentationURL: "https://github.com/bluenazgul/unifi-device-card"
 });
 if (!window[DEV_LOG_FLAG]) {
   window[DEV_LOG_FLAG] = true;

--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.b6b5e92 */
+/* UniFi Device Card 0.0.0-dev.64b3977 */
 
 // src/model-registry.js
 function range(start, end) {
@@ -1826,8 +1826,12 @@ async function buildDeviceContext(hass, deviceId, cardConfig = null) {
   }
   const discoveredPortsRaw = discoverPorts(entities);
   let layout = getDeviceLayout(device, discoveredPortsRaw);
-  if (cardConfig?.ports_per_row) {
-    layout = applyPortsPerRowOverride(layout, cardConfig.ports_per_row);
+  const configuredPortsPerRow = Number.parseInt(cardConfig?.ports_per_row, 10);
+  const hasConfiguredPortsPerRow = Number.isFinite(configuredPortsPerRow) && configuredPortsPerRow > 0;
+  if (hasConfiguredPortsPerRow) {
+    layout = applyPortsPerRowOverride(layout, configuredPortsPerRow);
+  } else if (type === "switch") {
+    layout = applyPortsPerRowOverride(layout, 8);
   }
   const numberedPorts = filterPortsByLayout(discoveredPortsRaw, layout);
   const specialPorts = discoverSpecialPorts(entities);
@@ -3047,7 +3051,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.b6b5e92";
+var VERSION = "0.0.0-dev.64b3977";
 var UnifiDeviceCard = class extends HTMLElement {
   static getConfigElement() {
     return document.createElement("unifi-device-card-editor");
@@ -3066,6 +3070,7 @@ var UnifiDeviceCard = class extends HTMLElement {
     this._loadedDeviceId = null;
     this._resizeObserver = null;
     this._lastMeasuredWidth = 0;
+    this._cardSize = 8;
   }
   connectedCallback() {
     if (this._resizeObserver) return;
@@ -3104,7 +3109,34 @@ var UnifiDeviceCard = class extends HTMLElement {
     this._render();
   }
   getCardSize() {
-    return 8;
+    return this._cardSize || this._estimateCardSize();
+  }
+  _estimateCardSize() {
+    if (!this._config?.device_id) return 4;
+    if (!this._ctx) return 5;
+    if (this._ctx?.type === "access_point") return 8;
+    const { specials, numbered } = this._buildSlotData(this._ctx);
+    const specialPortsInUse = new Set(
+      specials.map((slot) => slot?.port).filter((port) => Number.isInteger(port))
+    );
+    const visibleNumbered = numbered.filter((slot) => !specialPortsInUse.has(slot.port));
+    const panelRows = this._buildEffectiveRows(this._ctx, visibleNumbered).length + (specials.length ? 1 : 0);
+    const selected = [...specials, ...visibleNumbered].find((slot) => slot.key === this._selectedKey) || specials[0] || visibleNumbered[0] || null;
+    const hasPoe = !!(selected?.poe_switch_entity || selected?.poe_power_entity || selected?.power_cycle_entity);
+    const hasTraffic = !!(selected?.rx_entity || selected?.tx_entity);
+    return Math.max(6, Math.min(20, 5 + panelRows + (hasPoe ? 1 : 0) + (hasTraffic ? 1 : 0)));
+  }
+  _updateCardSize() {
+    const cardEl = this.shadowRoot?.querySelector("ha-card");
+    if (!cardEl) return;
+    const measured = Math.max(1, Math.ceil(cardEl.getBoundingClientRect().height / 50));
+    const nextSize = Number.isFinite(measured) ? measured : this._estimateCardSize();
+    if (nextSize === this._cardSize) return;
+    this._cardSize = nextSize;
+    this.dispatchEvent(new Event("iron-resize", { bubbles: true, composed: true }));
+  }
+  _finalizeRender() {
+    requestAnimationFrame(() => this._updateCardSize());
   }
   _t(key) {
     return t(this._hass, key);
@@ -4306,6 +4338,7 @@ var UnifiDeviceCard = class extends HTMLElement {
           </div>
           <div class="empty-state">${this._t("select_device")}</div>
         </ha-card>`;
+      this._finalizeRender();
       return;
     }
     if (this._loading) {
@@ -4319,6 +4352,7 @@ var UnifiDeviceCard = class extends HTMLElement {
           </div>
           <div class="loading-state"><div class="spinner"></div>${this._t("loading")}</div>
         </ha-card>`;
+      this._finalizeRender();
       return;
     }
     if (!this._ctx) {
@@ -4332,9 +4366,11 @@ var UnifiDeviceCard = class extends HTMLElement {
           </div>
           <div class="empty-state">${this._t("no_data")}</div>
         </ha-card>`;
+      this._finalizeRender();
       return;
     }
     this._renderPanelAndDetail();
+    this._finalizeRender();
   }
 };
 customElements.define("unifi-device-card", UnifiDeviceCard);
@@ -4342,5 +4378,7 @@ window.customCards = window.customCards || [];
 window.customCards.push({
   type: "unifi-device-card",
   name: "UniFi Device Card",
-  description: "Lovelace card for UniFi Devices."
+  description: `Lovelace card for UniFi devices (v${VERSION}).`,
+  preview: true,
+  documentationURL: "https://github.com/bacco007/unifi-device-card"
 });

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1522,8 +1522,13 @@ async function buildDeviceContext(hass, deviceId, cardConfig = null) {
 
   const discoveredPortsRaw = discoverPorts(entities);
   let layout = getDeviceLayout(device, discoveredPortsRaw);
-  if (cardConfig?.ports_per_row) {
-    layout = applyPortsPerRowOverride(layout, cardConfig.ports_per_row);
+  const configuredPortsPerRow = Number.parseInt(cardConfig?.ports_per_row, 10);
+  const hasConfiguredPortsPerRow = Number.isFinite(configuredPortsPerRow) && configuredPortsPerRow > 0;
+
+  if (hasConfiguredPortsPerRow) {
+    layout = applyPortsPerRowOverride(layout, configuredPortsPerRow);
+  } else if (type === "switch") {
+    layout = applyPortsPerRowOverride(layout, 8);
   }
   const numberedPorts = filterPortsByLayout(discoveredPortsRaw, layout);
   const specialPorts = discoverSpecialPorts(entities);

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -1498,7 +1498,7 @@ window.customCards.push({
   name: "UniFi Device Card",
   description: `Lovelace card for UniFi devices (v${VERSION}).`,
   preview: true,
-  documentationURL: "https://github.com/bacco007/unifi-device-card",
+  documentationURL: "https://github.com/bluenazgul/unifi-device-card",
 });
 
 if (!window[DEV_LOG_FLAG]) {

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -16,6 +16,7 @@ import { t } from "./translations.js";
 import "./unifi-device-card-editor.js";
 
 const VERSION = __VERSION__;
+const DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 
 class UnifiDeviceCard extends HTMLElement {
   static getConfigElement() {
@@ -1499,3 +1500,8 @@ window.customCards.push({
   preview: true,
   documentationURL: "https://github.com/bacco007/unifi-device-card",
 });
+
+if (!window[DEV_LOG_FLAG]) {
+  window[DEV_LOG_FLAG] = true;
+  console.info(`[UNIFI-DEVICE-CARD] Version ${VERSION}`);
+}

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -37,6 +37,7 @@ class UnifiDeviceCard extends HTMLElement {
     this._loadedDeviceId = null;
     this._resizeObserver = null;
     this._lastMeasuredWidth = 0;
+    this._cardSize = 8;
   }
 
   connectedCallback() {
@@ -82,7 +83,42 @@ class UnifiDeviceCard extends HTMLElement {
   }
 
   getCardSize() {
-    return 8;
+    return this._cardSize || this._estimateCardSize();
+  }
+
+  _estimateCardSize() {
+    if (!this._config?.device_id) return 4;
+    if (!this._ctx) return 5;
+    if (this._ctx?.type === "access_point") return 8;
+
+    const { specials, numbered } = this._buildSlotData(this._ctx);
+    const specialPortsInUse = new Set(
+      specials.map((slot) => slot?.port).filter((port) => Number.isInteger(port))
+    );
+    const visibleNumbered = numbered.filter((slot) => !specialPortsInUse.has(slot.port));
+    const panelRows = this._buildEffectiveRows(this._ctx, visibleNumbered).length + (specials.length ? 1 : 0);
+    const selected = [...specials, ...visibleNumbered].find((slot) => slot.key === this._selectedKey)
+      || specials[0]
+      || visibleNumbered[0]
+      || null;
+    const hasPoe = !!(selected?.poe_switch_entity || selected?.poe_power_entity || selected?.power_cycle_entity);
+    const hasTraffic = !!(selected?.rx_entity || selected?.tx_entity);
+
+    return Math.max(6, Math.min(20, 5 + panelRows + (hasPoe ? 1 : 0) + (hasTraffic ? 1 : 0)));
+  }
+
+  _updateCardSize() {
+    const cardEl = this.shadowRoot?.querySelector("ha-card");
+    if (!cardEl) return;
+    const measured = Math.max(1, Math.ceil(cardEl.getBoundingClientRect().height / 50));
+    const nextSize = Number.isFinite(measured) ? measured : this._estimateCardSize();
+    if (nextSize === this._cardSize) return;
+    this._cardSize = nextSize;
+    this.dispatchEvent(new Event("iron-resize", { bubbles: true, composed: true }));
+  }
+
+  _finalizeRender() {
+    requestAnimationFrame(() => this._updateCardSize());
   }
 
   _t(key) {
@@ -1414,6 +1450,7 @@ class UnifiDeviceCard extends HTMLElement {
           </div>
           <div class="empty-state">${this._t("select_device")}</div>
         </ha-card>`;
+      this._finalizeRender();
       return;
     }
 
@@ -1428,6 +1465,7 @@ class UnifiDeviceCard extends HTMLElement {
           </div>
           <div class="loading-state"><div class="spinner"></div>${this._t("loading")}</div>
         </ha-card>`;
+      this._finalizeRender();
       return;
     }
 
@@ -1442,10 +1480,12 @@ class UnifiDeviceCard extends HTMLElement {
           </div>
           <div class="empty-state">${this._t("no_data")}</div>
         </ha-card>`;
+      this._finalizeRender();
       return;
     }
 
     this._renderPanelAndDetail();
+    this._finalizeRender();
   }
 }
 
@@ -1455,5 +1495,7 @@ window.customCards = window.customCards || [];
 window.customCards.push({
   type: "unifi-device-card",
   name: "UniFi Device Card",
-  description: "Lovelace card for UniFi Devices.",
+  description: `Lovelace card for UniFi devices (v${VERSION}).`,
+  preview: true,
+  documentationURL: "https://github.com/bacco007/unifi-device-card",
 });


### PR DESCRIPTION
### Motivation

- Improve card sizing behavior so the Lovelace layout reflects the actual rendered height and content of the UniFi Device Card. 
- Provide a sensible default `ports_per_row` for switch devices when not explicitly configured. 
- Publish updated package metadata and version used in the built bundle.

### Description

- Added dynamic card sizing: introduce `_cardSize`, `getCardSize()`, `_estimateCardSize()`, `_updateCardSize()`, and `_finalizeRender()` to compute and emit an updated card size after rendering. 
- Ensure `_finalizeRender()` is called after render paths (empty, loading, no-data, and normal render) to update the card size post-render. 
- Default switch layout: parse `ports_per_row` with `Number.parseInt` and apply the override only when a finite positive value is provided, otherwise apply `ports_per_row = 8` for devices of type `switch`. 
- Update metadata and version strings in both source and distribution bundles and add `preview: true` and `documentationURL` to the `window.customCards` entry.

### Testing

- Ran the production build to regenerate `dist/unifi-device-card.js` which updated the version string and included the source changes (build succeeded). 
- No automated unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da2df059e48333bcaf30915c72392c)