### PR TITLE
fix: prefer front-panel content width when calculating dynamic ports_per_row

### DIFF
--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.4.86-dev */
+/* UniFi Device Card 0.0.0-dev.736d89f */
 
 // src/model-registry.js
 function range(start, end) {
@@ -3051,7 +3051,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.4.86-dev";
+var VERSION = "0.0.0-dev.736d89f";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var UnifiDeviceCard = class extends HTMLElement {
   static getConfigElement() {
@@ -3188,13 +3188,24 @@ var UnifiDeviceCard = class extends HTMLElement {
     if (cardWidth > 0) return cardWidth;
     return this.parentElement?.getBoundingClientRect?.().width || 0;
   }
+  _measuredFrontPanelContentWidth() {
+    const frontPanel = this.shadowRoot?.querySelector(".frontpanel");
+    if (!frontPanel) return 0;
+    const panelWidth = frontPanel.getBoundingClientRect?.().width || frontPanel.clientWidth || 0;
+    if (panelWidth <= 0) return 0;
+    const computed = getComputedStyle(frontPanel);
+    const paddingLeft = Number.parseFloat(computed.paddingLeft) || 0;
+    const paddingRight = Number.parseFloat(computed.paddingRight) || 0;
+    return Math.max(0, panelWidth - paddingLeft - paddingRight);
+  }
   _maxFittableColumns() {
-    const hostWidth = this._measuredCardWidth();
-    if (!hostWidth) return Infinity;
     const portSize = this._portSize();
+    const panelContentWidth = this._measuredFrontPanelContentWidth();
+    const hostWidth = this._measuredCardWidth();
+    if (!panelContentWidth && !hostWidth) return Infinity;
     const horizontalPadding = 40;
     const gap = 6;
-    const available = Math.max(180, hostWidth - horizontalPadding);
+    const available = panelContentWidth > 0 ? panelContentWidth : Math.max(180, hostWidth - horizontalPadding);
     return Math.max(1, Math.floor((available + gap) / (portSize + gap)));
   }
   _wholeNumberState(entityId) {

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -181,14 +181,30 @@ class UnifiDeviceCard extends HTMLElement {
     return this.parentElement?.getBoundingClientRect?.().width || 0;
   }
 
-  _maxFittableColumns() {
-    const hostWidth = this._measuredCardWidth();
-    if (!hostWidth) return Infinity;
+  _measuredFrontPanelContentWidth() {
+    const frontPanel = this.shadowRoot?.querySelector(".frontpanel");
+    if (!frontPanel) return 0;
 
+    const panelWidth = frontPanel.getBoundingClientRect?.().width || frontPanel.clientWidth || 0;
+    if (panelWidth <= 0) return 0;
+
+    const computed = getComputedStyle(frontPanel);
+    const paddingLeft = Number.parseFloat(computed.paddingLeft) || 0;
+    const paddingRight = Number.parseFloat(computed.paddingRight) || 0;
+    return Math.max(0, panelWidth - paddingLeft - paddingRight);
+  }
+
+  _maxFittableColumns() {
     const portSize = this._portSize();
+    const panelContentWidth = this._measuredFrontPanelContentWidth();
+    const hostWidth = this._measuredCardWidth();
+    if (!panelContentWidth && !hostWidth) return Infinity;
+
     const horizontalPadding = 40;
     const gap = 6;
-    const available = Math.max(180, hostWidth - horizontalPadding);
+    const available = panelContentWidth > 0
+      ? panelContentWidth
+      : Math.max(180, hostWidth - horizontalPadding);
     return Math.max(1, Math.floor((available + gap) / (portSize + gap)));
   }
 


### PR DESCRIPTION
### Motivation
- Users reported that `ports_per_row` was still not applied reliably because the card estimated available columns from the host/card width, which can overestimate usable space and cause rows to be clipped.
- The change ensures the configured default (for example `8`) or the user-provided `ports_per_row` is used when it actually fits, and is reduced automatically when it does not.

### Description
- In `src/unifi-device-card.js` added `_measuredFrontPanelContentWidth()` to measure the actual front-panel inner content width (panel width minus left/right padding).
- Updated `_maxFittableColumns()` in `src/unifi-device-card.js` to prefer the front-panel content width when available and fall back to the previous host/card width calculation if the panel is not yet measurable.
- Rebuilt the distribution output so `dist/unifi-device-card.js` is updated to match the `/src` change (generated artifact only).

### Testing
- Ran `npm run build` which completed successfully and produced an updated `dist/unifi-device-card.js` (success).
- Attempted `npm run lint` but the repository does not define a `lint` script (no-op / informational).
- Attempted `npm test` but the repository does not define a `test` script (no-op / informational).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da3643df188333b045cc7b4e5ad8df)