### PR TITLE
Fix duplicate editor helper declarations breaking build

### DIFF
--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.6e9c391 */
+/* UniFi Device Card 0.0.0-dev.7320fb8 */
 
 // src/model-registry.js
 function range(start, end) {
@@ -3184,7 +3184,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.6e9c391";
+var VERSION = "0.0.0-dev.7320fb8";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var UnifiDeviceCard = class extends HTMLElement {
   static getConfigElement() {

--- a/src/unifi-device-card-editor.js
+++ b/src/unifi-device-card-editor.js
@@ -138,36 +138,6 @@ function collectDefaultSpecialPorts(layout) {
   ).sort((a, b) => a - b);
 }
 
-function normalizeSpecialPortNumbers(value) {
-  if (!Array.isArray(value)) return [];
-
-  const normalized = value
-    .map((entry) => Number.parseInt(entry, 10))
-    .filter((num) => Number.isInteger(num) && num > 0);
-
-  return Array.from(new Set(normalized)).sort((a, b) => a - b);
-}
-
-function collectLayoutPorts(layout) {
-  if (!layout) return [];
-  const numbered = (layout.rows || []).flat().filter((port) => Number.isInteger(port) && port > 0);
-  const specials = (layout.specialSlots || [])
-    .map((slot) => slot?.port)
-    .filter((port) => Number.isInteger(port) && port > 0);
-  return Array.from(new Set([...numbered, ...specials])).sort((a, b) => a - b);
-}
-
-function collectDefaultSpecialPorts(layout) {
-  if (!layout) return [];
-  return Array.from(
-    new Set(
-      (layout.specialSlots || [])
-        .map((slot) => slot?.port)
-        .filter((port) => Number.isInteger(port) && port > 0)
-    )
-  ).sort((a, b) => a - b);
-}
-
 class UnifiDeviceCardEditor extends HTMLElement {
   constructor() {
     super();


### PR DESCRIPTION
### Motivation
- The build failed because `src/unifi-device-card-editor.js` contained duplicate top-level definitions of helper functions, which is illegal for ES modules and caused esbuild to abort with "already been declared" errors. 

### Description
- Removed the duplicated top-level helper declarations for `normalizeSpecialPortNumbers`, `collectLayoutPorts`, and `collectDefaultSpecialPorts` in `src/unifi-device-card-editor.js`. 
- Updated the generated bundle so `dist/unifi-device-card.js` is consistent with the fixed source. 
- Changes only touch the editor helpers and the generated distribution output (`src/unifi-device-card-editor.js`, `dist/unifi-device-card.js`).

### Testing
- Ran `npm run build` and the build completed successfully. 
- `npm run lint` was not run because there is no `lint` script defined in `package.json`. 
- `npm test` was not run because there is no `test` script defined in `package.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da48f42c508333a916e7471c8dcbd8)