### PR TITLE
Render WAN/WAN2 and top-row special ports only when Edit special ports is enabled; fix editor order

### DIFF
--- a/src/unifi-device-card-editor.js
+++ b/src/unifi-device-card-editor.js
@@ -500,6 +500,8 @@ class UnifiDeviceCardEditor extends HTMLElement {
 
     if (!isGateway) return "";
 
+    if (!showControls) return "";
+
     const layout = this._deviceCtx?.layout;
     if (!layout) {
       return `
@@ -530,8 +532,6 @@ class UnifiDeviceCardEditor extends HTMLElement {
     if (roleSelectionsConflict(selectedWan, "wan", selectedWan2, "wan2", layout)) {
       selectedWan2 = "none";
     }
-
-    if (!showControls) return "";
 
     return `
       <div class="field">
@@ -819,16 +819,6 @@ class UnifiDeviceCardEditor extends HTMLElement {
           <label>${this._t("editor_ports_per_row_label")}</label>
           <input id="ports_per_row" type="text" inputmode="numeric" value="${portsPerRow}">
           <div class="hint">${this._t("editor_ports_per_row_hint")}</div>
-        </div>
-
-        <div class="field">
-          <label>${this._t("editor_custom_special_ports_label")}</label>
-          <select id="custom_special_ports" multiple size="${Math.min(10, Math.max(4, customSpecialPortOptions.length || 4))}">
-            ${customSpecialPortOptions
-              .map((port) => `<option value="${port}" ${selectedCustomSpecialPorts.includes(port) ? "selected" : ""}>Port ${port}</option>`)
-              .join("")}
-          </select>
-          <div class="hint">${this._t("editor_custom_special_ports_hint")}</div>
         </div>` : ""}
 
         ${isSwitchOrGateway ? `
@@ -845,8 +835,6 @@ class UnifiDeviceCardEditor extends HTMLElement {
           <div class="hint">${this._t("editor_ap_scale_hint")}</div>
         </div>` : ""}
 
-        ${this._gatewayControlsHTML(editSpecialPorts)}
-
         ${isSwitchOrGateway ? `
         <div class="field">
           <label class="checkbox-row">
@@ -857,6 +845,8 @@ class UnifiDeviceCardEditor extends HTMLElement {
         </div>
 
         ${editSpecialPorts ? `
+        ${this._gatewayControlsHTML(true)}
+
         <div class="field">
           <label>${this._t("editor_custom_special_ports_label")}</label>
           <div id="special_ports_list" class="port-toggle-list">
@@ -865,7 +855,8 @@ class UnifiDeviceCardEditor extends HTMLElement {
               .join("")}
           </div>
           <div class="hint">${this._t("editor_custom_special_ports_hint")}</div>
-        </div>` : ""}` : ""}
+        </div>` : ""}
+        ` : ""}
 
         <div class="field">
           <label>${this._t("editor_bg_label")}</label>


### PR DESCRIPTION
### Motivation
- The WAN/WAN2 selectors and the top-row "Spezial-Ports" controls should be grouped under the `Spezial-Ports bearbeiten` toggle and only be visible when `edit_special_ports` is `true` to avoid confusing/partially-hidden controls in the visual editor. 
- The visual order must be `WAN-Port`, `WAN2-Port`, `Spezial-Ports (obere Reihe)` when editing special ports.

### Description
- Updated `src/unifi-device-card-editor.js` to move rendering of the gateway WAN/WAN2 selectors so they appear under the `edit_special_ports` toggle and in the requested order. 
- Changed `_gatewayControlsHTML(showControls = true)` to return no markup at all when `showControls` is `false` (previously the controls could be present but hidden), so WAN/WAN2 are truly not rendered unless editing is enabled. 
- Removed the legacy duplicate multi-select block for `custom_special_ports` that could reference editor-only variables and cause inconsistent behavior in the visual editor. 
- No manual edits were made to `dist` as implementation changes reside in `/src` and the build output is generated by the normal build step.

### Testing
- Ran `npm run build` and the build completed successfully. 
- Ran `node --check src/unifi-device-card-editor.js` and the file passed a syntax check.

Files changed: `src/unifi-device-card-editor.js` (implementation); `dist` is treated as generated output and was not manually committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da4afab5fc8333942a93a18358ccb6)