### PR TITLE
fix: restore header telemetry for switches & gateways

### DIFF
--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.31de7cc */
+/* UniFi Device Card 0.0.0-dev.46103cc */
 
 // src/model-registry.js
 function range(start, end) {
@@ -1159,11 +1159,26 @@ function findDeviceEntityByPatterns(entities, patterns = []) {
   }
   return null;
 }
+function isPortLevelTelemetrySensor(entityId) {
+  const id = lower(entityId);
+  return id.includes("_port_") || id.includes("_wan_") || id.includes("link_speed") || id.includes("_rx") || id.includes("_tx") || id.includes("throughput");
+}
+function findSystemStatEntity(entities, includePatterns = [], excludePatterns = []) {
+  for (const entity of entities || []) {
+    const id = lower(entity.entity_id);
+    if (!id.startsWith("sensor.")) continue;
+    if (isPortLevelTelemetrySensor(id)) continue;
+    if (!includePatterns.some((pattern) => id.includes(pattern))) continue;
+    if (excludePatterns.some((pattern) => id.includes(pattern))) continue;
+    return entity.entity_id;
+  }
+  return null;
+}
 function getDeviceTelemetry(entities) {
   return {
-    cpu_utilization_entity: findDeviceEntityByPatterns(entities, ["cpu_utilization", "cpu_usage", "processor_utilization"]),
-    cpu_temperature_entity: findDeviceEntityByPatterns(entities, ["cpu_temperature", "processor_temperature", "temperature_cpu"]),
-    memory_utilization_entity: findDeviceEntityByPatterns(entities, ["memory_utilization", "memory_usage", "ram_utilization"])
+    cpu_utilization_entity: findDeviceEntityByPatterns(entities, ["cpu_utilization", "cpu_usage", "processor_utilization"]) || findSystemStatEntity(entities, ["cpu"], ["temperature", "temp", "clock", "frequency", "fan"]),
+    cpu_temperature_entity: findDeviceEntityByPatterns(entities, ["cpu_temperature", "processor_temperature", "temperature_cpu"]) || findSystemStatEntity(entities, ["cpu_temp", "cpu_temperature", "processor_temperature", "temperature_cpu", "cpu"], ["utilization", "usage", "clock", "frequency"]),
+    memory_utilization_entity: findDeviceEntityByPatterns(entities, ["memory_utilization", "memory_usage", "ram_utilization"]) || findSystemStatEntity(entities, ["memory", "ram"], ["temperature", "temp", "slot"])
   };
 }
 function getDeviceOnlineEntity(entities) {
@@ -3177,7 +3192,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.31de7cc";
+var VERSION = "0.0.0-dev.46103cc";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var UnifiDeviceCard = class extends HTMLElement {
   static getConfigElement() {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -482,11 +482,41 @@ function findDeviceEntityByPatterns(entities, patterns = []) {
   return null;
 }
 
+function isPortLevelTelemetrySensor(entityId) {
+  const id = lower(entityId);
+  return (
+    id.includes("_port_") ||
+    id.includes("_wan_") ||
+    id.includes("link_speed") ||
+    id.includes("_rx") ||
+    id.includes("_tx") ||
+    id.includes("throughput")
+  );
+}
+
+function findSystemStatEntity(entities, includePatterns = [], excludePatterns = []) {
+  for (const entity of entities || []) {
+    const id = lower(entity.entity_id);
+    if (!id.startsWith("sensor.")) continue;
+    if (isPortLevelTelemetrySensor(id)) continue;
+    if (!includePatterns.some((pattern) => id.includes(pattern))) continue;
+    if (excludePatterns.some((pattern) => id.includes(pattern))) continue;
+    return entity.entity_id;
+  }
+  return null;
+}
+
 export function getDeviceTelemetry(entities) {
   return {
-    cpu_utilization_entity: findDeviceEntityByPatterns(entities, ["cpu_utilization", "cpu_usage", "processor_utilization"]),
-    cpu_temperature_entity: findDeviceEntityByPatterns(entities, ["cpu_temperature", "processor_temperature", "temperature_cpu"]),
-    memory_utilization_entity: findDeviceEntityByPatterns(entities, ["memory_utilization", "memory_usage", "ram_utilization"]),
+    cpu_utilization_entity:
+      findDeviceEntityByPatterns(entities, ["cpu_utilization", "cpu_usage", "processor_utilization"]) ||
+      findSystemStatEntity(entities, ["cpu"], ["temperature", "temp", "clock", "frequency", "fan"]),
+    cpu_temperature_entity:
+      findDeviceEntityByPatterns(entities, ["cpu_temperature", "processor_temperature", "temperature_cpu"]) ||
+      findSystemStatEntity(entities, ["cpu_temp", "cpu_temperature", "processor_temperature", "temperature_cpu", "cpu"], ["utilization", "usage", "clock", "frequency"]),
+    memory_utilization_entity:
+      findDeviceEntityByPatterns(entities, ["memory_utilization", "memory_usage", "ram_utilization"]) ||
+      findSystemStatEntity(entities, ["memory", "ram"], ["temperature", "temp", "slot"]),
   };
 }
 


### PR DESCRIPTION
### Motivation
- Header-Metriken (CPU, Temperatur, Speicher) tauchten bei Switches/Gateways nicht mehr zuverlässig auf; portbezogene Sensoren wurden fälschlich priorisiert oder falsche Entities ausgewählt.
- Ziel ist ein minimaler Bugfix, der wieder robuste Erkennung systemweiter Telemetrie sicherstellt, ohne Editor-/Dokumentationsdateien zu ändern.

### Description
- Added `isPortLevelTelemetrySensor` to exclude per-port/port-level sensors (e.g. `_port_`, `_wan_`, `link_speed`, `_rx`, `_tx`, `throughput`) from header matching in `src/helpers.js`.
- Added `findSystemStatEntity` to provide fallback matching for common system stat naming variants while honoring exclusion patterns in `src/helpers.js`.
- Updated `getDeviceTelemetry` to use existing pattern matching first and then fallback to `findSystemStatEntity` for `cpu_utilization_entity`, `cpu_temperature_entity`, and `memory_utilization_entity` so switches/gateways (and APs) surface header stats again.
- Rebuilt bundle output `dist/unifi-device-card.js` to include the changes (generated artifact only).

### Testing
- Ran `npm run build` and the build completed successfully (`dist/unifi-device-card.js` updated). 
- Attempted `npm run lint` but the project has no `lint` script defined so no lint run was performed.
- Attempted `npm test` but the project has no `test` script defined so no automated tests were run.

Notes: `README.md` and `CHANGELOG.md` were intentionally left unchanged per release request.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da616e37f48333867e08cbd218a228)