### PR TITLE
Refine styling for ports/LEDs, add stacking context and bump dev version

### DIFF
--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.5af7cd0 */
+/* UniFi Device Card 0.0.0-dev.75276f6 */
 
 // src/model-registry.js
 function range(start, end) {
@@ -3192,7 +3192,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.5af7cd0";
+var VERSION = "0.0.0-dev.75276f6";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var UnifiDeviceCard = class extends HTMLElement {
   static getConfigElement() {
@@ -3722,6 +3722,8 @@ var UnifiDeviceCard = class extends HTMLElement {
         background: var(--udc-card-bg, var(--ha-card-background, var(--card-background-color)));
         border-radius: var(--ha-card-border-radius, 12px);
         overflow: hidden;
+        position: relative;
+        isolation: isolate;
       }
 
       .header {
@@ -3841,6 +3843,9 @@ var UnifiDeviceCard = class extends HTMLElement {
         display: grid;
         gap: 3px;
         border-bottom: 1px solid var(--udc-border);
+        position: relative;
+        z-index: 0;
+        overflow: hidden;
       }
 
       .frontpanel.theme-white { background: #d6d6d9; }
@@ -4023,6 +4028,7 @@ var UnifiDeviceCard = class extends HTMLElement {
           inset 0 1px 0 rgba(255,255,255,.05),
           inset 0 -1px 0 rgba(0,0,0,.45);
         overflow: hidden;
+        z-index: 0;
       }
 
       .rj45-shell-top {
@@ -4066,11 +4072,13 @@ var UnifiDeviceCard = class extends HTMLElement {
       .rj45-led {
         position: absolute;
         bottom: 1px;
-        height: 5px;
+        height: 4px;
         border-radius: 0;
-        background: #868b93;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,.2);
-        z-index: 5;
+        background: linear-gradient(180deg, #9ea3ab 0%, #767c85 100%);
+        box-shadow:
+          inset 0 1px 0 rgba(255,255,255,.16),
+          inset 0 -1px 0 rgba(0,0,0,.28);
+        z-index: 1;
       }
 
       .rj45-led.left {
@@ -4086,17 +4094,19 @@ var UnifiDeviceCard = class extends HTMLElement {
       }
 
       .rj45-led.orange {
-        background: #efb21a;
+        background: linear-gradient(180deg, #efc14d 0%, #efb21a 58%, #b8820d 100%);
         box-shadow:
-          0 0 4px rgba(239,178,26,.75),
-          inset 0 -1px 0 rgba(0,0,0,.18);
+          0 0 2px rgba(239,178,26,.42),
+          inset 0 1px 0 rgba(255,255,255,.22),
+          inset 0 -1px 0 rgba(0,0,0,.35);
       }
 
       .rj45-led.green {
-        background: #33d35d;
+        background: linear-gradient(180deg, #63ea86 0%, #33d35d 58%, #1c8e3a 100%);
         box-shadow:
-          0 0 4px rgba(51,211,93,.75),
-          inset 0 -1px 0 rgba(0,0,0,.18);
+          0 0 2px rgba(51,211,93,.42),
+          inset 0 1px 0 rgba(255,255,255,.22),
+          inset 0 -1px 0 rgba(0,0,0,.35);
       }
 
       .rj45-led.off {
@@ -4134,24 +4144,28 @@ var UnifiDeviceCard = class extends HTMLElement {
 
       .sfp-top-led {
         width: 16px;
-        height: 5px;
+        height: 4px;
         border-radius: 0;
-        background: #8a8e95;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,.25);
+        background: linear-gradient(180deg, #9ea3ab 0%, #767c85 100%);
+        box-shadow:
+          inset 0 1px 0 rgba(255,255,255,.16),
+          inset 0 -1px 0 rgba(0,0,0,.28);
       }
 
       .sfp-top-led.orange {
-        background: #efb21a;
+        background: linear-gradient(180deg, #efc14d 0%, #efb21a 58%, #b8820d 100%);
         box-shadow:
-          0 0 4px rgba(239,178,26,.75),
-          inset 0 -1px 0 rgba(0,0,0,.18);
+          0 0 2px rgba(239,178,26,.42),
+          inset 0 1px 0 rgba(255,255,255,.22),
+          inset 0 -1px 0 rgba(0,0,0,.35);
       }
 
       .sfp-top-led.green {
-        background: #33d35d;
+        background: linear-gradient(180deg, #63ea86 0%, #33d35d 58%, #1c8e3a 100%);
         box-shadow:
-          0 0 4px rgba(51,211,93,.75),
-          inset 0 -1px 0 rgba(0,0,0,.18);
+          0 0 2px rgba(51,211,93,.42),
+          inset 0 1px 0 rgba(255,255,255,.22),
+          inset 0 -1px 0 rgba(0,0,0,.35);
       }
 
       .sfp-top-led.off {
@@ -4163,6 +4177,7 @@ var UnifiDeviceCard = class extends HTMLElement {
         position: relative;
         width: calc(var(--udc-port-size) - 2px);
         height: var(--udc-port-size);
+        z-index: 0;
       }
 
       .sfp-frame {
@@ -4247,6 +4262,8 @@ var UnifiDeviceCard = class extends HTMLElement {
       .section {
         padding: 12px 14px 14px;
         background: var(--udc-chrome-bg, transparent);
+        position: relative;
+        z-index: 1;
       }
 
       .detail-title {

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -679,6 +679,8 @@ class UnifiDeviceCard extends HTMLElement {
         background: var(--udc-card-bg, var(--ha-card-background, var(--card-background-color)));
         border-radius: var(--ha-card-border-radius, 12px);
         overflow: hidden;
+        position: relative;
+        isolation: isolate;
       }
 
       .header {
@@ -798,6 +800,9 @@ class UnifiDeviceCard extends HTMLElement {
         display: grid;
         gap: 3px;
         border-bottom: 1px solid var(--udc-border);
+        position: relative;
+        z-index: 0;
+        overflow: hidden;
       }
 
       .frontpanel.theme-white { background: #d6d6d9; }
@@ -980,6 +985,7 @@ class UnifiDeviceCard extends HTMLElement {
           inset 0 1px 0 rgba(255,255,255,.05),
           inset 0 -1px 0 rgba(0,0,0,.45);
         overflow: hidden;
+        z-index: 0;
       }
 
       .rj45-shell-top {
@@ -1023,11 +1029,13 @@ class UnifiDeviceCard extends HTMLElement {
       .rj45-led {
         position: absolute;
         bottom: 1px;
-        height: 5px;
+        height: 4px;
         border-radius: 0;
-        background: #868b93;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,.2);
-        z-index: 5;
+        background: linear-gradient(180deg, #9ea3ab 0%, #767c85 100%);
+        box-shadow:
+          inset 0 1px 0 rgba(255,255,255,.16),
+          inset 0 -1px 0 rgba(0,0,0,.28);
+        z-index: 1;
       }
 
       .rj45-led.left {
@@ -1043,17 +1051,19 @@ class UnifiDeviceCard extends HTMLElement {
       }
 
       .rj45-led.orange {
-        background: #efb21a;
+        background: linear-gradient(180deg, #efc14d 0%, #efb21a 58%, #b8820d 100%);
         box-shadow:
-          0 0 4px rgba(239,178,26,.75),
-          inset 0 -1px 0 rgba(0,0,0,.18);
+          0 0 2px rgba(239,178,26,.42),
+          inset 0 1px 0 rgba(255,255,255,.22),
+          inset 0 -1px 0 rgba(0,0,0,.35);
       }
 
       .rj45-led.green {
-        background: #33d35d;
+        background: linear-gradient(180deg, #63ea86 0%, #33d35d 58%, #1c8e3a 100%);
         box-shadow:
-          0 0 4px rgba(51,211,93,.75),
-          inset 0 -1px 0 rgba(0,0,0,.18);
+          0 0 2px rgba(51,211,93,.42),
+          inset 0 1px 0 rgba(255,255,255,.22),
+          inset 0 -1px 0 rgba(0,0,0,.35);
       }
 
       .rj45-led.off {
@@ -1091,24 +1101,28 @@ class UnifiDeviceCard extends HTMLElement {
 
       .sfp-top-led {
         width: 16px;
-        height: 5px;
+        height: 4px;
         border-radius: 0;
-        background: #8a8e95;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,.25);
+        background: linear-gradient(180deg, #9ea3ab 0%, #767c85 100%);
+        box-shadow:
+          inset 0 1px 0 rgba(255,255,255,.16),
+          inset 0 -1px 0 rgba(0,0,0,.28);
       }
 
       .sfp-top-led.orange {
-        background: #efb21a;
+        background: linear-gradient(180deg, #efc14d 0%, #efb21a 58%, #b8820d 100%);
         box-shadow:
-          0 0 4px rgba(239,178,26,.75),
-          inset 0 -1px 0 rgba(0,0,0,.18);
+          0 0 2px rgba(239,178,26,.42),
+          inset 0 1px 0 rgba(255,255,255,.22),
+          inset 0 -1px 0 rgba(0,0,0,.35);
       }
 
       .sfp-top-led.green {
-        background: #33d35d;
+        background: linear-gradient(180deg, #63ea86 0%, #33d35d 58%, #1c8e3a 100%);
         box-shadow:
-          0 0 4px rgba(51,211,93,.75),
-          inset 0 -1px 0 rgba(0,0,0,.18);
+          0 0 2px rgba(51,211,93,.42),
+          inset 0 1px 0 rgba(255,255,255,.22),
+          inset 0 -1px 0 rgba(0,0,0,.35);
       }
 
       .sfp-top-led.off {
@@ -1120,6 +1134,7 @@ class UnifiDeviceCard extends HTMLElement {
         position: relative;
         width: calc(var(--udc-port-size) - 2px);
         height: var(--udc-port-size);
+        z-index: 0;
       }
 
       .sfp-frame {
@@ -1204,6 +1219,8 @@ class UnifiDeviceCard extends HTMLElement {
       .section {
         padding: 12px 14px 14px;
         background: var(--udc-chrome-bg, transparent);
+        position: relative;
+        z-index: 1;
       }
 
       .detail-title {


### PR DESCRIPTION
### Motivation
- Improve visual fidelity of port and LED elements and fix stacking/overflow issues in the card UI.
- Ensure distribution reflects the latest source styling changes by updating the built artifact version.

### Description
- Bumped dev version string in the built bundle from `0.0.0-dev.5af7cd0` to `0.0.0-dev.75276f6` and updated `dist/unifi-device-card.js` accordingly.
- Added `position: relative` and `isolation: isolate` to `ha-card` to create a new stacking context and prevent z-index/overflow bleed; applied `position: relative`, `z-index`, and `overflow: hidden` to `.frontpanel` and `.section` to contain visual elements.
- Updated port visuals: reduced LED heights, replaced flat colors with vertical gradients, adjusted box-shadows for `rj45-led` and `.sfp-top-led`, and refined orange/green LED styling for both RJ45 and SFP elements.
- Set `z-index: 0` on several port container elements (`.port-rj45`, `.port-sfp`) to ensure consistent layering with updated LED and notch elements.

### Testing
- Rebuilt the source to regenerate `dist/unifi-device-card.js` (`npm run build`), and the build completed successfully.
- Ran project linters and style checks and they passed without errors.
- Executed the test suite (`npm test`) and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da67c1957483338433819ffb6a2d15)