### PR TITLE
feat: derive PoE entities from manual port speed override

### DIFF
--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.5.1 */
+/* UniFi Device Card 0.0.0-dev.1c1bfe9 */
 
 // src/model-registry.js
 function range(start, end) {
@@ -3192,7 +3192,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.5.1";
+var VERSION = "0.0.0-dev.1c1bfe9";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var UnifiDeviceCard = class extends HTMLElement {
   static getConfigElement() {
@@ -3464,6 +3464,7 @@ var UnifiDeviceCard = class extends HTMLElement {
       ctx?.type === "gateway" ? discoverSpecialPorts(ctx?.entities || []) : [],
       discovered
     );
+    this._applyManualPortSensorOverrides(numberedRaw, specialsRaw);
     if (ctx?.type === "gateway") {
       return applyGatewayPortOverrides(
         this._config,
@@ -3473,6 +3474,74 @@ var UnifiDeviceCard = class extends HTMLElement {
       );
     }
     return { specials: specialsRaw, numbered: numberedRaw };
+  }
+  _manualPortSpeedOverrides() {
+    const out = /* @__PURE__ */ new Map();
+    const entries = Object.entries(this._config || {});
+    for (const [key, value] of entries) {
+      const match = String(key || "").match(/^port_(\d+)$/i);
+      if (!match) continue;
+      const port = Number.parseInt(match[1], 10);
+      const entityId = String(value || "").trim();
+      if (!Number.isInteger(port) || port < 1 || !entityId) continue;
+      out.set(port, entityId);
+    }
+    return out;
+  }
+  _applyManualPortSensorOverrides(numbered, specials) {
+    const overrides = this._manualPortSpeedOverrides();
+    if (!overrides.size) return;
+    const allSlots = [...Array.isArray(numbered) ? numbered : [], ...Array.isArray(specials) ? specials : []];
+    const overrideEntities = new Set(overrides.values());
+    for (const slot of allSlots) {
+      if (!slot || !overrideEntities.has(slot.speed_entity)) continue;
+      slot.speed_entity = null;
+    }
+    for (const [port, entityId] of overrides.entries()) {
+      const slot = allSlots.find((entry) => entry?.port === port);
+      if (!slot) continue;
+      slot.speed_entity = entityId;
+      if (!Array.isArray(slot.raw_entities)) slot.raw_entities = [];
+      if (!slot.raw_entities.includes(entityId)) slot.raw_entities.push(entityId);
+      const derivedRx = this._deriveTelemetrySibling(entityId, "rx");
+      if (derivedRx) {
+        slot.rx_entity = derivedRx;
+        if (!slot.raw_entities.includes(derivedRx)) slot.raw_entities.push(derivedRx);
+      }
+      const derivedTx = this._deriveTelemetrySibling(entityId, "tx");
+      if (derivedTx) {
+        slot.tx_entity = derivedTx;
+        if (!slot.raw_entities.includes(derivedTx)) slot.raw_entities.push(derivedTx);
+      }
+      const derivedPoePower = this._deriveTelemetrySibling(entityId, "poe_power");
+      if (derivedPoePower) {
+        slot.poe_power_entity = derivedPoePower;
+        if (!slot.raw_entities.includes(derivedPoePower)) slot.raw_entities.push(derivedPoePower);
+      }
+      const derivedPoeSwitch = this._deriveTelemetrySibling(entityId, "poe_switch");
+      if (derivedPoeSwitch) {
+        slot.poe_switch_entity = derivedPoeSwitch;
+        if (!slot.raw_entities.includes(derivedPoeSwitch)) slot.raw_entities.push(derivedPoeSwitch);
+      }
+    }
+  }
+  _deriveTelemetrySibling(speedEntityId, metric) {
+    const source = String(speedEntityId || "").trim();
+    if (!source.startsWith("sensor.") || !source.endsWith("_link_speed")) return null;
+    const base = source.replace(/^sensor\./i, "").replace(/_link_speed$/i, "");
+    if (!base) return null;
+    const candidates = metric === "rx" ? [`sensor.${base}_rx`] : metric === "tx" ? [`sensor.${base}_tx`] : metric === "poe_power" ? [
+      `sensor.${base}_poe_power`,
+      `sensor.${base}_poe_consumption`,
+      `sensor.${base}_power_draw`
+    ] : metric === "poe_switch" ? [
+      `switch.${base}_poe`,
+      `switch.${base}_poe_enabled`,
+      `switch.${base}_poe_port_control`,
+      `switch.${base}_port_poe`
+    ] : [];
+    if (!candidates.length) return null;
+    return candidates.find((candidate) => !!this._hass?.states?.[candidate]) || null;
   }
   _normalizePortList(value) {
     if (!Array.isArray(value)) return [];

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -343,6 +343,8 @@ class UnifiDeviceCard extends HTMLElement {
       discovered
     );
 
+    this._applyManualPortSensorOverrides(numberedRaw, specialsRaw);
+
     if (ctx?.type === "gateway") {
       return applyGatewayPortOverrides(
         this._config,
@@ -353,6 +355,100 @@ class UnifiDeviceCard extends HTMLElement {
     }
 
     return { specials: specialsRaw, numbered: numberedRaw };
+  }
+
+  _manualPortSpeedOverrides() {
+    const out = new Map();
+    const entries = Object.entries(this._config || {});
+
+    for (const [key, value] of entries) {
+      const match = String(key || "").match(/^port_(\d+)$/i);
+      if (!match) continue;
+
+      const port = Number.parseInt(match[1], 10);
+      const entityId = String(value || "").trim();
+      if (!Number.isInteger(port) || port < 1 || !entityId) continue;
+
+      out.set(port, entityId);
+    }
+
+    return out;
+  }
+
+  _applyManualPortSensorOverrides(numbered, specials) {
+    const overrides = this._manualPortSpeedOverrides();
+    if (!overrides.size) return;
+
+    const allSlots = [...(Array.isArray(numbered) ? numbered : []), ...(Array.isArray(specials) ? specials : [])];
+    const overrideEntities = new Set(overrides.values());
+
+    for (const slot of allSlots) {
+      if (!slot || !overrideEntities.has(slot.speed_entity)) continue;
+      slot.speed_entity = null;
+    }
+
+    for (const [port, entityId] of overrides.entries()) {
+      const slot = allSlots.find((entry) => entry?.port === port);
+      if (!slot) continue;
+
+      slot.speed_entity = entityId;
+      if (!Array.isArray(slot.raw_entities)) slot.raw_entities = [];
+      if (!slot.raw_entities.includes(entityId)) slot.raw_entities.push(entityId);
+
+      const derivedRx = this._deriveTelemetrySibling(entityId, "rx");
+      if (derivedRx) {
+        slot.rx_entity = derivedRx;
+        if (!slot.raw_entities.includes(derivedRx)) slot.raw_entities.push(derivedRx);
+      }
+
+      const derivedTx = this._deriveTelemetrySibling(entityId, "tx");
+      if (derivedTx) {
+        slot.tx_entity = derivedTx;
+        if (!slot.raw_entities.includes(derivedTx)) slot.raw_entities.push(derivedTx);
+      }
+
+      const derivedPoePower = this._deriveTelemetrySibling(entityId, "poe_power");
+      if (derivedPoePower) {
+        slot.poe_power_entity = derivedPoePower;
+        if (!slot.raw_entities.includes(derivedPoePower)) slot.raw_entities.push(derivedPoePower);
+      }
+
+      const derivedPoeSwitch = this._deriveTelemetrySibling(entityId, "poe_switch");
+      if (derivedPoeSwitch) {
+        slot.poe_switch_entity = derivedPoeSwitch;
+        if (!slot.raw_entities.includes(derivedPoeSwitch)) slot.raw_entities.push(derivedPoeSwitch);
+      }
+    }
+  }
+
+  _deriveTelemetrySibling(speedEntityId, metric) {
+    const source = String(speedEntityId || "").trim();
+    if (!source.startsWith("sensor.") || !source.endsWith("_link_speed")) return null;
+
+    const base = source.replace(/^sensor\./i, "").replace(/_link_speed$/i, "");
+    if (!base) return null;
+
+    const candidates = metric === "rx"
+      ? [`sensor.${base}_rx`]
+      : metric === "tx"
+        ? [`sensor.${base}_tx`]
+        : metric === "poe_power"
+          ? [
+              `sensor.${base}_poe_power`,
+              `sensor.${base}_poe_consumption`,
+              `sensor.${base}_power_draw`,
+            ]
+          : metric === "poe_switch"
+            ? [
+                `switch.${base}_poe`,
+                `switch.${base}_poe_enabled`,
+                `switch.${base}_poe_port_control`,
+                `switch.${base}_port_poe`,
+              ]
+            : [];
+
+    if (!candidates.length) return null;
+    return candidates.find((candidate) => !!this._hass?.states?.[candidate]) || null;
   }
 
   _normalizePortList(value) {


### PR DESCRIPTION
## Summary
- Extended manual `port_<n>: sensor.<base>_link_speed` fallback handling to also discover and attach PoE-related siblings for that same port.
- In addition to `rx` and `tx`, the card now tries to resolve:
  - PoE power sensors (`poe_power_entity`)
  - PoE control switch entities (`poe_switch_entity`)
- Sibling assignment remains conditional: only entities that exist in `hass.states` are applied.
- Rebuilt `dist/unifi-device-card.js` from updated `/src`.

## Resolution candidates
From `sensor.<base>_link_speed`, the card now checks:
- RX: `sensor.<base>_rx`
- TX: `sensor.<base>_tx`
- PoE power: `sensor.<base>_poe_power`, `sensor.<base>_poe_consumption`, `sensor.<base>_power_draw`
- PoE switch: `switch.<base>_poe`, `switch.<base>_poe_enabled`, `switch.<base>_poe_port_control`, `switch.<base>_port_poe`

## Validation
- `npm run build` ✅
- `npm run lint` ❌ (no lint script exists in repository)


------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da8f2586608333af1ad61f991ca39e)