### PR TITLE
fix: normalize port speed units and dim inactive ports

### DIFF
--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1901,6 +1901,17 @@ function stateObj(hass, entityId) {
 function stateValue(hass, entityId) {
   return stateObj(hass, entityId)?.state ?? null;
 }
+function parseLinkSpeedMbit(hass, entityId) {
+  const obj = stateObj(hass, entityId);
+  const raw = obj?.state;
+  if (raw == null || raw === "unavailable" || raw === "unknown") return null;
+  const n = parseFloat(String(raw).replace(",", "."));
+  if (!Number.isFinite(n)) return null;
+  const unit = String(obj?.attributes?.unit_of_measurement || "").toLowerCase();
+  if (unit.includes("gb")) return n * 1e3;
+  if (unit.includes("kb")) return n / 1e3;
+  return n;
+}
 function isOn(hass, entityId) {
   const s = stateValue(hass, entityId);
   return s === "on" || s === "true" || s === "connected" || s === "up" || s === "active";
@@ -1931,11 +1942,10 @@ function isPortConnected(hass, port) {
     if (["on", "true", "connected", "up", "active"].includes(s)) return true;
     if (["off", "false", "disconnected", "down", "inactive"].includes(s)) return false;
   }
-  const speed = stateValue(hass, port.speed_entity);
-  if (speed && speed !== "unavailable" && speed !== "unknown") {
-    const n = parseFloat(String(speed).replace(",", "."));
-    if (!Number.isNaN(n) && n > 10) return true;
-    if (!Number.isNaN(n) && n <= 10) return false;
+  const speedMbit = parseLinkSpeedMbit(hass, port.speed_entity);
+  if (speedMbit != null) {
+    if (speedMbit > 10) return true;
+    if (speedMbit <= 10) return false;
   }
   const rx = stateValue(hass, port.rx_entity);
   const tx = stateValue(hass, port.tx_entity);
@@ -3680,11 +3690,7 @@ var UnifiDeviceCard = class extends HTMLElement {
     return onlineTokens.some((token) => raw === token || raw.includes(token));
   }
   _speedValueMbit(port) {
-    const text = String(getPortSpeedText(this._hass, port) || "");
-    const m = text.match(/([0-9]+(?:[.,][0-9]+)?)/);
-    if (!m) return null;
-    const n = parseFloat(m[1].replace(",", "."));
-    return Number.isFinite(n) ? n : null;
+    return parseLinkSpeedMbit(this._hass, port?.speed_entity);
   }
   _linkLedClass(port) {
     const connected = isPortConnected(this._hass, port);
@@ -4063,6 +4069,7 @@ var UnifiDeviceCard = class extends HTMLElement {
         min-width: 0;
         border: none;
         background: transparent;
+        transition: outline .1s ease, opacity .15s ease, filter .15s ease;
       }
 
       .port:focus {
@@ -4084,6 +4091,23 @@ var UnifiDeviceCard = class extends HTMLElement {
         display: flex;
         justify-content: center;
         align-items: flex-start;
+        transition: opacity .15s ease, filter .15s ease;
+      }
+
+      .port.down .port-housing {
+        opacity: .42;
+        filter: saturate(.45) brightness(.78);
+      }
+
+      .port.up .port-housing {
+        opacity: 1;
+        filter: saturate(1.05) brightness(1.02);
+      }
+
+      .port:hover .port-housing,
+      .port.selected .port-housing {
+        opacity: 1;
+        filter: none;
       }
 
       .port-rj45 {
@@ -4318,10 +4342,22 @@ var UnifiDeviceCard = class extends HTMLElement {
         letter-spacing: 0;
         user-select: none;
         color: #646a76;
+        transition: color .15s ease, opacity .15s ease;
+      }
+
+      .port.down .port-num {
+        color: #4c5260;
+        opacity: .6;
       }
 
       .port.up .port-num {
         color: #414957;
+        opacity: 1;
+      }
+
+      .port:hover .port-num,
+      .port.selected .port-num {
+        opacity: 1;
       }
 
       .port.is-sfp .port-num {

--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1944,8 +1944,8 @@ function isPortConnected(hass, port) {
   }
   const speedMbit = parseLinkSpeedMbit(hass, port.speed_entity);
   if (speedMbit != null) {
-    if (speedMbit > 10) return true;
-    if (speedMbit <= 10) return false;
+    if (speedMbit > 0) return true;
+    if (speedMbit <= 0) return false;
   }
   const rx = stateValue(hass, port.rx_entity);
   const tx = stateValue(hass, port.tx_entity);
@@ -4064,7 +4064,6 @@ var UnifiDeviceCard = class extends HTMLElement {
         align-items: center;
         padding: 0 0 1px;
         border-radius: 2px;
-        transition: outline .1s ease;
         position: relative;
         min-width: 0;
         border: none;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1628,6 +1628,20 @@ export function stateValue(hass, entityId) {
   return stateObj(hass, entityId)?.state ?? null;
 }
 
+export function parseLinkSpeedMbit(hass, entityId) {
+  const obj = stateObj(hass, entityId);
+  const raw = obj?.state;
+  if (raw == null || raw === "unavailable" || raw === "unknown") return null;
+
+  const n = parseFloat(String(raw).replace(",", "."));
+  if (!Number.isFinite(n)) return null;
+
+  const unit = String(obj?.attributes?.unit_of_measurement || "").toLowerCase();
+  if (unit.includes("gb")) return n * 1000;
+  if (unit.includes("kb")) return n / 1000;
+  return n;
+}
+
 export function isOn(hass, entityId) {
   const s = stateValue(hass, entityId);
   return s === "on" || s === "true" || s === "connected" || s === "up" || s === "active";
@@ -1667,11 +1681,10 @@ export function isPortConnected(hass, port) {
     if (["off", "false", "disconnected", "down", "inactive"].includes(s)) return false;
   }
 
-  const speed = stateValue(hass, port.speed_entity);
-  if (speed && speed !== "unavailable" && speed !== "unknown") {
-    const n = parseFloat(String(speed).replace(",", "."));
-    if (!Number.isNaN(n) && n > 10) return true;
-    if (!Number.isNaN(n) && n <= 10) return false;
+  const speedMbit = parseLinkSpeedMbit(hass, port.speed_entity);
+  if (speedMbit != null) {
+    if (speedMbit > 10) return true;
+    if (speedMbit <= 10) return false;
   }
 
   const rx = stateValue(hass, port.rx_entity);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1683,8 +1683,8 @@ export function isPortConnected(hass, port) {
 
   const speedMbit = parseLinkSpeedMbit(hass, port.speed_entity);
   if (speedMbit != null) {
-    if (speedMbit > 10) return true;
-    if (speedMbit <= 10) return false;
+    if (speedMbit > 0) return true;
+    if (speedMbit <= 0) return false;
   }
 
   const rx = stateValue(hass, port.rx_entity);

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -1039,7 +1039,6 @@ class UnifiDeviceCard extends HTMLElement {
         align-items: center;
         padding: 0 0 1px;
         border-radius: 2px;
-        transition: outline .1s ease;
         position: relative;
         min-width: 0;
         border: none;

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -10,6 +10,7 @@ import {
   isPortConnected,
   mergePortsWithLayout,
   mergeSpecialsWithLayout,
+  parseLinkSpeedMbit,
   stateObj,
 } from "./helpers.js";
 import { t } from "./translations.js";
@@ -646,11 +647,7 @@ class UnifiDeviceCard extends HTMLElement {
   }
 
   _speedValueMbit(port) {
-    const text = String(getPortSpeedText(this._hass, port) || "");
-    const m = text.match(/([0-9]+(?:[.,][0-9]+)?)/);
-    if (!m) return null;
-    const n = parseFloat(m[1].replace(",", "."));
-    return Number.isFinite(n) ? n : null;
+    return parseLinkSpeedMbit(this._hass, port?.speed_entity);
   }
 
   _linkLedClass(port) {
@@ -1047,6 +1044,7 @@ class UnifiDeviceCard extends HTMLElement {
         min-width: 0;
         border: none;
         background: transparent;
+        transition: outline .1s ease, opacity .15s ease, filter .15s ease;
       }
 
       .port:focus {
@@ -1068,6 +1066,23 @@ class UnifiDeviceCard extends HTMLElement {
         display: flex;
         justify-content: center;
         align-items: flex-start;
+        transition: opacity .15s ease, filter .15s ease;
+      }
+
+      .port.down .port-housing {
+        opacity: .42;
+        filter: saturate(.45) brightness(.78);
+      }
+
+      .port.up .port-housing {
+        opacity: 1;
+        filter: saturate(1.05) brightness(1.02);
+      }
+
+      .port:hover .port-housing,
+      .port.selected .port-housing {
+        opacity: 1;
+        filter: none;
       }
 
       .port-rj45 {
@@ -1302,10 +1317,22 @@ class UnifiDeviceCard extends HTMLElement {
         letter-spacing: 0;
         user-select: none;
         color: #646a76;
+        transition: color .15s ease, opacity .15s ease;
+      }
+
+      .port.down .port-num {
+        color: #4c5260;
+        opacity: .6;
       }
 
       .port.up .port-num {
         color: #414957;
+        opacity: 1;
+      }
+
+      .port:hover .port-num,
+      .port.selected .port-num {
+        opacity: 1;
       }
 
       .port.is-sfp .port-num {


### PR DESCRIPTION
This PR has been retargeted to `develop` per request and the branch was rebased onto the current `develop` head (`48277ed`).

Latest branch head: `19f530b`

Changes in this PR remain the same:
- normalize link speed units for connection/LED logic
- dim inactive ports for better visibility
- include low-speed (`> 0`) negotiated links as connected

Ready for your `v0.5.x-dev` build/test flow.