### PR TITLE
Add UDM67A alias mapping to UDR7, infer port-count fallback, bump version and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v0.5.3] - 2026-04-12
+
+### 🐛 Bug Fixes
+- Included fixes from [PR #70](https://github.com/bluenazgul/unifi-device-card/pull/70): normalized link-speed unit handling for port LED status and improved connected-link detection for low negotiated speeds.
+- Added model alias detection for `UDM67A` so devices exposed as `UDM67A (UDR7)` are resolved to `UDR7` correctly.
+- Added fallback port-count inference for `UDM67A` to keep Dream Router 7 detection at 5 total ports even when only the alias is present.
+
 ## [v0.5.2] - 2026-04-12
 
 ### 📚 Documentation

--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.2a0834e */
+/* UniFi Device Card 0.0.0-dev.a27034d */
 
 // src/model-registry.js
 function range(start, end) {
@@ -689,6 +689,7 @@ function resolveModelKey(device) {
     if (candidate.includes("CLOUDGATEWAYFIBER")) return "UCGFIBER";
     if (candidate.includes("UDR7")) return "UDR7";
     if (candidate.includes("DREAMROUTER7")) return "UDR7";
+    if (candidate.includes("UDM67A")) return "UDR7";
     if (candidate.includes("UDRULT")) return "UDRULT";
     if (candidate.includes("UCGULTRA")) return "UCGULTRA";
     if (candidate.includes("CLOUDGATEWAYULTRA")) return "UCGULTRA";
@@ -797,7 +798,7 @@ function inferPortCountFromModel(device) {
   if (text.includes("UDMPROSE") || text.includes("UDMSE")) return 11;
   if (text.includes("UDMPRO")) return 11;
   if (text.includes("UCGFIBER") || text.includes("CLOUDGATEWAYFIBER")) return 7;
-  if (text.includes("UDR7") || text.includes("DREAMROUTER7")) return 5;
+  if (text.includes("UDR7") || text.includes("DREAMROUTER7") || text.includes("UDM67A")) return 5;
   if (text.includes("UCGULTRA") || text.includes("CLOUDGATEWAYULTRA") || text.includes("UDRULT")) return 5;
   if (text.includes("UCGMAX") || text.includes("CLOUDGATEWAYMAX")) return 5;
   if (text.includes("UXGPRO")) return 4;
@@ -3202,7 +3203,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.2a0834e";
+var VERSION = "0.0.0-dev.a27034d";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var UnifiDeviceCard = class extends HTMLElement {
   static getConfigElement() {

--- a/src/model-registry.js
+++ b/src/model-registry.js
@@ -663,6 +663,7 @@ export function resolveModelKey(device) {
     if (candidate.includes("CLOUDGATEWAYFIBER"))  return "UCGFIBER";
     if (candidate.includes("UDR7"))               return "UDR7";
     if (candidate.includes("DREAMROUTER7"))       return "UDR7";
+    if (candidate.includes("UDM67A"))             return "UDR7";
     if (candidate.includes("UDRULT"))             return "UDRULT";
     if (candidate.includes("UCGULTRA"))           return "UCGULTRA";
     if (candidate.includes("CLOUDGATEWAYULTRA"))  return "UCGULTRA";
@@ -787,7 +788,7 @@ export function inferPortCountFromModel(device) {
   if (text.includes("UDMPROSE") || text.includes("UDMSE"))                           return 11;
   if (text.includes("UDMPRO"))                                                        return 11;
   if (text.includes("UCGFIBER") || text.includes("CLOUDGATEWAYFIBER"))               return 7;
-  if (text.includes("UDR7") || text.includes("DREAMROUTER7"))                         return 5;
+  if (text.includes("UDR7") || text.includes("DREAMROUTER7") || text.includes("UDM67A")) return 5;
   if (text.includes("UCGULTRA") || text.includes("CLOUDGATEWAYULTRA") || text.includes("UDRULT")) return 5;
   if (text.includes("UCGMAX")   || text.includes("CLOUDGATEWAYMAX"))                 return 5;
   if (text.includes("UXGPRO"))                                                        return 4;


### PR DESCRIPTION
### Motivation
- Ensure devices reported as `UDM67A (UDR7)` or similar aliases are recognized as the Dream Router 7 family so the card applies the correct model mapping and port layout.
- Preserve existing front-panel/port-count behavior for Dream Router 7 devices when only the alias is present.
- Keep distributed bundle and package metadata in sync with the source change.

### Description
- Added `UDM67A` as an alias mapping to the `UDR7` model in `resolveModelKey` in `src/model-registry.js` and the bundled `dist/unifi-device-card.js`.
- Added `UDM67A` to the port-count inference in `inferPortCountFromModel` to return `5` ports for Dream Router 7 devices.
- Bumped the built `VERSION` comment/variable in `dist/unifi-device-card.js` and updated `CHANGELOG.md` with a `v0.5.3` entry describing the fixes.

### Testing
- Built the distribution artifact to update `dist/unifi-device-card.js` and verified the alias and port-count strings are present in the bundle.
- No automated unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db699d90ac8333942ab6c4cf03e7cc)