### PR TITLE
Improve UDM67A/UDR7 detection, preserve physical special-port identity, and broaden port entity parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v0.5.4] - 2026-04-12
+
+### 🐛 Bug Fixes
+- Fixed UDR7 (`UDM67A (UDR7)`) model recognition so devices containing both `UDM67A` and `UDR7` are still resolved as UDR7 where appropriate.
+- Improved UDR7 / UDM-Pro (`UDMPRO`) disambiguation for `UDM67A`-based identifiers in device detection and layout selection.
+- Fixed UDR7 SFP (port 5) rendering when used as WAN special port so it keeps SFP visualization instead of falling back to RJ45.
+- Preserved physical special-port identity during WAN/WAN2 remapping to avoid wrong connector type display and link-status confusion on remapped special ports.
+- Improved UDMPROSE/UDMSE active-port discovery by accepting additional aiounifi-style port entity patterns (for example `*_lan_*` / `*_eth_*` / `*_sfp_*`) in port extraction and port-entity classification.
+
 ## [v0.5.3] - 2026-04-12
 
 ### 🐛 Bug Fixes

--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.5.3-dev */
+/* UniFi Device Card 0.0.0-dev.eb2c473 */
 
 // src/model-registry.js
 function range(start, end) {
@@ -536,11 +536,24 @@ var MODEL_REGISTRY = {
     frontStyle: "gateway-single-row",
     rows: [[1, 2, 3]],
     portCount: 5,
-    displayModel: "Dream Router 7",
+    displayModel: "UDM67A (UDR7)",
     theme: "white",
     specialSlots: [
       { key: "wan", label: "WAN", port: 4 },
       { key: "sfp_1", label: "SFP+ WAN", port: 5 }
+    ]
+  },
+  UDM67A: {
+    kind: "gateway",
+    frontStyle: "gateway-rack",
+    rows: [range(1, 8)],
+    portCount: 11,
+    displayModel: "UDM67A (UDM-Pro / UDMPRO)",
+    theme: "silver",
+    specialSlots: [
+      { key: "wan", label: "WAN", port: 9 },
+      { key: "sfp_1", label: "SFP+ 1", port: 10 },
+      { key: "sfp_2", label: "SFP+ 2", port: 11 }
     ]
   },
   UCGMAX: {
@@ -687,9 +700,10 @@ function resolveModelKey(device) {
     if (candidate === "E7" || candidate.startsWith("E7")) return "E7";
     if (candidate.includes("UCGFIBER")) return "UCGFIBER";
     if (candidate.includes("CLOUDGATEWAYFIBER")) return "UCGFIBER";
+    if (candidate.includes("UDM67AUDR7")) return "UDR7";
     if (candidate.includes("UDR7")) return "UDR7";
     if (candidate.includes("DREAMROUTER7")) return "UDR7";
-    if (candidate.includes("UDM67A")) return "UDR7";
+    if (candidate.includes("UDM67A")) return "UDM67A";
     if (candidate.includes("UDRULT")) return "UDRULT";
     if (candidate.includes("UCGULTRA")) return "UCGULTRA";
     if (candidate.includes("CLOUDGATEWAYULTRA")) return "UCGULTRA";
@@ -798,7 +812,8 @@ function inferPortCountFromModel(device) {
   if (text.includes("UDMPROSE") || text.includes("UDMSE")) return 11;
   if (text.includes("UDMPRO")) return 11;
   if (text.includes("UCGFIBER") || text.includes("CLOUDGATEWAYFIBER")) return 7;
-  if (text.includes("UDR7") || text.includes("DREAMROUTER7") || text.includes("UDM67A")) return 5;
+  if (text.includes("UDM67AUDR7") || text.includes("UDR7") || text.includes("DREAMROUTER7")) return 5;
+  if (text.includes("UDM67A")) return 11;
   if (text.includes("UCGULTRA") || text.includes("CLOUDGATEWAYULTRA") || text.includes("UDRULT")) return 5;
   if (text.includes("UCGMAX") || text.includes("CLOUDGATEWAYMAX")) return 5;
   if (text.includes("UXGPRO")) return 4;
@@ -832,8 +847,20 @@ function inferPortCountFromModel(device) {
 }
 function getDeviceLayout(device, discoveredPorts = []) {
   const modelKey = resolveModelKey(device);
-  if (modelKey && MODEL_REGISTRY[modelKey]) {
-    return { modelKey, ...MODEL_REGISTRY[modelKey] };
+  const normalizedText = normalizeModelKey(
+    [device?.model, device?.hw_version, device?.name, device?.name_by_user].filter(Boolean).join(" ")
+  );
+  const maxDiscoveredPort = discoveredPorts.length > 0 ? Math.max(...discoveredPorts.map((p) => p.port || 0)) : 0;
+  let effectiveModelKey = modelKey;
+  if (effectiveModelKey === "UDM67A") {
+    if (normalizedText.includes("UDM67AUDR7") || normalizedText.includes("UDR7") || normalizedText.includes("DREAMROUTER7")) {
+      effectiveModelKey = "UDR7";
+    } else if (maxDiscoveredPort > 0 && maxDiscoveredPort <= 5) {
+      effectiveModelKey = "UDR7";
+    }
+  }
+  if (effectiveModelKey && MODEL_REGISTRY[effectiveModelKey]) {
+    return { modelKey: effectiveModelKey, ...MODEL_REGISTRY[effectiveModelKey] };
   }
   if (isAccessPointLikeModel(device)) {
     return {
@@ -953,6 +980,7 @@ function getDeviceType(device, entities = []) {
       "UCGFIBER",
       "UDMPRO",
       "UDMPROSE",
+      "UDM67A",
       "UXGPRO",
       "UXGL",
       "UGW3",
@@ -1343,6 +1371,8 @@ function extractPortNumber(entity) {
   const eid = lower(entity.entity_id);
   const eidMatch = eid.match(/_port_(\d+)(?:_|$)/i);
   if (eidMatch) return parseInt(eidMatch[1], 10);
+  const eidAltMatch = eid.match(/_(?:lan|eth|ethernet|sfp)_(\d+)(?:_|$)/i);
+  if (eidAltMatch) return parseInt(eidAltMatch[1], 10);
   const originalNameMatch = (entity.original_name || "").match(/\bport\s+(\d+)\b/i);
   if (originalNameMatch) return parseInt(originalNameMatch[1], 10);
   const nameMatch = (entity.name || "").match(/\bport\s+(\d+)\b/i);
@@ -1352,26 +1382,27 @@ function extractPortNumber(entity) {
 function classifyPortEntity(entity, isSpecial = false) {
   const id = lower(entity.entity_id);
   const eid = entity.entity_id || "";
+  const hasPortLikeId = /_(?:port|lan|eth|ethernet|sfp)_(\d+)(?:_|$)/i.test(id);
   const tk = lower(entity.translation_key || "");
   const dc = lower(entity.device_class || "");
   const odc = lower(entity.original_device_class || "");
   if (eid.startsWith("button.") && (id.includes("power_cycle") || tk === "power_cycle" || id.includes("_restart") || id.includes("_reboot"))) {
     return "power_cycle_entity";
   }
-  if (eid.startsWith("switch.") && id.includes("_port_") && id.endsWith("_poe")) {
+  if (eid.startsWith("switch.") && hasPortLikeId && id.endsWith("_poe")) {
     return "poe_switch_entity";
   }
-  if (eid.startsWith("switch.") && (id.includes("_port_") || isSpecial)) {
+  if (eid.startsWith("switch.") && (hasPortLikeId || isSpecial)) {
     return "port_switch_entity";
   }
   if (eid.startsWith("binary_sensor.")) {
-    if (id.includes("_port_")) return "link_entity";
+    if (hasPortLikeId) return "link_entity";
     if (isSpecial && (id.includes("_wan") || id.includes("_sfp") || id.includes("_uplink") || id.includes("_connected") || id.includes("_link") || tk === "port_link")) {
       return "link_entity";
     }
   }
   if (eid.startsWith("sensor.")) {
-    if (id.includes("_port_")) {
+    if (hasPortLikeId) {
       if (id.endsWith("_rx") || id.includes("_rx_") || id.includes("download") || tk === "port_bandwidth_rx" || tk === "rx") {
         return "rx_entity";
       }
@@ -1444,6 +1475,7 @@ function ensureSpecialPort(map, key, label) {
   if (!map.has(key)) {
     map.set(key, {
       key,
+      physical_key: key,
       port: null,
       label,
       kind: "special",
@@ -1565,13 +1597,14 @@ function mergeSpecialsWithLayout(layout, discoveredSpecials, discoveredPorts = [
   const merged = layoutSpecials.map((slot) => {
     if (slot.port != null) {
       const portData = byPort.get(slot.port);
-      if (portData) return { ...portData, key: slot.key, label: slot.label, kind: "special" };
+      if (portData) return { ...portData, key: slot.key, physical_key: slot.key, label: slot.label, kind: "special" };
     }
     const keyData = byKey.get(slot.key);
     if (keyData) {
       return {
         ...keyData,
         key: slot.key,
+        physical_key: slot.key,
         label: slot.label,
         kind: "special",
         port: slot.port ?? keyData.port ?? null
@@ -1579,6 +1612,7 @@ function mergeSpecialsWithLayout(layout, discoveredSpecials, discoveredPorts = [
     }
     return {
       key: slot.key,
+      physical_key: slot.key,
       port: slot.port ?? null,
       label: slot.label,
       kind: "special",
@@ -1623,6 +1657,7 @@ function emptyNumberedPort(portNumber) {
 function emptySpecialPort(key, label, port = null) {
   return {
     key,
+    physical_key: key,
     port,
     label,
     kind: "special",
@@ -1699,6 +1734,7 @@ function makeSpecialFromPhysical(roleKey, physical) {
   return {
     ...cloneSlot(physical),
     key: roleKey,
+    physical_key: physical?.physical_key || physical?.key || roleKey,
     label: roleKey === "wan2" ? "WAN 2" : "WAN",
     kind: "special"
   };
@@ -1761,6 +1797,7 @@ function applyGatewayPortOverrides(config, specials, numbered, layout) {
       newSpecials.push({
         ...cloneSlot(specialData),
         key: roleKey,
+        physical_key: specialData?.physical_key || specialData?.key || roleKey,
         label: roleKey === "wan2" ? "WAN 2" : "WAN",
         kind: "special"
       });
@@ -3203,7 +3240,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.5.3-dev";
+var VERSION = "0.0.0-dev.eb2c473";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var UnifiDeviceCard = class extends HTMLElement {
   static getConfigElement() {
@@ -3258,9 +3295,12 @@ var UnifiDeviceCard = class extends HTMLElement {
     this._render();
   }
   set hass(hass) {
+    const previousHass = this._hass;
     this._hass = hass;
     this._ensureLoaded();
-    this._render();
+    if (!previousHass || !this._ctx || this._hasRelevantStateChanges(previousHass, hass)) {
+      this._render();
+    }
   }
   getCardSize() {
     return this._cardSize || this._estimateCardSize();
@@ -3486,6 +3526,16 @@ var UnifiDeviceCard = class extends HTMLElement {
     }
     return { specials: specialsRaw, numbered: numberedRaw };
   }
+  _hasRelevantStateChanges(previousHass, nextHass) {
+    const entities = this._ctx?.entities || [];
+    if (!Array.isArray(entities) || entities.length === 0) return true;
+    for (const entity of entities) {
+      const id = entity?.entity_id;
+      if (!id) continue;
+      if (previousHass?.states?.[id] !== nextHass?.states?.[id]) return true;
+    }
+    return false;
+  }
   _manualPortSpeedOverrides() {
     const out = /* @__PURE__ */ new Map();
     const entries = Object.entries(this._config || {});
@@ -3708,7 +3758,11 @@ var UnifiDeviceCard = class extends HTMLElement {
   _isSfpLike(slot) {
     const label = String(slot?.label || "").toLowerCase();
     const key = String(slot?.key || "").toLowerCase();
-    return slot?.kind === "special" && (label.includes("sfp") || key.includes("sfp") || key.includes("uplink"));
+    const physicalKey = String(slot?.physical_key || "").toLowerCase();
+    const layoutSlot = Number.isInteger(slot?.port) ? (this._ctx?.layout?.specialSlots || []).find((s) => s.port === slot.port) : null;
+    const layoutKey = String(layoutSlot?.key || "").toLowerCase();
+    const layoutLabel = String(layoutSlot?.label || "").toLowerCase();
+    return slot?.kind === "special" && (label.includes("sfp") || key.includes("sfp") || physicalKey.includes("sfp") || key.includes("uplink") || physicalKey.includes("uplink") || layoutKey.includes("sfp") || layoutKey.includes("uplink") || layoutLabel.includes("sfp"));
   }
   _isWanLike(slot) {
     const key = String(slot?.key || "").toLowerCase();

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -156,6 +156,7 @@ export function getDeviceType(device, entities = []) {
         "UCGFIBER",
         "UDMPRO",
         "UDMPROSE",
+        "UDM67A",
         "UXGPRO",
         "UXGL",
         "UGW3",
@@ -799,6 +800,8 @@ function extractPortNumber(entity) {
   const eid = lower(entity.entity_id);
   const eidMatch = eid.match(/_port_(\d+)(?:_|$)/i);
   if (eidMatch) return parseInt(eidMatch[1], 10);
+  const eidAltMatch = eid.match(/_(?:lan|eth|ethernet|sfp)_(\d+)(?:_|$)/i);
+  if (eidAltMatch) return parseInt(eidAltMatch[1], 10);
 
   const originalNameMatch = (entity.original_name || "").match(/\bport\s+(\d+)\b/i);
   if (originalNameMatch) return parseInt(originalNameMatch[1], 10);
@@ -812,6 +815,7 @@ function extractPortNumber(entity) {
 function classifyPortEntity(entity, isSpecial = false) {
   const id = lower(entity.entity_id);
   const eid = entity.entity_id || "";
+  const hasPortLikeId = /_(?:port|lan|eth|ethernet|sfp)_(\d+)(?:_|$)/i.test(id);
   const tk = lower(entity.translation_key || "");
   const dc = lower(entity.device_class || "");
   const odc = lower(entity.original_device_class || "");
@@ -823,16 +827,16 @@ function classifyPortEntity(entity, isSpecial = false) {
     return "power_cycle_entity";
   }
 
-  if (eid.startsWith("switch.") && id.includes("_port_") && id.endsWith("_poe")) {
+  if (eid.startsWith("switch.") && hasPortLikeId && id.endsWith("_poe")) {
     return "poe_switch_entity";
   }
 
-  if (eid.startsWith("switch.") && (id.includes("_port_") || isSpecial)) {
+  if (eid.startsWith("switch.") && (hasPortLikeId || isSpecial)) {
     return "port_switch_entity";
   }
 
   if (eid.startsWith("binary_sensor.")) {
-    if (id.includes("_port_")) return "link_entity";
+    if (hasPortLikeId) return "link_entity";
     if (
       isSpecial &&
       (
@@ -849,7 +853,7 @@ function classifyPortEntity(entity, isSpecial = false) {
   }
 
   if (eid.startsWith("sensor.")) {
-    if (id.includes("_port_")) {
+    if (hasPortLikeId) {
       if (
         id.endsWith("_rx") ||
         id.includes("_rx_") ||
@@ -998,6 +1002,7 @@ function ensureSpecialPort(map, key, label) {
   if (!map.has(key)) {
     map.set(key, {
       key,
+      physical_key: key,
       port: null,
       label,
       kind: "special",
@@ -1151,7 +1156,7 @@ export function mergeSpecialsWithLayout(layout, discoveredSpecials, discoveredPo
   const merged = layoutSpecials.map((slot) => {
     if (slot.port != null) {
       const portData = byPort.get(slot.port);
-      if (portData) return { ...portData, key: slot.key, label: slot.label, kind: "special" };
+      if (portData) return { ...portData, key: slot.key, physical_key: slot.key, label: slot.label, kind: "special" };
     }
 
     const keyData = byKey.get(slot.key);
@@ -1159,6 +1164,7 @@ export function mergeSpecialsWithLayout(layout, discoveredSpecials, discoveredPo
       return {
         ...keyData,
         key: slot.key,
+        physical_key: slot.key,
         label: slot.label,
         kind: "special",
         port: slot.port ?? keyData.port ?? null,
@@ -1167,6 +1173,7 @@ export function mergeSpecialsWithLayout(layout, discoveredSpecials, discoveredPo
 
     return {
       key: slot.key,
+      physical_key: slot.key,
       port: slot.port ?? null,
       label: slot.label,
       kind: "special",
@@ -1219,6 +1226,7 @@ function emptyNumberedPort(portNumber) {
 function emptySpecialPort(key, label, port = null) {
   return {
     key,
+    physical_key: key,
     port,
     label,
     kind: "special",
@@ -1307,6 +1315,7 @@ function makeSpecialFromPhysical(roleKey, physical) {
   return {
     ...cloneSlot(physical),
     key: roleKey,
+    physical_key: physical?.physical_key || physical?.key || roleKey,
     label: roleKey === "wan2" ? "WAN 2" : "WAN",
     kind: "special",
   };
@@ -1404,6 +1413,7 @@ export function applyGatewayPortOverrides(config, specials, numbered, layout) {
       newSpecials.push({
         ...cloneSlot(specialData),
         key: roleKey,
+        physical_key: specialData?.physical_key || specialData?.key || roleKey,
         label: roleKey === "wan2" ? "WAN 2" : "WAN",
         kind: "special",
       });

--- a/src/model-registry.js
+++ b/src/model-registry.js
@@ -484,10 +484,19 @@ export const MODEL_REGISTRY = {
   },
   UDR7: {
     kind: "gateway", frontStyle: "gateway-single-row", rows: [[1, 2, 3]],
-    portCount: 5, displayModel: "Dream Router 7", theme: "white",
+    portCount: 5, displayModel: "UDM67A (UDR7)", theme: "white",
     specialSlots: [
       { key: "wan", label: "WAN", port: 4 },
       { key: "sfp_1", label: "SFP+ WAN", port: 5 },
+    ],
+  },
+  UDM67A: {
+    kind: "gateway", frontStyle: "gateway-rack", rows: [range(1, 8)],
+    portCount: 11, displayModel: "UDM67A (UDM-Pro / UDMPRO)", theme: "silver",
+    specialSlots: [
+      { key: "wan",   label: "WAN",    port: 9  },
+      { key: "sfp_1", label: "SFP+ 1", port: 10 },
+      { key: "sfp_2", label: "SFP+ 2", port: 11 },
     ],
   },
   UCGMAX: {
@@ -661,9 +670,10 @@ export function resolveModelKey(device) {
     if (candidate === "E7" || candidate.startsWith("E7")) return "E7";
     if (candidate.includes("UCGFIBER"))           return "UCGFIBER";
     if (candidate.includes("CLOUDGATEWAYFIBER"))  return "UCGFIBER";
+    if (candidate.includes("UDM67AUDR7"))         return "UDR7";
     if (candidate.includes("UDR7"))               return "UDR7";
     if (candidate.includes("DREAMROUTER7"))       return "UDR7";
-    if (candidate.includes("UDM67A"))             return "UDR7";
+    if (candidate.includes("UDM67A"))             return "UDM67A";
     if (candidate.includes("UDRULT"))             return "UDRULT";
     if (candidate.includes("UCGULTRA"))           return "UCGULTRA";
     if (candidate.includes("CLOUDGATEWAYULTRA"))  return "UCGULTRA";
@@ -788,7 +798,8 @@ export function inferPortCountFromModel(device) {
   if (text.includes("UDMPROSE") || text.includes("UDMSE"))                           return 11;
   if (text.includes("UDMPRO"))                                                        return 11;
   if (text.includes("UCGFIBER") || text.includes("CLOUDGATEWAYFIBER"))               return 7;
-  if (text.includes("UDR7") || text.includes("DREAMROUTER7") || text.includes("UDM67A")) return 5;
+  if (text.includes("UDM67AUDR7") || text.includes("UDR7") || text.includes("DREAMROUTER7")) return 5;
+  if (text.includes("UDM67A"))                                                        return 11;
   if (text.includes("UCGULTRA") || text.includes("CLOUDGATEWAYULTRA") || text.includes("UDRULT")) return 5;
   if (text.includes("UCGMAX")   || text.includes("CLOUDGATEWAYMAX"))                 return 5;
   if (text.includes("UXGPRO"))                                                        return 4;
@@ -832,8 +843,26 @@ export function inferPortCountFromModel(device) {
 
 export function getDeviceLayout(device, discoveredPorts = []) {
   const modelKey = resolveModelKey(device);
-  if (modelKey && MODEL_REGISTRY[modelKey]) {
-    return { modelKey, ...MODEL_REGISTRY[modelKey] };
+  const normalizedText = normalizeModelKey(
+    [device?.model, device?.hw_version, device?.name, device?.name_by_user].filter(Boolean).join(" ")
+  );
+  const maxDiscoveredPort = discoveredPorts.length > 0 ? Math.max(...discoveredPorts.map((p) => p.port || 0)) : 0;
+
+  let effectiveModelKey = modelKey;
+  if (effectiveModelKey === "UDM67A") {
+    if (
+      normalizedText.includes("UDM67AUDR7") ||
+      normalizedText.includes("UDR7") ||
+      normalizedText.includes("DREAMROUTER7")
+    ) {
+      effectiveModelKey = "UDR7";
+    } else if (maxDiscoveredPort > 0 && maxDiscoveredPort <= 5) {
+      effectiveModelKey = "UDR7";
+    }
+  }
+
+  if (effectiveModelKey && MODEL_REGISTRY[effectiveModelKey]) {
+    return { modelKey: effectiveModelKey, ...MODEL_REGISTRY[effectiveModelKey] };
   }
 
   if (isAccessPointLikeModel(device)) {

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -80,9 +80,12 @@ class UnifiDeviceCard extends HTMLElement {
   }
 
   set hass(hass) {
+    const previousHass = this._hass;
     this._hass = hass;
     this._ensureLoaded();
-    this._render();
+    if (!previousHass || !this._ctx || this._hasRelevantStateChanges(previousHass, hass)) {
+      this._render();
+    }
   }
 
   getCardSize() {
@@ -356,6 +359,19 @@ class UnifiDeviceCard extends HTMLElement {
     }
 
     return { specials: specialsRaw, numbered: numberedRaw };
+  }
+
+  _hasRelevantStateChanges(previousHass, nextHass) {
+    const entities = this._ctx?.entities || [];
+    if (!Array.isArray(entities) || entities.length === 0) return true;
+
+    for (const entity of entities) {
+      const id = entity?.entity_id;
+      if (!id) continue;
+      if (previousHass?.states?.[id] !== nextHass?.states?.[id]) return true;
+    }
+
+    return false;
   }
 
   _manualPortSpeedOverrides() {
@@ -668,9 +684,24 @@ class UnifiDeviceCard extends HTMLElement {
   _isSfpLike(slot) {
     const label = String(slot?.label || "").toLowerCase();
     const key = String(slot?.key || "").toLowerCase();
+    const physicalKey = String(slot?.physical_key || "").toLowerCase();
+    const layoutSlot = Number.isInteger(slot?.port)
+      ? (this._ctx?.layout?.specialSlots || []).find((s) => s.port === slot.port)
+      : null;
+    const layoutKey = String(layoutSlot?.key || "").toLowerCase();
+    const layoutLabel = String(layoutSlot?.label || "").toLowerCase();
     return (
       slot?.kind === "special" &&
-      (label.includes("sfp") || key.includes("sfp") || key.includes("uplink"))
+      (
+        label.includes("sfp") ||
+        key.includes("sfp") ||
+        physicalKey.includes("sfp") ||
+        key.includes("uplink") ||
+        physicalKey.includes("uplink") ||
+        layoutKey.includes("sfp") ||
+        layoutKey.includes("uplink") ||
+        layoutLabel.includes("sfp")
+      )
     );
   }
 


### PR DESCRIPTION
### Motivation
- Fix incorrect model resolution and layout/port rendering for devices that expose both `UDM67A` and `UDR7` identifiers and avoid mis-rendering of SFP/RJ45 connectors when ports are remapped. 
- Preserve the physical identity of special ports during WAN/WAN2 remapping to prevent connector-type and link-status confusion. 
- Make port entity discovery and classification more robust for additional entity naming patterns produced by different integrations (for example `*_lan_*`, `*_eth_*`, `*_sfp_*`).

### Description
- Added a new `UDM67A` entry to the model registry with proper `portCount`, `rows`, and `specialSlots`, and changed `UDR7`/`UDM67A` display names to disambiguate the models. 
- Updated `resolveModelKey`, `inferPortCountFromModel`, and `getDeviceLayout` to prefer `UDM67A` when appropriate and to remap `UDM67A`→`UDR7` based on identifying text (`UDM67AUDR7`, `UDR7`, `DREAMROUTER7`) or the number of discovered ports. 
- Preserved physical special-port identity by introducing and propagating a `physical_key` on special-slot objects in `mergeSpecialsWithLayout`, `ensureSpecialPort`, `emptySpecialPort`, `makeSpecialFromPhysical`, and the WAN/WAN2 override path so layout metadata is retained when creating virtual special slots. 
- Broadened port entity extraction and classification by accepting alternative id patterns with `_(?:lan|eth|ethernet|sfp)_` when extracting port numbers and by treating those patterns as port-like when classifying entities so `poe`, `link`, `rx/tx/speed` sensors are discovered for more entity naming conventions. 
- Improved SFP detection in rendering by considering the `physical_key` and layout slot metadata in `_isSfpLike` so remapped WAN/SFP ports keep correct connector visuals. 
- Added render optimization to the card `hass` setter: track `previousHass` and only re-render when relevant device entity states changed via `_hasRelevantStateChanges`. 
- Updated the built distribution file `dist/unifi-device-card.js` to include the changes.

### Testing
- Built the distribution using the project build script (`npm run build`) to update `dist/unifi-device-card.js`, which completed successfully. 
- Lint/build checks were executed (`npm run lint` / `npm run build`) as a smoke test of the changes and succeeded. 
- No new automated unit tests were added; changes rely on existing codepaths and were validated via the updated build output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db75b18d08833396bd94282702e265)