### PR TITLE
Add USW Pro Max 16 non-PoE model and improve switch alias/fallback detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v0.5.6] - 2026-04-12
+
+### ✨ Improvements
+- Added explicit non-PoE `USW Pro Max 16` (`USPM16`) model mapping and switch classification, including 16x RJ45 + 2x SFP+ port layout fallback.
+- Improved `USW-24` / `USW-48` fallback model resolution so generic identifiers now default to non-PoE variants, while explicit `...P`/`...PoE` identifiers still resolve to PoE models.
+- Added missing `SWITCHPRO48` alias handling (plus `SWITCHPRO24`/`SWITCHPRO48` fallback port-count inference) for better alignment with alternate UniFi/aiounifi naming variants.
+
 ## [v0.5.5] - 2026-04-12
 
 ### ✨ Improvements

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ If you see improvements, issues, or fixes, feel free to open an issue or create 
 | USW Pro 24 (`US24PRO2`) | 24 + 2 SFP+ | Silver |
 | USW Pro 48 PoE (`US48PRO`) | 48 + 4 SFP+ | Silver |
 | USW Pro 48 (`US48PRO2`) | 48 + 4 SFP+ | Silver |
+| USW Pro Max 16 (`USPM16`) | 16 + 2 SFP+ | Silver |
 | USW Pro Max 16 PoE (`USPM16P`) | 16 + 2 SFP+ | Silver |
 | USW Pro Max 24 (`USPM24`) | 24 + 2 SFP+ | Silver |
 | USW Pro Max 24 PoE (`USPM24P`) | 24 + 2 SFP+ | Silver |

--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.5.52-dev */
+/* UniFi Device Card 0.0.0-dev.9fcab02 */
 
 // src/model-registry.js
 function range(start, end) {
@@ -410,6 +410,19 @@ var MODEL_REGISTRY = {
       { key: "sfp_2", label: "SFP+ 2", port: 50 },
       { key: "sfp_3", label: "SFP+ 3", port: 51 },
       { key: "sfp_4", label: "SFP+ 4", port: 52 }
+    ]
+  },
+  // USW Pro Max 16  — 16× RJ45, 2× SFP+
+  USPM16: {
+    kind: "switch",
+    frontStyle: "dual-row",
+    rows: [range(1, 8), range(9, 16)],
+    portCount: 18,
+    displayModel: "USW Pro Max 16",
+    theme: "silver",
+    specialSlots: [
+      { key: "sfp_1", label: "SFP+ 1", port: 17 },
+      { key: "sfp_2", label: "SFP+ 2", port: 18 }
     ]
   },
   // USW Pro Max 16 PoE  — 16× RJ45, 2× SFP+
@@ -881,6 +894,7 @@ function resolveModelKey(device) {
     if (candidate.includes("USWPRO48POE")) return "US48PRO";
     if (candidate.includes("PRO48POE")) return "US48PRO";
     if (candidate.includes("USWPRO48")) return "US48PRO2";
+    if (candidate.includes("SWITCHPRO48")) return "US48PRO2";
     if (candidate.includes("PRO48")) return "US48PRO2";
     if (candidate === "US24PRO2") return "US24PRO2";
     if (candidate.includes("US24PRO2")) return "US24PRO2";
@@ -893,6 +907,9 @@ function resolveModelKey(device) {
     if (candidate === "USPM16P") return "USPM16P";
     if (candidate.includes("USWPROMAX16POE")) return "USPM16P";
     if (candidate.includes("PROMAX16POE")) return "USPM16P";
+    if (candidate === "USPM16") return "USPM16";
+    if (candidate.includes("USWPROMAX16")) return "USPM16";
+    if (candidate.includes("PROMAX16")) return "USPM16";
     if (candidate === "USPM24P") return "USPM24P";
     if (candidate.includes("USWPROMAX24POE")) return "USPM24P";
     if (candidate.includes("PROMAX24POE")) return "USPM24P";
@@ -954,16 +971,20 @@ function resolveModelKey(device) {
     if (candidate === "USL24") return "USL24";
     if (candidate.includes("USW24G2")) return "USL24";
     if (candidate.includes("USW24POE")) return "USL24P";
+    if (candidate.includes("USW24P")) return "USL24P";
     if (candidate === "USL48P") return "USL48P";
     if (candidate === "USL48") return "USL48";
     if (candidate.includes("USW48G2")) return "USL48";
     if (candidate.includes("USW48POE")) return "USL48P";
+    if (candidate.includes("USW48P")) return "USL48P";
     if (candidate.includes("USW24NONPOE")) return "USL24";
     if (candidate.includes("USW48NONPOE")) return "USL48";
-    if (candidate.includes("USW24")) return "USL24P";
-    if (candidate.includes("USW48")) return "USL48P";
-    if (candidate.startsWith("US24")) return "USL24P";
-    if (candidate.startsWith("US48")) return "USL48P";
+    if (candidate.includes("USW24")) return "USL24";
+    if (candidate.includes("USW48")) return "USL48";
+    if (candidate.startsWith("US24P")) return "USL24P";
+    if (candidate.startsWith("US48P")) return "USL48P";
+    if (candidate.startsWith("US24")) return "USL24";
+    if (candidate.startsWith("US48")) return "USL48";
   }
   return null;
 }
@@ -996,9 +1017,9 @@ function inferPortCountFromModel(device) {
   if (text.includes("USF5P") || text.includes("USWFLEX")) return 5;
   if (text.includes("US16P150") || text.includes("US16P")) return 18;
   if (text.includes("USL16P")) return 18;
-  if (text.includes("US24PRO2") || text.includes("US24PRO") || text.includes("USWPRO24")) return 26;
-  if (text.includes("US48PRO2") || text.includes("US48PRO") || text.includes("USWPRO48")) return 52;
-  if (text.includes("USPM16P") || text.includes("PROMAX16POE")) return 18;
+  if (text.includes("US24PRO2") || text.includes("US24PRO") || text.includes("USWPRO24") || text.includes("SWITCHPRO24")) return 26;
+  if (text.includes("US48PRO2") || text.includes("US48PRO") || text.includes("USWPRO48") || text.includes("SWITCHPRO48")) return 52;
+  if (text.includes("USPM16P") || text.includes("USPM16") || text.includes("PROMAX16")) return 18;
   if (text.includes("USPM24P") || text.includes("USPM24") || text.includes("PROMAX24")) return 26;
   if (text.includes("USPM48P") || text.includes("USPM48") || text.includes("PROMAX48")) return 52;
   if (text.includes("US648P") || text.includes("ENTERPRISE48POE")) return 52;
@@ -1186,6 +1207,7 @@ function getDeviceType(device, entities = []) {
       "US24PRO2",
       "US48PRO",
       "US48PRO2",
+      "USPM16",
       "USPM16P",
       "USPM24",
       "USPM24P",
@@ -3644,7 +3666,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.5.52-dev";
+var VERSION = "0.0.0-dev.9fcab02";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var UnifiDeviceCard = class extends HTMLElement {
   static getConfigElement() {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -196,6 +196,7 @@ export function getDeviceType(device, entities = []) {
         "US24PRO2",
         "US48PRO",
         "US48PRO2",
+        "USPM16",
         "USPM16P",
         "USPM24",
         "USPM24P",

--- a/src/model-registry.js
+++ b/src/model-registry.js
@@ -387,6 +387,16 @@ export const MODEL_REGISTRY = {
     ],
   },
 
+  // USW Pro Max 16  — 16× RJ45, 2× SFP+
+  USPM16: {
+    kind: "switch", frontStyle: "dual-row", rows: [range(1, 8), range(9, 16)],
+    portCount: 18, displayModel: "USW Pro Max 16", theme: "silver",
+    specialSlots: [
+      { key: "sfp_1", label: "SFP+ 1", port: 17 },
+      { key: "sfp_2", label: "SFP+ 2", port: 18 },
+    ],
+  },
+
   // USW Pro Max 16 PoE  — 16× RJ45, 2× SFP+
   USPM16P: {
     kind: "switch", frontStyle: "dual-row", rows: [range(1, 8), range(9, 16)],
@@ -824,6 +834,7 @@ export function resolveModelKey(device) {
     if (candidate.includes("USWPRO48POE"))        return "US48PRO";
     if (candidate.includes("PRO48POE"))           return "US48PRO";
     if (candidate.includes("USWPRO48"))           return "US48PRO2";
+    if (candidate.includes("SWITCHPRO48"))        return "US48PRO2";
     if (candidate.includes("PRO48"))              return "US48PRO2";
 
     if (candidate === "US24PRO2")                 return "US24PRO2";
@@ -838,6 +849,9 @@ export function resolveModelKey(device) {
     if (candidate === "USPM16P")                  return "USPM16P";
     if (candidate.includes("USWPROMAX16POE"))     return "USPM16P";
     if (candidate.includes("PROMAX16POE"))        return "USPM16P";
+    if (candidate === "USPM16")                   return "USPM16";
+    if (candidate.includes("USWPROMAX16"))        return "USPM16";
+    if (candidate.includes("PROMAX16"))           return "USPM16";
 
     if (candidate === "USPM24P")                  return "USPM24P";
     if (candidate.includes("USWPROMAX24POE"))     return "USPM24P";
@@ -908,18 +922,22 @@ export function resolveModelKey(device) {
     if (candidate === "USL24")                    return "USL24";
     if (candidate.includes("USW24G2"))            return "USL24";
     if (candidate.includes("USW24POE"))           return "USL24P";
+    if (candidate.includes("USW24P"))             return "USL24P";
 
     if (candidate === "USL48P")                   return "USL48P";
     if (candidate === "USL48")                    return "USL48";
     if (candidate.includes("USW48G2"))            return "USL48";
     if (candidate.includes("USW48POE"))           return "USL48P";
+    if (candidate.includes("USW48P"))             return "USL48P";
 
     if (candidate.includes("USW24NONPOE"))        return "USL24";
     if (candidate.includes("USW48NONPOE"))        return "USL48";
-    if (candidate.includes("USW24"))              return "USL24P";
-    if (candidate.includes("USW48"))              return "USL48P";
-    if (candidate.startsWith("US24"))             return "USL24P";
-    if (candidate.startsWith("US48"))             return "USL48P";
+    if (candidate.includes("USW24"))              return "USL24";
+    if (candidate.includes("USW48"))              return "USL48";
+    if (candidate.startsWith("US24P"))            return "USL24P";
+    if (candidate.startsWith("US48P"))            return "USL48P";
+    if (candidate.startsWith("US24"))             return "USL24";
+    if (candidate.startsWith("US48"))             return "USL48";
   }
 
   return null;
@@ -959,9 +977,9 @@ export function inferPortCountFromModel(device) {
   if (text.includes("US16P150") || text.includes("US16P"))                           return 18;
   if (text.includes("USL16P"))                                                        return 18;
 
-  if (text.includes("US24PRO2") || text.includes("US24PRO") || text.includes("USWPRO24")) return 26;
-  if (text.includes("US48PRO2") || text.includes("US48PRO") || text.includes("USWPRO48")) return 52;
-  if (text.includes("USPM16P")  || text.includes("PROMAX16POE"))                     return 18;
+  if (text.includes("US24PRO2") || text.includes("US24PRO") || text.includes("USWPRO24") || text.includes("SWITCHPRO24")) return 26;
+  if (text.includes("US48PRO2") || text.includes("US48PRO") || text.includes("USWPRO48") || text.includes("SWITCHPRO48")) return 52;
+  if (text.includes("USPM16P")  || text.includes("USPM16") || text.includes("PROMAX16")) return 18;
   if (text.includes("USPM24P")  || text.includes("USPM24")  || text.includes("PROMAX24")) return 26;
   if (text.includes("USPM48P")  || text.includes("USPM48")  || text.includes("PROMAX48")) return 52;
 


### PR DESCRIPTION
### Motivation
- Add explicit non-PoE recognition for the new USW Pro Max 16 model and ensure the UI can render its 16×RJ45 + 2×SFP+ layout correctly. 
- Improve detection of various UniFi/aiounifi naming variants so generic identifiers resolve to the intended non-PoE or PoE models more reliably. 
- Align documentation and built artifacts with the updated model registry so the card and editor classify devices consistently.

### Description
- Introduces a new model entry `USPM16` in the model registry with `dual-row` layout, `portCount: 18`, and two SFP+ special slots. 
- Adds `USPM16` handling in `resolveModelKey`, `inferPortCountFromModel`, and device type lists so non-PoE Pro Max 16 devices are classified as switches. 
- Adds alias handling for `SWITCHPRO24` and `SWITCHPRO48` and adjusts `USW-24`/`USW-48` fallback logic so generic `USW24`/`USW48` resolve to non-PoE variants while explicit `...P` identifiers still map to PoE models. 
- Updates `README.md` and `CHANGELOG.md` to document the new model and overall improvements, and updates built artifact `dist/unifi-device-card.js` with the new registry and version metadata.

### Testing
- Ran the project build with `npm run build` to regenerate `dist/unifi-device-card.js`, which completed successfully. 
- Verified model resolution and layout logic by exercising `resolveModelKey` and `inferPortCountFromModel` paths locally against sample model strings; checks matched the expected `USPM16` and switch alias mappings. 
- Ran the repository test command `npm test`; no automated unit tests are configured in this repository (build only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbdd0aa3288333ad3e2c29c40a3726)