### PR TITLE
Add USW Pro Max 16, new model aliases and improve port-entity detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [v0.5.6] - 2026-04-12
+
+### ✨ Improvements
+- Added explicit non-PoE `USW Pro Max 16` (`USPM16`) model mapping and switch classification, including 16x RJ45 + 2x SFP+ port layout fallback.
+- Improved `USW-24` / `USW-48` fallback model resolution so generic identifiers now default to non-PoE variants, while explicit `...P`/`...PoE` identifiers still resolve to PoE models.
+- Added missing `SWITCHPRO48` alias handling (plus `SWITCHPRO24`/`SWITCHPRO48` fallback port-count inference) for better alignment with alternate UniFi/aiounifi naming variants.
+- Added additional alias support checks from recent device reports: `U7MSH`/`U7MESH` → `U7 Mesh` AP model and `USL24PB`/`USL48PB` → PoE switch variants.
+- Improved port-entity detection regex for LAN/ETH/SFP identifiers with compact numbering (for example `lan1`/`eth1`) to better detect active ports on devices like `USG-3P` (`UGW3`) when entity naming differs.
+- Extended shared port-id detection used by switch/gateway classification and telemetry heuristics to also recognize `lan1`/`eth1`/`sfp1` naming variants (not only `_port_#`), reducing model-specific edge cases.
+
 ## [v0.5.5] - 2026-04-12
 
 ### ✨ Improvements

--- a/README.md
+++ b/README.md
@@ -68,13 +68,14 @@ If you see improvements, issues, or fixes, feel free to open an issue or create 
 | USW Lite 16 PoE (`USL16LP`, `USL16LPB`) | 16 | White |
 | USW 16 PoE (`USL16P`) | 16 + 2 SFP | Silver |
 | USW 24 (`USL24`) | 24 + 2 SFP | Silver |
-| USW 24 PoE (`USL24P`, `USW24P`) | 24 + 2 SFP | Silver |
+| USW 24 PoE (`USL24P`, `USL24PB`, `USW24P`) | 24 + 2 SFP | Silver |
 | USW 48 (`USL48`) | 48 + 4 SFP | Silver |
 | USW 48 PoE (`USL48P`, `USW48P`) | 48 + 4 SFP | Silver |
 | USW Pro 24 PoE (`US24PRO`) | 24 + 2 SFP+ | Silver |
 | USW Pro 24 (`US24PRO2`) | 24 + 2 SFP+ | Silver |
 | USW Pro 48 PoE (`US48PRO`) | 48 + 4 SFP+ | Silver |
 | USW Pro 48 (`US48PRO2`) | 48 + 4 SFP+ | Silver |
+| USW Pro Max 16 (`USPM16`) | 16 + 2 SFP+ | Silver |
 | USW Pro Max 16 PoE (`USPM16P`) | 16 + 2 SFP+ | Silver |
 | USW Pro Max 24 (`USPM24`) | 24 + 2 SFP+ | Silver |
 | USW Pro Max 24 PoE (`USPM24P`) | 24 + 2 SFP+ | Silver |
@@ -108,6 +109,7 @@ If you see improvements, issues, or fixes, feel free to open an issue or create 
 | U6 Mesh (`U6MESH`) | AP panel | White |
 | U6 Extender (`U6EXTENDER`) | AP panel | White |
 | U7 In-Wall (`U7IW`) | AP panel | White |
+| U7 Mesh (`U7MSH`) | AP panel | White |
 | U7 LR (`U7LR`) | AP panel | White |
 | U7 Lite (`U7LITE`) | AP panel | White |
 | U7 Pro XG (`U7PROXG`) | AP panel | White |

--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.5.52-dev */
+/* UniFi Device Card 0.0.0-dev.515d5cd */
 
 // src/model-registry.js
 function range(start, end) {
@@ -93,6 +93,7 @@ var MODEL_REGISTRY = {
   U7PROWALL: apModel("U7 Pro Wall"),
   U7IW: apModel("U7 In-Wall"),
   U7LR: apModel("U7 LR"),
+  U7MSH: apModel("U7 Mesh"),
   U7LITE: apModel("U7 Lite"),
   U7OUTDOOR: apModel("U7 Outdoor"),
   U7PROXG: apModel("U7 Pro XG"),
@@ -410,6 +411,19 @@ var MODEL_REGISTRY = {
       { key: "sfp_2", label: "SFP+ 2", port: 50 },
       { key: "sfp_3", label: "SFP+ 3", port: 51 },
       { key: "sfp_4", label: "SFP+ 4", port: 52 }
+    ]
+  },
+  // USW Pro Max 16  — 16× RJ45, 2× SFP+
+  USPM16: {
+    kind: "switch",
+    frontStyle: "dual-row",
+    rows: [range(1, 8), range(9, 16)],
+    portCount: 18,
+    displayModel: "USW Pro Max 16",
+    theme: "silver",
+    specialSlots: [
+      { key: "sfp_1", label: "SFP+ 1", port: 17 },
+      { key: "sfp_2", label: "SFP+ 2", port: 18 }
     ]
   },
   // USW Pro Max 16 PoE  — 16× RJ45, 2× SFP+
@@ -822,6 +836,8 @@ function resolveModelKey(device) {
     if (candidate.includes("U7IW")) return "U7IW";
     if (candidate.includes("U7INWALL")) return "U7IW";
     if (candidate.includes("U7LR")) return "U7LR";
+    if (candidate.includes("U7MSH")) return "U7MSH";
+    if (candidate.includes("U7MESH")) return "U7MSH";
     if (candidate.includes("U7LITE")) return "U7LITE";
     if (candidate.includes("U7ULTRA")) return "U7LITE";
     if (candidate.includes("U7PROWALL")) return "U7PROWALL";
@@ -881,6 +897,7 @@ function resolveModelKey(device) {
     if (candidate.includes("USWPRO48POE")) return "US48PRO";
     if (candidate.includes("PRO48POE")) return "US48PRO";
     if (candidate.includes("USWPRO48")) return "US48PRO2";
+    if (candidate.includes("SWITCHPRO48")) return "US48PRO2";
     if (candidate.includes("PRO48")) return "US48PRO2";
     if (candidate === "US24PRO2") return "US24PRO2";
     if (candidate.includes("US24PRO2")) return "US24PRO2";
@@ -893,6 +910,9 @@ function resolveModelKey(device) {
     if (candidate === "USPM16P") return "USPM16P";
     if (candidate.includes("USWPROMAX16POE")) return "USPM16P";
     if (candidate.includes("PROMAX16POE")) return "USPM16P";
+    if (candidate === "USPM16") return "USPM16";
+    if (candidate.includes("USWPROMAX16")) return "USPM16";
+    if (candidate.includes("PROMAX16")) return "USPM16";
     if (candidate === "USPM24P") return "USPM24P";
     if (candidate.includes("USWPROMAX24POE")) return "USPM24P";
     if (candidate.includes("PROMAX24POE")) return "USPM24P";
@@ -951,19 +971,25 @@ function resolveModelKey(device) {
     if (candidate.includes("USW16POE")) return "USL16P";
     if (candidate.includes("USW16P")) return "USL16P";
     if (candidate === "USL24P") return "USL24P";
+    if (candidate === "USL24PB") return "USL24P";
     if (candidate === "USL24") return "USL24";
     if (candidate.includes("USW24G2")) return "USL24";
     if (candidate.includes("USW24POE")) return "USL24P";
+    if (candidate.includes("USW24P")) return "USL24P";
     if (candidate === "USL48P") return "USL48P";
+    if (candidate === "USL48PB") return "USL48P";
     if (candidate === "USL48") return "USL48";
     if (candidate.includes("USW48G2")) return "USL48";
     if (candidate.includes("USW48POE")) return "USL48P";
+    if (candidate.includes("USW48P")) return "USL48P";
     if (candidate.includes("USW24NONPOE")) return "USL24";
     if (candidate.includes("USW48NONPOE")) return "USL48";
-    if (candidate.includes("USW24")) return "USL24P";
-    if (candidate.includes("USW48")) return "USL48P";
-    if (candidate.startsWith("US24")) return "USL24P";
-    if (candidate.startsWith("US48")) return "USL48P";
+    if (candidate.includes("USW24")) return "USL24";
+    if (candidate.includes("USW48")) return "USL48";
+    if (candidate.startsWith("US24P")) return "USL24P";
+    if (candidate.startsWith("US48P")) return "USL48P";
+    if (candidate.startsWith("US24")) return "USL24";
+    if (candidate.startsWith("US48")) return "USL48";
   }
   return null;
 }
@@ -996,9 +1022,9 @@ function inferPortCountFromModel(device) {
   if (text.includes("USF5P") || text.includes("USWFLEX")) return 5;
   if (text.includes("US16P150") || text.includes("US16P")) return 18;
   if (text.includes("USL16P")) return 18;
-  if (text.includes("US24PRO2") || text.includes("US24PRO") || text.includes("USWPRO24")) return 26;
-  if (text.includes("US48PRO2") || text.includes("US48PRO") || text.includes("USWPRO48")) return 52;
-  if (text.includes("USPM16P") || text.includes("PROMAX16POE")) return 18;
+  if (text.includes("US24PRO2") || text.includes("US24PRO") || text.includes("USWPRO24") || text.includes("SWITCHPRO24")) return 26;
+  if (text.includes("US48PRO2") || text.includes("US48PRO") || text.includes("USWPRO48") || text.includes("SWITCHPRO48")) return 52;
+  if (text.includes("USPM16P") || text.includes("USPM16") || text.includes("PROMAX16")) return 18;
   if (text.includes("USPM24P") || text.includes("USPM24") || text.includes("PROMAX24")) return 26;
   if (text.includes("USPM48P") || text.includes("USPM48") || text.includes("PROMAX48")) return 52;
   if (text.includes("US648P") || text.includes("ENTERPRISE48POE")) return 52;
@@ -1111,6 +1137,9 @@ var AP_MODEL_PREFIXES2 = ["UAP", "UAC", "U6", "U7", "UAL", "UAPMESH", "E7", "UWB
 function normalizeModelStr(value) {
   return String(value ?? "").toUpperCase().replace(/[^A-Z0-9]/g, "");
 }
+function hasIndexedPortId(entityId) {
+  return /_(?:port|lan|eth|ethernet|sfp)[_-]?\d+(?:_|$)/i.test(String(entityId || ""));
+}
 function modelStartsWith(device, prefixes) {
   const candidates = [device?.model, device?.hw_version].filter(Boolean).map(normalizeModelStr);
   return prefixes.some((pfx) => candidates.some((c) => c.startsWith(pfx)));
@@ -1125,7 +1154,7 @@ function isVirtualControllerDevice(device) {
   return combined.includes("network application") || combined.includes("unifi os") || combined.includes("controller");
 }
 function hasInfrastructureEntitySignals(entities = []) {
-  const hasPortEntities = entities.some((e) => /_port_\d+(?:_|$)/i.test(e?.entity_id || ""));
+  const hasPortEntities = entities.some((e) => hasIndexedPortId(e?.entity_id));
   if (hasPortEntities) return true;
   const hasRebootControl = entities.some((e) => {
     const id = lower(e?.entity_id);
@@ -1186,6 +1215,7 @@ function getDeviceType(device, entities = []) {
       "US24PRO2",
       "US48PRO",
       "US48PRO2",
+      "USPM16",
       "USPM16P",
       "USPM24",
       "USPM24P",
@@ -1214,7 +1244,7 @@ function getDeviceType(device, entities = []) {
     return id.endsWith("_clients") || id.includes("_clients_") || id.endsWith("_uptime") || id.includes("_is_online") || id.includes("_connected");
   });
   if (hasAccessPointSignals && hasUbiquitiManufacturer(device)) return "access_point";
-  const hasPorts = entities.some((e) => /_port_\d+(?:_|$)/i.test(e.entity_id));
+  const hasPorts = entities.some((e) => hasIndexedPortId(e.entity_id));
   if (hasPorts) return "switch";
   if (hasUbiquitiManufacturer(device)) {
     const model = lower(device?.model);
@@ -1341,7 +1371,7 @@ function isUnifiDevice(device, unifiEntryIds, entities) {
   if (modelStartsWith(device, [...SWITCH_MODEL_PREFIXES, ...GATEWAY_MODEL_PREFIXES, ...AP_MODEL_PREFIXES2])) {
     return true;
   }
-  if (entities.some((e) => /_port_\d+(?:_|$)/i.test(e.entity_id)) && hasUbiquitiManufacturer(device)) {
+  if (entities.some((e) => hasIndexedPortId(e.entity_id)) && hasUbiquitiManufacturer(device)) {
     return true;
   }
   if (hasUbiquitiManufacturer(device) && getDeviceType(device, entities) === "access_point" && hasInfraSignals) {
@@ -1372,7 +1402,7 @@ function findDeviceEntityByPatterns(entities, patterns = []) {
 }
 function isPortLevelTelemetrySensor(entityId) {
   const id = lower(entityId);
-  return id.includes("_port_") || id.includes("_wan_") || id.includes("link_speed") || id.includes("_rx") || id.includes("_tx") || id.includes("throughput");
+  return hasIndexedPortId(id) || id.includes("_wan_") || id.includes("link_speed") || id.includes("_rx") || id.includes("_tx") || id.includes("throughput");
 }
 function findSystemStatEntity(entities, includePatterns = [], excludePatterns = []) {
   for (const entity of entities || []) {
@@ -1553,7 +1583,7 @@ function extractPortNumber(entity) {
   const eid = lower(entity.entity_id);
   const eidMatch = eid.match(/_port_(\d+)(?:_|$)/i);
   if (eidMatch) return parseInt(eidMatch[1], 10);
-  const eidAltMatch = eid.match(/_(?:lan|eth|ethernet|sfp)_(\d+)(?:_|$)/i);
+  const eidAltMatch = eid.match(/_(?:lan|eth|ethernet|sfp)[_-]?(\d+)(?:_|$)/i);
   if (eidAltMatch) return parseInt(eidAltMatch[1], 10);
   const originalNameMatch = (entity.original_name || "").match(/\bport\s+(\d+)\b/i);
   if (originalNameMatch) return parseInt(originalNameMatch[1], 10);
@@ -1564,7 +1594,7 @@ function extractPortNumber(entity) {
 function classifyPortEntity(entity, isSpecial = false) {
   const id = lower(entity.entity_id);
   const eid = entity.entity_id || "";
-  const hasPortLikeId = /_(?:port|lan|eth|ethernet|sfp)_(\d+)(?:_|$)/i.test(id);
+  const hasPortLikeId = /_(?:port|lan|eth|ethernet|sfp)[_-]?(\d+)(?:_|$)/i.test(id);
   const tk = lower(entity.translation_key || "");
   const dc = lower(entity.device_class || "");
   const odc = lower(entity.original_device_class || "");
@@ -2038,7 +2068,7 @@ async function buildDeviceContext(hass, deviceId, cardConfig = null) {
   const type = getDeviceType(device, entities);
   if (type !== "switch" && type !== "gateway" && type !== "access_point") return null;
   const needsUID = entities.filter(
-    (e) => !e.unique_id && e.translation_key && PORT_TRANSLATION_KEYS.has(e.translation_key) && !/_port_\d+/i.test(e.entity_id) && !/\bport\s+\d+\b/i.test(e.original_name || "")
+    (e) => !e.unique_id && e.translation_key && PORT_TRANSLATION_KEYS.has(e.translation_key) && !hasIndexedPortId(e.entity_id) && !/\bport\s+\d+\b/i.test(e.original_name || "")
   );
   if (needsUID.length > 0) {
     const details = await Promise.all(
@@ -3644,7 +3674,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.5.52-dev";
+var VERSION = "0.0.0-dev.515d5cd";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var UnifiDeviceCard = class extends HTMLElement {
   static getConfigElement() {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -94,6 +94,10 @@ function normalizeModelStr(value) {
   return String(value ?? "").toUpperCase().replace(/[^A-Z0-9]/g, "");
 }
 
+function hasIndexedPortId(entityId) {
+  return /_(?:port|lan|eth|ethernet|sfp)[_-]?\d+(?:_|$)/i.test(String(entityId || ""));
+}
+
 function modelStartsWith(device, prefixes) {
   const candidates = [device?.model, device?.hw_version]
     .filter(Boolean)
@@ -119,7 +123,7 @@ function isVirtualControllerDevice(device) {
 }
 
 function hasInfrastructureEntitySignals(entities = []) {
-  const hasPortEntities = entities.some((e) => /_port_\d+(?:_|$)/i.test(e?.entity_id || ""));
+  const hasPortEntities = entities.some((e) => hasIndexedPortId(e?.entity_id));
   if (hasPortEntities) return true;
 
   const hasRebootControl = entities.some((e) => {
@@ -196,6 +200,7 @@ export function getDeviceType(device, entities = []) {
         "US24PRO2",
         "US48PRO",
         "US48PRO2",
+        "USPM16",
         "USPM16P",
         "USPM24",
         "USPM24P",
@@ -234,7 +239,7 @@ export function getDeviceType(device, entities = []) {
   });
   if (hasAccessPointSignals && hasUbiquitiManufacturer(device)) return "access_point";
 
-  const hasPorts = entities.some((e) => /_port_\d+(?:_|$)/i.test(e.entity_id));
+  const hasPorts = entities.some((e) => hasIndexedPortId(e.entity_id));
   if (hasPorts) return "switch";
 
   if (hasUbiquitiManufacturer(device)) {
@@ -444,7 +449,7 @@ function isUnifiDevice(device, unifiEntryIds, entities) {
   }
 
   if (
-    entities.some((e) => /_port_\d+(?:_|$)/i.test(e.entity_id)) &&
+    entities.some((e) => hasIndexedPortId(e.entity_id)) &&
     hasUbiquitiManufacturer(device)
   ) {
     return true;
@@ -499,7 +504,7 @@ function findDeviceEntityByPatterns(entities, patterns = []) {
 function isPortLevelTelemetrySensor(entityId) {
   const id = lower(entityId);
   return (
-    id.includes("_port_") ||
+    hasIndexedPortId(id) ||
     id.includes("_wan_") ||
     id.includes("link_speed") ||
     id.includes("_rx") ||
@@ -813,7 +818,7 @@ function extractPortNumber(entity) {
   const eid = lower(entity.entity_id);
   const eidMatch = eid.match(/_port_(\d+)(?:_|$)/i);
   if (eidMatch) return parseInt(eidMatch[1], 10);
-  const eidAltMatch = eid.match(/_(?:lan|eth|ethernet|sfp)_(\d+)(?:_|$)/i);
+  const eidAltMatch = eid.match(/_(?:lan|eth|ethernet|sfp)[_-]?(\d+)(?:_|$)/i);
   if (eidAltMatch) return parseInt(eidAltMatch[1], 10);
 
   const originalNameMatch = (entity.original_name || "").match(/\bport\s+(\d+)\b/i);
@@ -828,7 +833,7 @@ function extractPortNumber(entity) {
 function classifyPortEntity(entity, isSpecial = false) {
   const id = lower(entity.entity_id);
   const eid = entity.entity_id || "";
-  const hasPortLikeId = /_(?:port|lan|eth|ethernet|sfp)_(\d+)(?:_|$)/i.test(id);
+  const hasPortLikeId = /_(?:port|lan|eth|ethernet|sfp)[_-]?(\d+)(?:_|$)/i.test(id);
   const tk = lower(entity.translation_key || "");
   const dc = lower(entity.device_class || "");
   const odc = lower(entity.original_device_class || "");
@@ -1545,7 +1550,7 @@ async function buildDeviceContext(hass, deviceId, cardConfig = null) {
       !e.unique_id &&
       e.translation_key &&
       PORT_TRANSLATION_KEYS.has(e.translation_key) &&
-      !/_port_\d+/i.test(e.entity_id) &&
+      !hasIndexedPortId(e.entity_id) &&
       !/\bport\s+\d+\b/i.test(e.original_name || "")
   );
 

--- a/src/model-registry.js
+++ b/src/model-registry.js
@@ -129,6 +129,7 @@ export const MODEL_REGISTRY = {
   U7PROWALL: apModel("U7 Pro Wall"),
   U7IW: apModel("U7 In-Wall"),
   U7LR: apModel("U7 LR"),
+  U7MSH: apModel("U7 Mesh"),
   U7LITE: apModel("U7 Lite"),
   U7OUTDOOR: apModel("U7 Outdoor"),
   U7PROXG: apModel("U7 Pro XG"),
@@ -384,6 +385,16 @@ export const MODEL_REGISTRY = {
       { key: "sfp_2", label: "SFP+ 2", port: 50 },
       { key: "sfp_3", label: "SFP+ 3", port: 51 },
       { key: "sfp_4", label: "SFP+ 4", port: 52 },
+    ],
+  },
+
+  // USW Pro Max 16  — 16× RJ45, 2× SFP+
+  USPM16: {
+    kind: "switch", frontStyle: "dual-row", rows: [range(1, 8), range(9, 16)],
+    portCount: 18, displayModel: "USW Pro Max 16", theme: "silver",
+    specialSlots: [
+      { key: "sfp_1", label: "SFP+ 1", port: 17 },
+      { key: "sfp_2", label: "SFP+ 2", port: 18 },
     ],
   },
 
@@ -762,6 +773,8 @@ export function resolveModelKey(device) {
     if (candidate.includes("U7IW"))               return "U7IW";
     if (candidate.includes("U7INWALL"))           return "U7IW";
     if (candidate.includes("U7LR"))               return "U7LR";
+    if (candidate.includes("U7MSH"))              return "U7MSH";
+    if (candidate.includes("U7MESH"))             return "U7MSH";
     if (candidate.includes("U7LITE"))             return "U7LITE";
     if (candidate.includes("U7ULTRA"))            return "U7LITE";
     if (candidate.includes("U7PROWALL"))          return "U7PROWALL";
@@ -824,6 +837,7 @@ export function resolveModelKey(device) {
     if (candidate.includes("USWPRO48POE"))        return "US48PRO";
     if (candidate.includes("PRO48POE"))           return "US48PRO";
     if (candidate.includes("USWPRO48"))           return "US48PRO2";
+    if (candidate.includes("SWITCHPRO48"))        return "US48PRO2";
     if (candidate.includes("PRO48"))              return "US48PRO2";
 
     if (candidate === "US24PRO2")                 return "US24PRO2";
@@ -838,6 +852,9 @@ export function resolveModelKey(device) {
     if (candidate === "USPM16P")                  return "USPM16P";
     if (candidate.includes("USWPROMAX16POE"))     return "USPM16P";
     if (candidate.includes("PROMAX16POE"))        return "USPM16P";
+    if (candidate === "USPM16")                   return "USPM16";
+    if (candidate.includes("USWPROMAX16"))        return "USPM16";
+    if (candidate.includes("PROMAX16"))           return "USPM16";
 
     if (candidate === "USPM24P")                  return "USPM24P";
     if (candidate.includes("USWPROMAX24POE"))     return "USPM24P";
@@ -905,21 +922,29 @@ export function resolveModelKey(device) {
     if (candidate.includes("USW16P"))             return "USL16P";
 
     if (candidate === "USL24P")                   return "USL24P";
+    if (candidate === "USL24PB")                  return "USL24P";
     if (candidate === "USL24")                    return "USL24";
     if (candidate.includes("USW24G2"))            return "USL24";
     if (candidate.includes("USW24POE"))           return "USL24P";
+    if (candidate.includes("USW24P"))             return "USL24P";
 
     if (candidate === "USL48P")                   return "USL48P";
+    if (candidate === "USL48PB")                  return "USL48P";
     if (candidate === "USL48")                    return "USL48";
     if (candidate.includes("USW48G2"))            return "USL48";
     if (candidate.includes("USW48POE"))           return "USL48P";
+    if (candidate.includes("USW48P"))             return "USL48P";
 
     if (candidate.includes("USW24NONPOE"))        return "USL24";
     if (candidate.includes("USW48NONPOE"))        return "USL48";
-    if (candidate.includes("USW24"))              return "USL24P";
-    if (candidate.includes("USW48"))              return "USL48P";
-    if (candidate.startsWith("US24"))             return "USL24P";
-    if (candidate.startsWith("US48"))             return "USL48P";
+    // Note: aiounifi/controller naming can expose marketed USW-24/USW-48
+    // while the internal model keys are USL24/USL48 (non-PoE Gen2).
+    if (candidate.includes("USW24"))              return "USL24";
+    if (candidate.includes("USW48"))              return "USL48";
+    if (candidate.startsWith("US24P"))            return "USL24P";
+    if (candidate.startsWith("US48P"))            return "USL48P";
+    if (candidate.startsWith("US24"))             return "USL24";
+    if (candidate.startsWith("US48"))             return "USL48";
   }
 
   return null;
@@ -959,9 +984,9 @@ export function inferPortCountFromModel(device) {
   if (text.includes("US16P150") || text.includes("US16P"))                           return 18;
   if (text.includes("USL16P"))                                                        return 18;
 
-  if (text.includes("US24PRO2") || text.includes("US24PRO") || text.includes("USWPRO24")) return 26;
-  if (text.includes("US48PRO2") || text.includes("US48PRO") || text.includes("USWPRO48")) return 52;
-  if (text.includes("USPM16P")  || text.includes("PROMAX16POE"))                     return 18;
+  if (text.includes("US24PRO2") || text.includes("US24PRO") || text.includes("USWPRO24") || text.includes("SWITCHPRO24")) return 26;
+  if (text.includes("US48PRO2") || text.includes("US48PRO") || text.includes("USWPRO48") || text.includes("SWITCHPRO48")) return 52;
+  if (text.includes("USPM16P")  || text.includes("USPM16") || text.includes("PROMAX16")) return 18;
   if (text.includes("USPM24P")  || text.includes("USPM24")  || text.includes("PROMAX24")) return 26;
   if (text.includes("USPM48P")  || text.includes("USPM48")  || text.includes("PROMAX48")) return 52;
 


### PR DESCRIPTION
### Motivation
- Add missing model and alias mappings so new UniFi device variants are detected and rendered with correct layouts and PoE classification.
- Make port/entity detection more robust for varied naming used by integrations (for example `lan1`, `eth1`, `sfp1` and hyphen vs underscore variants).
- Reduce model-specific edge cases by defaulting ambiguous `USW-24`/`USW-48` identifiers to non-PoE variants unless an explicit PoE marker is present.

### Description
- Added a dedicated `USPM16` model entry with a 16×RJ45 + 2×SFP+ layout and corresponding mapping for the non-PoE variant and preserved the existing `USPM16P` PoE entry.
- Added `U7MSH` (`U7 Mesh`) AP alias and additional alias handling for `SWITCHPRO24`/`SWITCHPRO48`, `USL24PB`/`USL48PB`, `USW24P`/`USW48P`, and other recent naming variants to `resolveModelKey`/`MODEL_REGISTRY` and `inferPortCountFromModel`.
- Introduced a new helper `hasIndexedPortId` and replaced multiple `_port_`-only regex checks with a more flexible pattern that recognizes `port`, `lan`, `eth`, `ethernet`, and `sfp` with optional separators (underscore/hyphen/no-separator), and applied it across `extractPortNumber`, `classifyPortEntity`, `isPortLevelTelemetrySensor`, `hasInfrastructureEntitySignals`, `isUnifiDevice`, `getDeviceType`, and `buildDeviceContext`.
- Adjusted model resolution so generic `USW24`/`USW48` now prefer non-PoE internal keys (`USL24`/`USL48`) while explicit `P`/`PoE` identifiers still resolve to PoE models.
- Updated documentation files: `README.md` (supported devices list) and `CHANGELOG.md` (new v0.5.6 notes), and updated the built bundle/version banner in `dist/unifi-device-card.js`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbdd0aa3288333ad3e2c29c40a3726)