### PR TITLE
Unify indexed-port detection with shared regex and update dist build

### DIFF
--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.40f2530 */
+/* UniFi Device Card 0.0.0-dev.bd0308c */
 
 // src/model-registry.js
 function range(start, end) {
@@ -1137,8 +1137,12 @@ var AP_MODEL_PREFIXES2 = ["UAP", "UAC", "U6", "U7", "UAL", "UAPMESH", "E7", "UWB
 function normalizeModelStr(value) {
   return String(value ?? "").toUpperCase().replace(/[^A-Z0-9]/g, "");
 }
+var INDEXED_PORT_ID_RE = /(?:^|[_-])(?:port|lan|eth|ethernet|sfp)[_-]?(\d+)(?:[_-]|$)/i;
+function findIndexedPortIdMatch(value) {
+  return String(value || "").match(INDEXED_PORT_ID_RE);
+}
 function hasIndexedPortId(entityId) {
-  return /_(?:port|lan|eth|ethernet|sfp)[_-]?\d+(?:_|$)/i.test(String(entityId || ""));
+  return !!findIndexedPortIdMatch(entityId);
 }
 function modelStartsWith(device, prefixes) {
   const candidates = [device?.model, device?.hw_version].filter(Boolean).map(normalizeModelStr);
@@ -1514,10 +1518,10 @@ function classifyRelevantEntityType(entity) {
   if (eid.startsWith("button.") && (id.includes("power_cycle") || tk === "power_cycle")) {
     return "power_cycle";
   }
-  if (eid.startsWith("switch.") && id.includes("_port_") && id.endsWith("_poe")) {
+  if (eid.startsWith("switch.") && hasIndexedPortId(id) && id.endsWith("_poe")) {
     return "poe_switch";
   }
-  if (eid.startsWith("switch.") && id.includes("_port_")) {
+  if (eid.startsWith("switch.") && hasIndexedPortId(id)) {
     return "port_switch";
   }
   if (eid.startsWith("sensor.") && (id.includes("_poe_power") || id.includes("_poe") && id.includes("power") || id.includes("power_draw") || id.includes("power_consumption") || id.includes("consumption") || tk === "poe_power" || tk === "port_poe_power" || tk === "poe_power_consumption" || dc === "power" || odc === "power")) {
@@ -1578,13 +1582,11 @@ async function getRelevantEntityWarningsForDevice(hass, deviceId) {
 }
 function extractPortNumber(entity) {
   const uid = normalize(entity.unique_id);
-  const uidMatch = uid.match(/_port[_-]?(\d+)(?:[_-]|$)/i) || uid.match(/-(\d+)-[a-z]/i) || uid.match(/port[_-](\d+)/i) || uid.match(/[_-](\d+)$/);
+  const uidMatch = findIndexedPortIdMatch(uid) || uid.match(/-(\d+)-[a-z]/i);
   if (uidMatch) return parseInt(uidMatch[1], 10);
   const eid = lower(entity.entity_id);
-  const eidMatch = eid.match(/_port_(\d+)(?:_|$)/i);
+  const eidMatch = findIndexedPortIdMatch(eid);
   if (eidMatch) return parseInt(eidMatch[1], 10);
-  const eidAltMatch = eid.match(/_(?:lan|eth|ethernet|sfp)[_-]?(\d+)(?:_|$)/i);
-  if (eidAltMatch) return parseInt(eidAltMatch[1], 10);
   const originalNameMatch = (entity.original_name || "").match(/\bport\s+(\d+)\b/i);
   if (originalNameMatch) return parseInt(originalNameMatch[1], 10);
   const nameMatch = (entity.name || "").match(/\bport\s+(\d+)\b/i);
@@ -1594,7 +1596,7 @@ function extractPortNumber(entity) {
 function classifyPortEntity(entity, isSpecial = false) {
   const id = lower(entity.entity_id);
   const eid = entity.entity_id || "";
-  const hasPortLikeId = /_(?:port|lan|eth|ethernet|sfp)[_-]?(\d+)(?:_|$)/i.test(id);
+  const hasPortLikeId = hasIndexedPortId(id);
   const tk = lower(entity.translation_key || "");
   const dc = lower(entity.device_class || "");
   const odc = lower(entity.original_device_class || "");
@@ -3674,7 +3676,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.40f2530";
+var VERSION = "0.0.0-dev.bd0308c";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var UnifiDeviceCard = class extends HTMLElement {
   static getConfigElement() {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -94,8 +94,14 @@ function normalizeModelStr(value) {
   return String(value ?? "").toUpperCase().replace(/[^A-Z0-9]/g, "");
 }
 
+const INDEXED_PORT_ID_RE = /(?:^|[_-])(?:port|lan|eth|ethernet|sfp)[_-]?(\d+)(?:[_-]|$)/i;
+
+function findIndexedPortIdMatch(value) {
+  return String(value || "").match(INDEXED_PORT_ID_RE);
+}
+
 function hasIndexedPortId(entityId) {
-  return /_(?:port|lan|eth|ethernet|sfp)[_-]?\d+(?:_|$)/i.test(String(entityId || ""));
+  return !!findIndexedPortIdMatch(entityId);
 }
 
 function modelStartsWith(device, prefixes) {
@@ -682,10 +688,10 @@ function classifyRelevantEntityType(entity) {
   if (eid.startsWith("button.") && (id.includes("power_cycle") || tk === "power_cycle")) {
     return "power_cycle";
   }
-  if (eid.startsWith("switch.") && id.includes("_port_") && id.endsWith("_poe")) {
+  if (eid.startsWith("switch.") && hasIndexedPortId(id) && id.endsWith("_poe")) {
     return "poe_switch";
   }
-  if (eid.startsWith("switch.") && id.includes("_port_")) {
+  if (eid.startsWith("switch.") && hasIndexedPortId(id)) {
     return "port_switch";
   }
   if (
@@ -807,19 +813,13 @@ export const getDeviceWarningInfo = getRelevantEntityWarningsForDevice;
 
 function extractPortNumber(entity) {
   const uid = normalize(entity.unique_id);
-  const uidMatch =
-    uid.match(/_port[_-]?(\d+)(?:[_-]|$)/i) ||
-    uid.match(/-(\d+)-[a-z]/i) ||
-    uid.match(/port[_-](\d+)/i) ||
-    uid.match(/[_-](\d+)$/);
+  const uidMatch = findIndexedPortIdMatch(uid) || uid.match(/-(\d+)-[a-z]/i);
 
   if (uidMatch) return parseInt(uidMatch[1], 10);
 
   const eid = lower(entity.entity_id);
-  const eidMatch = eid.match(/_port_(\d+)(?:_|$)/i);
+  const eidMatch = findIndexedPortIdMatch(eid);
   if (eidMatch) return parseInt(eidMatch[1], 10);
-  const eidAltMatch = eid.match(/_(?:lan|eth|ethernet|sfp)[_-]?(\d+)(?:_|$)/i);
-  if (eidAltMatch) return parseInt(eidAltMatch[1], 10);
 
   const originalNameMatch = (entity.original_name || "").match(/\bport\s+(\d+)\b/i);
   if (originalNameMatch) return parseInt(originalNameMatch[1], 10);
@@ -833,7 +833,7 @@ function extractPortNumber(entity) {
 function classifyPortEntity(entity, isSpecial = false) {
   const id = lower(entity.entity_id);
   const eid = entity.entity_id || "";
-  const hasPortLikeId = /_(?:port|lan|eth|ethernet|sfp)[_-]?(\d+)(?:_|$)/i.test(id);
+  const hasPortLikeId = hasIndexedPortId(id);
   const tk = lower(entity.translation_key || "");
   const dc = lower(entity.device_class || "");
   const odc = lower(entity.original_device_class || "");


### PR DESCRIPTION
### Motivation
- Improve and centralize port identifier detection so various functions consistently recognize indexed port IDs like `port_1`, `eth-2`, `lan_3`, or `sfp-4` with different separators and boundaries.

### Description
- Add a single regex constant `INDEXED_PORT_ID_RE` and helper `findIndexedPortIdMatch` to normalize matching of indexed port identifiers.  
- Replace ad-hoc regex checks and matches with `findIndexedPortIdMatch` and `hasIndexedPortId` in `classifyRelevantEntityType`, `extractPortNumber`, and `classifyPortEntity` to reduce duplication and improve correctness.  
- Remove some redundant alternate-match logic and simplify extraction order to prefer the new unified matcher.  
- Update built distribution files and bump the dev version tag in `dist/unifi-device-card.js`.

### Testing
- Rebuilt the distribution bundle with `npm run build` to regenerate `dist/unifi-device-card.js`, which completed successfully.  
- Ran the project's automated test suite with `npm test` and linting with `npm run lint`; both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbe9087a448333a54b82086c149a2f)