### PR TITLE
Fix SFP ghost-link detection and preserve entities on WAN remap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.5.72] - 2026-04-13
+
+### 🐛 Bug Fixes
+- Fixed special-port link detection so only SFP/SFP28 special slots prefer live RX/TX traffic over negotiated link speed, preserving ghost-link protection without forcing WAN/WAN2/uplink into traffic-only evaluation.
+- Fixed gateway WAN/WAN2 override remapping to retain entities when a selected special slot (for example UDR7 SFP+ WAN) is resolved by key, preventing false `no_link` on mapped WAN special ports with valid link/traffic sensors.
+
 ## [0.5.71] - 2026-04-13
 
 ### 🐛 Bug Fixes

--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.5.71 */
+/* UniFi Device Card 0.0.0-dev.b510e98 */
 
 // src/model-registry.js
 function range(start, end) {
@@ -2017,7 +2017,9 @@ function applyGatewayPortOverrides(config, specials, numbered, layout) {
     const sel = roleAssignments.get(roleKey);
     if (!sel) continue;
     if (sel.type === "port") {
-      const physical = physicalByPort.get(sel.port) || emptyNumberedPort(sel.port);
+      const physicalByPortSlot = physicalByPort.get(sel.port);
+      const physicalByKeySlot = sel.key ? specialsByKey.get(sel.key) : null;
+      const physical = physicalByPortSlot || physicalByKeySlot || emptyNumberedPort(sel.port);
       newSpecials.push(makeSpecialFromPhysical(roleKey, physical));
     } else {
       const specialData = specialsByKey.get(sel.key) || emptySpecialPort(roleKey, roleKey === "wan2" ? "WAN 2" : "WAN");
@@ -2210,13 +2212,18 @@ function trafficValue(hass, entityId) {
 function hasTraffic(hass, port) {
   return trafficValue(hass, port?.rx_entity) > 0 || trafficValue(hass, port?.tx_entity) > 0;
 }
+function isSfpSpecialPort(port) {
+  if (port?.kind !== "special") return false;
+  const key = lower(port?.physical_key || port?.key || "");
+  return key.startsWith("sfp_") || key.startsWith("sfp28_");
+}
 function isPortConnected(hass, port) {
   if (port.link_entity) {
     const s = lower(stateValue(hass, port.link_entity));
     if (["on", "true", "connected", "up", "active"].includes(s)) return true;
     if (["off", "false", "disconnected", "down", "inactive"].includes(s)) return false;
   }
-  if (port?.kind === "special" && (port?.rx_entity || port?.tx_entity)) {
+  if (isSfpSpecialPort(port) && (port?.rx_entity || port?.tx_entity)) {
     return hasTraffic(hass, port);
   }
   const speedMbit = parseLinkSpeedMbit(hass, port.speed_entity);
@@ -3701,7 +3708,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.5.71";
+var VERSION = "0.0.0-dev.b510e98";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var UnifiDeviceCard = class extends HTMLElement {
   static getConfigElement() {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1442,7 +1442,9 @@ export function applyGatewayPortOverrides(config, specials, numbered, layout) {
     if (!sel) continue;
 
     if (sel.type === "port") {
-      const physical = physicalByPort.get(sel.port) || emptyNumberedPort(sel.port);
+      const physicalByPortSlot = physicalByPort.get(sel.port);
+      const physicalByKeySlot = sel.key ? specialsByKey.get(sel.key) : null;
+      const physical = physicalByPortSlot || physicalByKeySlot || emptyNumberedPort(sel.port);
       newSpecials.push(makeSpecialFromPhysical(roleKey, physical));
     } else {
       const specialData =
@@ -1735,6 +1737,13 @@ function hasTraffic(hass, port) {
   return trafficValue(hass, port?.rx_entity) > 0 || trafficValue(hass, port?.tx_entity) > 0;
 }
 
+function isSfpSpecialPort(port) {
+  if (port?.kind !== "special") return false;
+
+  const key = lower(port?.physical_key || port?.key || "");
+  return key.startsWith("sfp_") || key.startsWith("sfp28_");
+}
+
 export function isPortConnected(hass, port) {
   if (port.link_entity) {
     const s = lower(stateValue(hass, port.link_entity));
@@ -1742,11 +1751,21 @@ export function isPortConnected(hass, port) {
     if (["off", "false", "disconnected", "down", "inactive"].includes(s)) return false;
   }
 
+  // --- BEGIN previous behavior (kept for easy rollback) ---
   // For WAN/SFP special slots, prefer live traffic over negotiated speed.
   // Some gateways report ghost speed on idle SFP ports even when no cable is active.
-  if (port?.kind === "special" && (port?.rx_entity || port?.tx_entity)) {
+  // if (port?.kind === "special" && (port?.rx_entity || port?.tx_entity)) {
+  //   return hasTraffic(hass, port);
+  // }
+  // --- END previous behavior ---
+
+  // --- BEGIN new behavior for Issue #91 ---
+  // Keep the ghost-speed protection for SFP/SFP28 special ports only.
+  // WAN/WAN2/Uplink special slots continue with speed_entity and then RX/TX fallback.
+  if (isSfpSpecialPort(port) && (port?.rx_entity || port?.tx_entity)) {
     return hasTraffic(hass, port);
   }
+  // --- END new behavior for Issue #91 ---
 
   const speedMbit = parseLinkSpeedMbit(hass, port.speed_entity);
   if (speedMbit != null) {


### PR DESCRIPTION
### Motivation
- Prevent false `no_link`/ghost-speed detection on SFP/SFP28 special ports while preserving normal link-speed behavior for WAN/WAN2/uplink slots. 
- Ensure gateway WAN/WAN2 override remapping does not drop or lose entity mappings when a special slot is resolved by key. 
- Record the change in `CHANGELOG.md` and regenerate the compiled distribution file.

### Description
- Added `isSfpSpecialPort` helper and adjusted `isPortConnected` so only SFP/SFP28 special slots prefer live RX/TX traffic over negotiated link speed. 
- Modified `applyGatewayPortOverrides` to prefer a physical slot resolved by port or, if missing, fall back to a special slot resolved by key so mapped WAN special ports retain their entities. 
- Kept the previous behavior commented for easy rollback and updated `CHANGELOG.md` with a `0.5.72` entry. 
- Regenerated `dist/unifi-device-card.js` to include the changes (compiled output and version string updated).

### Testing
- Ran the project build to regenerate `dist` (`npm run build`), which completed without build errors. 
- No automated tests were added or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcd527d7cc83338a20321634e49d57)