### PR TITLE
Modularize identity/unique-id/capabilities/classify and improve device detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.6.0] - 2026-04-16
+
+### ✨ Improvements
+- Refactored sensor/entity handling to a device-registry + capability driven flow (identity/capability/unique_id/classify modules) for more robust detection across UniFi setups.
+- Added richer tooltip support:
+  - AP uplink tooltip with wired/mesh context and peer details.
+  - Port mouseover tooltip with client count/name hints (when available from HA entities).
+- Added configurable per-card debug logging in browser console with colorized log output and YAML-configurable log levels (`log_level`, `debug`).
+
+### 🐛 Bug Fixes
+- Added RJ45 ghost-link guard so idle 10 Mbit reports without traffic/clients/PoE are no longer treated as connected.
+
 ## [0.5.91] - 2026-04-15
 
 ### ✨ Improvements

--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ rotate180: false              # optional (default: false) | true flips the switc
 ports_per_row: 8              # optional (switches only)
 port_size: 36                 # optional (switch/gateway front panel scale in px)
 ap_scale: 100                 # optional (AP size in %, 60-140)
+log_level: warn               # optional (error|warn|info|debug|trace)
+debug: false                  # optional shorthand (true => debug log level)
 edit_special_ports: false     # optional (switch/gateway only)
 special_ports: [1, 2, 9]      # optional (switch/gateway only)
 wan_port: auto                # optional (gateway only)
@@ -198,6 +200,8 @@ wan2_port: none               # optional (gateway only)
 | `ports_per_row` | number | auto | Optional row width override for switch layouts. |
 | `port_size` | number | `36` | Port size in pixels for switch/gateway front panel rendering (special and numbered ports are unified). |
 | `ap_scale` | number | `100` | AP device scale in percent (`60`-`140`) for AP card mode. |
+| `log_level` | string | `warn` | Per-card runtime log level in browser console: `error`, `warn`, `info`, `debug`, `trace`. |
+| `debug` | boolean | `false` | Shorthand for enabling debug logging (`true` behaves like `log_level: debug` if `log_level` is not set). |
 | `edit_special_ports` | boolean | `false` | Switch/Gateway only: enables WAN/WAN2 selectors and manual special-port editing in the UI/editor. |
 | `special_ports` | array<number> | auto | Switch/Gateway only: explicit port numbers shown in the top special row; non-selected ports render in the normal grid. |
 | `wan_port` | string | auto | Gateway only: assign WAN role (`auto`, slot key like `wan`, or `port_<n>`). |
@@ -229,7 +233,17 @@ Try a hard refresh (`Ctrl+Shift+R`).
 
 Confirm the device appears under **Settings → Devices & Services → UniFi**.
 
-The card logs debug output prefixed with `[unifi-device-card]` in the browser console showing why each device is accepted or rejected.
+The card can log runtime output in the browser console with `UNIFI-DEVICE-CARD` prefix and colorized levels.
+
+Example:
+
+```yaml
+type: custom:unifi-device-card
+device_id: YOUR_DEVICE_ID
+log_level: debug
+```
+
+For noisy traces, use `log_level: trace`. For quiet production usage, keep the default `warn`.
 
 ### Ports show as offline despite being connected
 

--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.07b3261 */
+/* UniFi Device Card 0.0.0-dev.c7ed3b7 */
 
 // src/model-registry.js
 function range(start, end) {
@@ -4107,7 +4107,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.07b3261";
+var VERSION = "0.0.0-dev.c7ed3b7";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var UnifiDeviceCard = class extends HTMLElement {
   static getConfigElement() {
@@ -4449,6 +4449,45 @@ var UnifiDeviceCard = class extends HTMLElement {
     const count = bestCount != null ? bestCount : bestNames.length;
     return { count, names: bestNames.slice(0, 8) };
   }
+  _extractClientNameFromStateObj(obj, entityId) {
+    const attrs = obj?.attributes || {};
+    const friendly = String(attrs.friendly_name || "").trim();
+    if (friendly) return friendly;
+    return String(entityId || "").replace(/^device_tracker\./i, "").replace(/_/g, " ").trim();
+  }
+  _extractPortFromAttributes(attrs) {
+    const keys = ["port", "switch_port", "sw_port", "uplink_port", "port_number", "wired_port"];
+    for (const key of keys) {
+      const match = String(attrs?.[key] ?? "").match(/\d+/);
+      if (match) return Number.parseInt(match[0], 10);
+    }
+    return null;
+  }
+  _extractParentMacFromAttributes(attrs) {
+    const keys = ["sw_mac", "switch_mac", "uplink_mac", "parent_mac", "network_device_mac"];
+    for (const key of keys) {
+      const mac = normalizeMac(attrs?.[key]);
+      if (mac) return mac;
+    }
+    return null;
+  }
+  _buildPortClientIndex() {
+    const deviceMac = normalizeMac(this._ctx?.identity?.primary_mac);
+    if (!deviceMac || !this._hass?.states) return /* @__PURE__ */ new Map();
+    const byPort = /* @__PURE__ */ new Map();
+    for (const [entityId, obj] of Object.entries(this._hass.states)) {
+      if (!entityId.startsWith("device_tracker.")) continue;
+      const attrs = obj?.attributes || {};
+      const parentMac = this._extractParentMacFromAttributes(attrs);
+      if (parentMac !== deviceMac) continue;
+      const port = this._extractPortFromAttributes(attrs);
+      if (!Number.isInteger(port) || port < 1) continue;
+      const name = this._extractClientNameFromStateObj(obj, entityId);
+      if (!byPort.has(port)) byPort.set(port, /* @__PURE__ */ new Set());
+      if (name) byPort.get(port).add(name);
+    }
+    return byPort;
+  }
   _buildSlotData(ctx) {
     const discovered = Array.isArray(ctx?.numberedPorts) ? ctx.numberedPorts : [];
     const numberedRaw = mergePortsWithLayout(ctx?.layout, discovered);
@@ -4741,7 +4780,7 @@ var UnifiDeviceCard = class extends HTMLElement {
       </div>
     `;
   }
-  _renderPortButton(slot, selectedKey) {
+  _renderPortButton(slot, selectedKey, portClientIndex = null) {
     const isSpecial = slot.kind === "special";
     const mediaType = this._portMediaType(slot);
     const isSfp = mediaType !== "rj45";
@@ -4750,13 +4789,16 @@ var UnifiDeviceCard = class extends HTMLElement {
     const poeStatus = getPoeStatus(this._hass, slot);
     const poeOn = poeStatus.active;
     const clientInfo = this._getPortClientInfo(slot);
+    const indexedNames = Number.isInteger(slot?.port) && portClientIndex?.has(slot.port) ? Array.from(portClientIndex.get(slot.port)) : [];
+    const mergedNames = Array.from(/* @__PURE__ */ new Set([...clientInfo?.names || [], ...indexedNames])).slice(0, 8);
+    const mergedCount = Math.max(clientInfo?.count || 0, indexedNames.length);
     const tooltip = [
       slot.port_label || (isSpecial ? slot.label : `${this._t("port_label")} ${slot.label}`),
       this._translateState(getPortLinkText(this._hass, slot)),
       linkUp ? getPortSpeedText(this._hass, slot) : null,
       poeOn ? `${this._t("poe")}${poeStatus.power ? ` ${poeStatus.power}` : " ON"}` : null,
-      clientInfo ? `${this._t("clients")}: ${clientInfo.count}` : null,
-      clientInfo?.names?.length ? clientInfo.names.join(", ") : null
+      mergedCount > 0 ? `${this._t("clients")}: ${mergedCount}` : null,
+      mergedNames.length ? mergedNames.join(", ") : null
     ].filter((v) => v && v !== "\u2014").join(" \xB7 ");
     const classes = [
       "port",
@@ -5604,12 +5646,13 @@ var UnifiDeviceCard = class extends HTMLElement {
     );
     const visibleNumbered = normalizedNumbered.filter((slot) => !specialPortsInUse.has(slot.port));
     const reverseFrontpanel = this._rotate180Enabled(ctx);
+    const portClientIndex = this._buildPortClientIndex();
     const baseRows = this._buildEffectiveRows(ctx, visibleNumbered);
     const effectiveRows = reverseFrontpanel ? baseRows.map((row) => [...row].reverse()).reverse() : baseRows;
     const renderedSpecials = reverseFrontpanel ? [...allSpecials].reverse() : allSpecials;
-    const specialRow = renderedSpecials.length ? `<div class="special-row">${renderedSpecials.map((s) => this._renderPortButton(s, selected?.key)).join("")}</div>` : "";
+    const specialRow = renderedSpecials.length ? `<div class="special-row">${renderedSpecials.map((s) => this._renderPortButton(s, selected?.key, portClientIndex)).join("")}</div>` : "";
     const layoutRows = effectiveRows.map((rowPorts) => {
-      const items = rowPorts.map((portNumber) => visibleNumbered.find((p) => p.port === portNumber)).filter(Boolean).map((slot) => this._renderPortButton(slot, selected?.key)).join("");
+      const items = rowPorts.map((portNumber) => visibleNumbered.find((p) => p.port === portNumber)).filter(Boolean).map((slot) => this._renderPortButton(slot, selected?.key, portClientIndex)).join("");
       const cols = Math.max(1, rowPorts.length);
       return items ? `<div class="port-row" style="grid-template-columns: repeat(${cols}, var(--udc-port-size));">${items}</div>` : "";
     }).filter(Boolean);

--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.e07d5da */
+/* UniFi Device Card 0.0.0-dev.a4075de */
 
 // src/model-registry.js
 function range(start, end) {
@@ -4063,7 +4063,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.e07d5da";
+var VERSION = "0.0.0-dev.a4075de";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var UnifiDeviceCard = class extends HTMLElement {
   static getConfigElement() {
@@ -4334,6 +4334,76 @@ var UnifiDeviceCard = class extends HTMLElement {
     if (!uplink) return null;
     const deviceLabel = String(uplink.via_device_name || uplink.via_mac || "").trim();
     return deviceLabel || null;
+  }
+  _escapeAttr(value) {
+    return String(value ?? "").replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  }
+  _apUplinkTooltip(uplink) {
+    if (!uplink) return "";
+    const lines = [];
+    const kind = String(uplink.kind || "").toLowerCase();
+    if (kind === "mesh") lines.push("Mesh Uplink");
+    else if (kind === "wired") lines.push("Wired Uplink");
+    else lines.push("Uplink");
+    if (uplink.via_device_name) lines.push(`Device: ${uplink.via_device_name}`);
+    if (uplink.remote_port) lines.push(`Port: ${uplink.remote_port}`);
+    if (uplink.via_mac) lines.push(`MAC: ${uplink.via_mac}`);
+    return lines.join(" \xB7 ");
+  }
+  _toClientNames(value) {
+    if (!Array.isArray(value)) return [];
+    const out = [];
+    for (const entry of value) {
+      if (typeof entry === "string" && entry.trim()) {
+        out.push(entry.trim());
+        continue;
+      }
+      if (entry && typeof entry === "object") {
+        const name = entry.name || entry.hostname || entry.client_name || entry.display_name || entry.mac || "";
+        if (String(name).trim()) out.push(String(name).trim());
+      }
+    }
+    return out;
+  }
+  _getPortClientInfo(slot) {
+    const candidates = new Set([
+      slot?.link_entity,
+      slot?.speed_entity,
+      slot?.port_switch_entity,
+      slot?.poe_power_entity,
+      slot?.rx_entity,
+      slot?.tx_entity,
+      ...Array.isArray(slot?.raw_entities) ? slot.raw_entities : []
+    ].filter(Boolean));
+    const numericKeys = [
+      "connected_clients",
+      "client_count",
+      "clients",
+      "num_clients",
+      "active_clients",
+      "station_count"
+    ];
+    const listKeys = ["clients", "connected_clients", "client_list", "stations", "hosts"];
+    let bestCount = null;
+    let bestNames = [];
+    for (const entityId of candidates) {
+      const attrs = stateObj(this._hass, entityId)?.attributes;
+      if (!attrs || typeof attrs !== "object") continue;
+      for (const key of numericKeys) {
+        const raw = attrs[key];
+        const num = Number.parseInt(raw, 10);
+        if (Number.isInteger(num) && num >= 0 && (bestCount == null || num > bestCount)) {
+          bestCount = num;
+        }
+      }
+      for (const key of listKeys) {
+        const names = this._toClientNames(attrs[key]);
+        if (names.length > bestNames.length) bestNames = names;
+      }
+    }
+    if ((bestCount == null || bestCount === 0) && bestNames.length === 0) return null;
+    const count = bestCount != null ? bestCount : bestNames.length;
+    return { count, names: bestNames.slice(0, 8) };
   }
   _buildSlotData(ctx) {
     const discovered = Array.isArray(ctx?.numberedPorts) ? ctx.numberedPorts : [];
@@ -4635,11 +4705,14 @@ var UnifiDeviceCard = class extends HTMLElement {
     const linkUp = isPortConnected(this._hass, slot);
     const poeStatus = getPoeStatus(this._hass, slot);
     const poeOn = poeStatus.active;
+    const clientInfo = this._getPortClientInfo(slot);
     const tooltip = [
       slot.port_label || (isSpecial ? slot.label : `${this._t("port_label")} ${slot.label}`),
       this._translateState(getPortLinkText(this._hass, slot)),
       linkUp ? getPortSpeedText(this._hass, slot) : null,
-      poeOn ? `${this._t("poe")}${poeStatus.power ? ` ${poeStatus.power}` : " ON"}` : null
+      poeOn ? `${this._t("poe")}${poeStatus.power ? ` ${poeStatus.power}` : " ON"}` : null,
+      clientInfo ? `${this._t("clients")}: ${clientInfo.count}` : null,
+      clientInfo?.names?.length ? clientInfo.names.join(", ") : null
     ].filter((v) => v && v !== "\u2014").join(" \xB7 ");
     const classes = [
       "port",
@@ -4676,7 +4749,7 @@ var UnifiDeviceCard = class extends HTMLElement {
           <div class="rj45-floor"></div>
         </div>
       `;
-    return `<button class="${classes}" data-key="${slot.key}" title="${tooltip}">
+    return `<button class="${classes}" data-key="${slot.key}" title="${this._escapeAttr(tooltip)}">
       <div class="port-housing">
         ${housing}
       </div>
@@ -5413,6 +5486,7 @@ var UnifiDeviceCard = class extends HTMLElement {
       const uptime = this._apUptimeState(this._ctx?.uptime_entity);
       const clients = this._wholeNumberState(this._ctx?.clients_entity);
       const apUplink = this._apUplinkText(this._ctx?.ap_uplink);
+      const apUplinkTooltip = this._apUplinkTooltip(this._ctx?.ap_uplink);
       const { ledEntity, ledEnabled, ringColor } = this._apLedState();
       const headerTitle2 = this._title();
       const headerMetrics2 = this._headerMetrics();
@@ -5460,7 +5534,7 @@ var UnifiDeviceCard = class extends HTMLElement {
               ${apUplink ? `
               <div class="detail-item">
                 <div class="detail-label">${this._t("uplink")}</div>
-                <div class="detail-value">${apUplink}</div>
+                <div class="detail-value" title="${this._escapeAttr(apUplinkTooltip)}">${apUplink}</div>
               </div>` : ""}
             </div>
           </div>

--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.0ab4b78 */
+/* UniFi Device Card 0.0.0-dev.8ac8089 */
 
 // src/model-registry.js
 function range(start, end) {
@@ -1340,16 +1340,15 @@ function buildDeviceCapabilities(entities, identity) {
 function normalizeModel(value) {
   return String(value ?? "").toUpperCase().replace(/[^A-Z0-9]/g, "");
 }
-var SWITCH_MODEL_PREFIXES2 = ["USW", "USL", "USPM", "USXG", "USF", "US8", "USC8", "US16", "US24", "US48", "USMINI", "FLEXMINI"];
-var GATEWAY_MODEL_PREFIXES2 = ["UDM", "UCG", "UXG", "UGW", "UDR7", "UDRULT", "UDMPRO", "UDMPROSE"];
-var AP_MODEL_PREFIXES2 = ["UAP", "UAC", "U6", "U7", "UAL", "UAPMESH", "E7", "UWB", "UDB"];
+var EXTRA_GATEWAY_PREFIXES = ["UDR7", "UDRULT", "UDMPRO", "UDMPROSE"];
+var EXTRA_AP_PREFIXES = ["UAC"];
 function startsWithAny(value, prefixes) {
   return prefixes.some((prefix) => value.startsWith(prefix));
 }
 function fromModel(model) {
-  if (startsWithAny(model, GATEWAY_MODEL_PREFIXES2)) return "gateway";
-  if (startsWithAny(model, SWITCH_MODEL_PREFIXES2)) return "switch";
-  if (startsWithAny(model, AP_MODEL_PREFIXES2)) return "access_point";
+  if (startsWithAny(model, [...GATEWAY_MODEL_PREFIXES, ...EXTRA_GATEWAY_PREFIXES])) return "gateway";
+  if (startsWithAny(model, SWITCH_MODEL_PREFIXES)) return "switch";
+  if (startsWithAny(model, [...AP_MODEL_PREFIXES, ...EXTRA_AP_PREFIXES])) return "access_point";
   return null;
 }
 function classifyDeviceType(identity, capabilities, entities = [], device = null) {
@@ -1404,31 +1403,8 @@ function hasUbiquitiManufacturer(device) {
   const m = lower(device?.manufacturer);
   return m.includes("ubiquiti") || m.includes("unifi");
 }
-var SWITCH_MODEL_PREFIXES3 = [
-  "USW",
-  "USL",
-  "USPM",
-  "USXG",
-  "USF",
-  "US8",
-  "USC8",
-  "US16",
-  "US24",
-  "US48",
-  "USMINI",
-  "FLEXMINI"
-];
-var GATEWAY_MODEL_PREFIXES3 = [
-  "UDM",
-  "UCG",
-  "UXG",
-  "UGW",
-  "UDR7",
-  "UDRULT",
-  "UDMPRO",
-  "UDMPROSE"
-];
-var AP_MODEL_PREFIXES3 = ["UAP", "UAC", "U6", "U7", "UAL", "UAPMESH", "E7", "UWB", "UDB"];
+var EXTRA_GATEWAY_PREFIXES2 = ["UDR7", "UDRULT", "UDMPRO", "UDMPROSE"];
+var EXTRA_AP_PREFIXES2 = ["UAC"];
 function normalizeModelStr(value) {
   return String(value ?? "").toUpperCase().replace(/[^A-Z0-9]/g, "");
 }
@@ -1577,9 +1553,11 @@ function isUnifiDevice(device, unifiEntryIds, entities) {
   if (Array.isArray(device?.config_entries) && device.config_entries.some((id) => unifiEntryIds.has(id))) {
     if (hasInfraSignals || !!resolveModelKey(device)) return true;
     if (modelStartsWith2(device, [
-      ...SWITCH_MODEL_PREFIXES3,
-      ...GATEWAY_MODEL_PREFIXES3,
-      ...AP_MODEL_PREFIXES3
+      ...SWITCH_MODEL_PREFIXES,
+      ...GATEWAY_MODEL_PREFIXES,
+      ...EXTRA_GATEWAY_PREFIXES2,
+      ...AP_MODEL_PREFIXES,
+      ...EXTRA_AP_PREFIXES2
     ])) {
       return true;
     }
@@ -1589,7 +1567,13 @@ function isUnifiDevice(device, unifiEntryIds, entities) {
     return false;
   }
   if (resolveModelKey(device)) return true;
-  if (modelStartsWith2(device, [...SWITCH_MODEL_PREFIXES3, ...GATEWAY_MODEL_PREFIXES3, ...AP_MODEL_PREFIXES3])) {
+  if (modelStartsWith2(device, [
+    ...SWITCH_MODEL_PREFIXES,
+    ...GATEWAY_MODEL_PREFIXES,
+    ...EXTRA_GATEWAY_PREFIXES2,
+    ...AP_MODEL_PREFIXES,
+    ...EXTRA_AP_PREFIXES2
+  ])) {
     return true;
   }
   if (entities.some((e) => hasIndexedPortId(e.entity_id)) && hasUbiquitiManufacturer(device)) {
@@ -4107,7 +4091,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.0ab4b78";
+var VERSION = "0.0.0-dev.8ac8089";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var LOG_LEVELS = { error: 0, warn: 1, info: 2, debug: 3, trace: 4 };
 var LOG_STYLES = {

--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.dfc2044 */
+/* UniFi Device Card 0.0.0-dev.ba10883 */
 
 // src/model-registry.js
 function range(start, end) {
@@ -4067,7 +4067,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.dfc2044";
+var VERSION = "0.0.0-dev.ba10883";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var UnifiDeviceCard = class extends HTMLElement {
   static getConfigElement() {
@@ -4337,10 +4337,7 @@ var UnifiDeviceCard = class extends HTMLElement {
   _apUplinkText(uplink) {
     if (!uplink) return null;
     const deviceLabel = String(uplink.via_device_name || uplink.via_mac || "").trim();
-    if (!deviceLabel) return null;
-    const port = String(uplink.remote_port || "").trim();
-    if (port) return `${deviceLabel} \xB7 Port ${port}`;
-    return deviceLabel;
+    return deviceLabel || null;
   }
   _escapeAttr(value) {
     return String(value ?? "").replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");

--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.c7ed3b7 */
+/* UniFi Device Card 0.0.0-dev.47a6788 */
 
 // src/model-registry.js
 function range(start, end) {
@@ -4107,8 +4107,18 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.c7ed3b7";
+var VERSION = "0.0.0-dev.47a6788";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
+var LOG_LEVELS = { error: 0, warn: 1, info: 2, debug: 3, trace: 4 };
+var LOG_STYLES = {
+  badge: "background:#00AEEF;color:#fff;padding:2px 6px;border-radius:2px;font-weight:700;",
+  version: "background:#2a2a2a;color:#fff;padding:2px 6px;border-radius:2px;font-weight:700;",
+  error: "color:#ff5f56;font-weight:700;",
+  warn: "color:#ffbd2e;font-weight:700;",
+  info: "color:#9effa1;font-weight:700;",
+  debug: "color:#8ab4f8;font-weight:700;",
+  trace: "color:#caa7ff;font-weight:700;"
+};
 var UnifiDeviceCard = class extends HTMLElement {
   static getConfigElement() {
     return document.createElement("unifi-device-card-editor");
@@ -4129,6 +4139,34 @@ var UnifiDeviceCard = class extends HTMLElement {
     this._lastMeasuredWidth = 0;
     this._lastMeasuredPanelWidth = 0;
     this._cardSize = 8;
+    this._instanceId = Math.random().toString(36).slice(2, 7);
+  }
+  _configuredLogLevel() {
+    const raw = String(this._config?.log_level || "").toLowerCase().trim();
+    if (raw && Object.prototype.hasOwnProperty.call(LOG_LEVELS, raw)) return raw;
+    if (this._config?.debug === true) return "debug";
+    return "warn";
+  }
+  _shouldLog(level) {
+    const target = LOG_LEVELS[this._configuredLogLevel()];
+    const current = LOG_LEVELS[level];
+    if (current == null || target == null) return false;
+    return current <= target;
+  }
+  _log(level, message, ...args) {
+    if (!this._shouldLog(level)) return;
+    const fn = level === "error" ? "error" : level === "warn" ? "warn" : "log";
+    const levelLabel = level.toUpperCase();
+    const device = this._config?.device_id ? ` ${this._config.device_id}` : "";
+    const header = `%cUNIFI-DEVICE-CARD%c ${levelLabel}%c${device} #${this._instanceId}`;
+    console[fn](
+      header,
+      LOG_STYLES.badge,
+      LOG_STYLES[level] || LOG_STYLES.info,
+      LOG_STYLES.version,
+      message,
+      ...args
+    );
   }
   connectedCallback() {
     if (this._resizeObserver) return;
@@ -4149,6 +4187,10 @@ var UnifiDeviceCard = class extends HTMLElement {
     const newConfig = config || {};
     const newDeviceId = newConfig?.device_id || null;
     this._config = newConfig;
+    this._log("info", "setConfig", {
+      device_id: newDeviceId || null,
+      log_level: this._configuredLogLevel()
+    });
     if (oldDeviceId !== newDeviceId) {
       this._ctx = null;
       this._selectedKey = null;
@@ -4165,6 +4207,7 @@ var UnifiDeviceCard = class extends HTMLElement {
     const previousHass = this._hass;
     this._hass = hass;
     this._ensureLoaded();
+    this._log("trace", "hass update");
     if (!previousHass || !this._ctx || this._hasRelevantStateChanges(previousHass, hass)) {
       this._render();
     }
@@ -4658,6 +4701,7 @@ var UnifiDeviceCard = class extends HTMLElement {
     if (this._loadedDeviceId === currentId && this._ctx) return;
     if (this._loading) return;
     this._loading = true;
+    this._log("debug", "loading device context");
     this._render();
     const token = ++this._loadToken;
     try {
@@ -4665,11 +4709,16 @@ var UnifiDeviceCard = class extends HTMLElement {
       if (token !== this._loadToken) return;
       this._ctx = ctx;
       this._loadedDeviceId = currentId;
+      this._log("info", "context loaded", {
+        type: ctx?.type || null,
+        model: ctx?.model || null,
+        identity_mac: ctx?.identity?.primary_mac || null
+      });
       const { specials, numbered } = this._buildSlotData(ctx);
       const first = specials[0] || numbered[0] || null;
       this._selectedKey = first?.key || null;
     } catch (err) {
-      console.error("[unifi-device-card] Failed to load device context", err);
+      this._log("error", "Failed to load device context", err);
       if (token !== this._loadToken) return;
       this._ctx = null;
       this._loadedDeviceId = null;
@@ -4684,10 +4733,12 @@ var UnifiDeviceCard = class extends HTMLElement {
   async _toggleEntity(entityId) {
     if (!entityId || !this._hass) return;
     const [domain] = entityId.split(".");
+    this._log("debug", "toggle entity", entityId);
     await this._hass.callService(domain, "toggle", { entity_id: entityId });
   }
   async _pressButton(entityId) {
     if (!entityId || !this._hass) return;
+    this._log("debug", "press button", entityId);
     await this._hass.callService("button", "press", { entity_id: entityId });
   }
   _title() {
@@ -5813,5 +5864,9 @@ window.customCards.push({
 });
 if (!window[DEV_LOG_FLAG]) {
   window[DEV_LOG_FLAG] = true;
-  console.info(`[UNIFI-DEVICE-CARD] Version ${VERSION}`);
+  console.log(
+    `%cUNIFI-DEVICE-CARD%c v${VERSION}`,
+    LOG_STYLES.badge,
+    LOG_STYLES.version
+  );
 }

--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.66f0757 */
+/* UniFi Device Card 0.0.0-dev.e07d5da */
 
 // src/model-registry.js
 function range(start, end) {
@@ -1111,6 +1111,278 @@ function getDeviceLayout(device, discoveredPorts = []) {
   };
 }
 
+// src/identity.js
+function normalizeText(value) {
+  return String(value ?? "").trim();
+}
+function normalizeMac(value) {
+  const raw = String(value ?? "").toLowerCase().replace(/[^0-9a-f]/g, "");
+  if (raw.length !== 12) return null;
+  return raw.match(/.{1,2}/g)?.join(":") || null;
+}
+function extractFirstMac(value) {
+  const text = String(value ?? "");
+  const match = text.match(/(?:[0-9a-f]{2}[:-]){5}[0-9a-f]{2}|[0-9a-f]{12}/i);
+  if (!match) return null;
+  return normalizeMac(match[0]);
+}
+function sameMac(a, b) {
+  const left = normalizeMac(a);
+  const right = normalizeMac(b);
+  return !!left && !!right && left === right;
+}
+function extractPrimaryMacFromConnections(connections) {
+  if (!Array.isArray(connections)) return null;
+  for (const entry of connections) {
+    if (!Array.isArray(entry) || entry.length < 2) continue;
+    const [type, value] = entry;
+    const key = String(type ?? "").toLowerCase();
+    if (key !== "mac") continue;
+    const mac = extractFirstMac(value);
+    if (mac) return mac;
+  }
+  for (const entry of connections) {
+    if (!Array.isArray(entry) || entry.length < 2) continue;
+    const mac = extractFirstMac(entry[1]);
+    if (mac) return mac;
+  }
+  return null;
+}
+function buildNormalizedDeviceIdentity(device) {
+  return {
+    device_id: device?.id || null,
+    model: normalizeText(device?.model),
+    manufacturer: normalizeText(device?.manufacturer),
+    name: normalizeText(device?.name_by_user || device?.name),
+    hw_version: normalizeText(device?.hw_version),
+    sw_version: normalizeText(device?.sw_version),
+    primary_mac: extractPrimaryMacFromConnections(device?.connections),
+    config_entries: Array.isArray(device?.config_entries) ? device.config_entries : []
+  };
+}
+function extractDeviceMacs(device) {
+  const macs = /* @__PURE__ */ new Set();
+  const candidates = [device?.connections, device?.identifiers];
+  for (const block of candidates) {
+    if (!Array.isArray(block)) continue;
+    for (const entry of block) {
+      if (!Array.isArray(entry) || entry.length < 2) continue;
+      const [, value] = entry;
+      const mac = extractFirstMac(value);
+      if (mac) macs.add(mac);
+    }
+  }
+  const primaryMac = extractPrimaryMacFromConnections(device?.connections);
+  if (primaryMac) macs.add(primaryMac);
+  return macs;
+}
+function findDeviceByMac(devices, mac) {
+  const normalized = normalizeMac(mac);
+  if (!normalized) return null;
+  for (const device of devices || []) {
+    const macs = extractDeviceMacs(device);
+    if (macs.has(normalized)) return device;
+  }
+  return null;
+}
+
+// src/unique-id.js
+var PORT_FEATURE_PREFIXES = {
+  port: "port_control",
+  power_cycle: "power_cycle",
+  poe_power: "poe_power",
+  port_rx: "port_rx",
+  port_tx: "port_tx",
+  port_bandwidth_rx: "port_rx",
+  port_bandwidth_tx: "port_tx",
+  port_link_speed: "link_speed"
+};
+var DEVICE_FEATURE_PREFIXES = {
+  device_restart: "restart",
+  device_uplink_mac: "uplink_mac",
+  rx: "client_rx",
+  tx: "client_tx",
+  wired_speed: "client_link_speed"
+};
+function parseUnifiPortUniqueId(uniqueId) {
+  const raw = String(uniqueId ?? "").trim().toLowerCase();
+  if (!raw) return null;
+  const match = raw.match(/^([a-z0-9_]+)-([0-9a-f:]{17}|[0-9a-f]{12})_(\d+)$/i);
+  if (!match) return null;
+  const [, prefix, macRaw, portRaw] = match;
+  const feature = PORT_FEATURE_PREFIXES[prefix] || null;
+  const mac = normalizeMac(macRaw);
+  const port = Number.parseInt(portRaw, 10);
+  if (!feature || !mac || !Number.isInteger(port)) return null;
+  return { feature, mac, port };
+}
+function parseUnifiDeviceUniqueId(uniqueId) {
+  const raw = String(uniqueId ?? "").trim().toLowerCase();
+  if (!raw) return null;
+  const match = raw.match(/^([a-z0-9_]+)-([0-9a-f:]{17}|[0-9a-f]{12})$/i);
+  if (!match) return null;
+  const [, prefix, macRaw] = match;
+  const feature = DEVICE_FEATURE_PREFIXES[prefix] || null;
+  const mac = normalizeMac(macRaw);
+  if (!feature || !mac) return null;
+  return { feature, mac };
+}
+function parseUnifiObjectUniqueId(uniqueId) {
+  const raw = String(uniqueId ?? "").trim().toLowerCase();
+  if (!raw) return null;
+  const match = raw.match(/^(wlan|qr_code|regenerate_password|firewall_policy)-(.+)$/i);
+  if (!match) return null;
+  const [, prefix, objectId] = match;
+  const featureMap = {
+    wlan: "wlan_control",
+    qr_code: "wlan_qr_code",
+    regenerate_password: "wlan_regenerate_password",
+    firewall_policy: "firewall_policy"
+  };
+  return {
+    feature: featureMap[prefix] || null,
+    object_id: objectId || null
+  };
+}
+
+// src/capabilities.js
+function emptyBucket() {
+  return { active: 0, disabled: 0, hidden: 0 };
+}
+function statusKey(entity) {
+  if (entity?.disabled_by) return "disabled";
+  if (entity?.hidden_by) return "hidden";
+  return "active";
+}
+function inferCapability(entity, identity) {
+  const domain = String(entity?.entity_id || "").split(".")[0] || "";
+  const tk = String(entity?.translation_key || "").toLowerCase();
+  const uniqueId = entity?.unique_id || "";
+  const portInfo = parseUnifiPortUniqueId(uniqueId);
+  if (portInfo && sameMac(portInfo.mac, identity?.primary_mac)) {
+    if (portInfo.feature === "port_control") return "port_control";
+    if (portInfo.feature === "power_cycle") return "power_cycle";
+    if (portInfo.feature === "poe_power") return "poe_power";
+    if (portInfo.feature === "port_rx") return "port_rx";
+    if (portInfo.feature === "port_tx") return "port_tx";
+    if (portInfo.feature === "link_speed") return "link_speed";
+  }
+  const deviceInfo = parseUnifiDeviceUniqueId(uniqueId);
+  if (deviceInfo && sameMac(deviceInfo.mac, identity?.primary_mac)) {
+    if (deviceInfo.feature === "uplink_mac") return "uplink_mac";
+    if (deviceInfo.feature === "restart") return "restart";
+    if (deviceInfo.feature === "client_rx") return "client_rx";
+    if (deviceInfo.feature === "client_tx") return "client_tx";
+    if (deviceInfo.feature === "client_link_speed") return "link_speed";
+  }
+  const objectInfo = parseUnifiObjectUniqueId(uniqueId);
+  if (objectInfo?.feature === "wlan_control" || tk === "wlan_control") return "wlan_control";
+  if (objectInfo?.feature === "firewall_policy" || tk === "firewall_policy_control") {
+    return "firewall_policy";
+  }
+  if (domain === "button" && (tk === "restart" || tk === "reboot" || tk === "power_cycle")) {
+    return tk === "power_cycle" ? "power_cycle" : "restart";
+  }
+  if (domain === "sensor" && tk === "port_bandwidth_rx") return "port_rx";
+  if (domain === "sensor" && tk === "port_bandwidth_tx") return "port_tx";
+  if (domain === "sensor" && tk === "client_bandwidth_rx") return "client_rx";
+  if (domain === "sensor" && tk === "client_bandwidth_tx") return "client_tx";
+  if (domain === "sensor" && (tk === "port_link_speed" || tk === "link_speed")) return "link_speed";
+  if (domain === "sensor" && (tk === "poe_power" || tk === "port_poe_power" || tk === "poe_power_consumption")) {
+    return "poe_power";
+  }
+  if (domain === "switch" && tk === "poe_port_control") return "port_control";
+  if (domain === "sensor" && tk === "device_uplink_mac") return "uplink_mac";
+  return null;
+}
+function buildDeviceCapabilities(entities, identity) {
+  const counts = {
+    restart: emptyBucket(),
+    ports: emptyBucket(),
+    port_control: emptyBucket(),
+    power_cycle: emptyBucket(),
+    poe_power: emptyBucket(),
+    port_rx: emptyBucket(),
+    port_tx: emptyBucket(),
+    client_rx: emptyBucket(),
+    client_tx: emptyBucket(),
+    link_speed: emptyBucket(),
+    uplink_mac: emptyBucket(),
+    ap_stats: emptyBucket(),
+    led_control: emptyBucket(),
+    wlan_control: emptyBucket(),
+    firewall_policy: emptyBucket()
+  };
+  for (const entity of entities || []) {
+    const status = statusKey(entity);
+    const cap = inferCapability(entity, identity);
+    if (cap && counts[cap]) counts[cap][status] += 1;
+    const portInfo = parseUnifiPortUniqueId(entity?.unique_id || "");
+    if (portInfo && (!identity?.primary_mac || sameMac(portInfo.mac, identity?.primary_mac))) {
+      counts.ports[status] += 1;
+    }
+    const id = String(entity?.entity_id || "").toLowerCase();
+    if (id.startsWith("light.") && (id.includes("led") || String(entity?.translation_key || "").includes("led"))) {
+      counts.led_control[status] += 1;
+    }
+    if (id.startsWith("sensor.") && (id.includes("_clients") || id.includes("_uptime"))) {
+      counts.ap_stats[status] += 1;
+    }
+  }
+  const out = { counts };
+  for (const [key, bucket] of Object.entries(counts)) {
+    out[key] = bucket.active + bucket.disabled + bucket.hidden > 0;
+  }
+  return out;
+}
+
+// src/classify.js
+function normalizeModel(value) {
+  return String(value ?? "").toUpperCase().replace(/[^A-Z0-9]/g, "");
+}
+var SWITCH_MODEL_PREFIXES2 = ["USW", "USL", "USPM", "USXG", "USF", "US8", "USC8", "US16", "US24", "US48", "USMINI", "FLEXMINI"];
+var GATEWAY_MODEL_PREFIXES2 = ["UDM", "UCG", "UXG", "UGW", "UDR7", "UDRULT", "UDMPRO", "UDMPROSE"];
+var AP_MODEL_PREFIXES2 = ["UAP", "UAC", "U6", "U7", "UAL", "UAPMESH", "E7", "UWB", "UDB"];
+function startsWithAny(value, prefixes) {
+  return prefixes.some((prefix) => value.startsWith(prefix));
+}
+function fromModel(model) {
+  if (startsWithAny(model, GATEWAY_MODEL_PREFIXES2)) return "gateway";
+  if (startsWithAny(model, SWITCH_MODEL_PREFIXES2)) return "switch";
+  if (startsWithAny(model, AP_MODEL_PREFIXES2)) return "access_point";
+  return null;
+}
+function classifyDeviceType(identity, capabilities, entities = [], device = null) {
+  const model = normalizeModel(identity?.model || identity?.hw_version || "");
+  const manufacturer = String(identity?.manufacturer || "").toLowerCase();
+  const name = String(identity?.name || "").toLowerCase();
+  const translationKeys = new Set((entities || []).map((entity) => String(entity?.translation_key || "").toLowerCase()));
+  const registryType = fromModel(model);
+  if (registryType) return registryType;
+  const gatewaySignals = model.startsWith("UXG") || model.startsWith("UDM") || model.startsWith("UCG") || model.startsWith("UGW") || name.includes("gateway") || name.includes("router");
+  if (gatewaySignals) return "gateway";
+  if (capabilities?.ap_stats || capabilities?.uplink_mac) return "access_point";
+  if (capabilities?.ports || capabilities?.port_control || capabilities?.poe_power) return "switch";
+  const modelKey = resolveModelKey(device || identity || {});
+  if (modelKey) {
+    if (["UDM", "UDR", "UDMPRO", "UDMPROSE", "UXGPRO", "UXGL", "UGW3", "UGW4", "UCGULTRA", "UCGMAX", "UCGFIBER"].includes(modelKey)) {
+      return "gateway";
+    }
+    if (["USMINI", "USWULTRA", "US8P60", "US8P150", "USL8LP", "USL16LP", "US24PRO", "US48PRO"].includes(modelKey) || modelKey.startsWith("US")) {
+      return "switch";
+    }
+  }
+  if (manufacturer.includes("ubiquiti") || manufacturer.includes("unifi")) {
+    if (name.includes("switch")) return "switch";
+    if (name.includes("access point") || name.includes(" ap")) return "access_point";
+  }
+  if (translationKeys.has("port_control") || translationKeys.has("poe_port_control")) return "switch";
+  if (translationKeys.has("device_uplink_mac")) return "access_point";
+  const entityIds = (entities || []).map((e) => String(e?.entity_id || "").toLowerCase());
+  if (entityIds.some((id) => id.includes("_port_") || id.includes("_sfp_"))) return "switch";
+  return "unknown";
+}
+
 // src/helpers.js
 function normalize(value) {
   return String(value ?? "").trim();
@@ -1132,7 +1404,7 @@ function hasUbiquitiManufacturer(device) {
   const m = lower(device?.manufacturer);
   return m.includes("ubiquiti") || m.includes("unifi");
 }
-var SWITCH_MODEL_PREFIXES2 = [
+var SWITCH_MODEL_PREFIXES3 = [
   "USW",
   "USL",
   "USPM",
@@ -1146,7 +1418,7 @@ var SWITCH_MODEL_PREFIXES2 = [
   "USMINI",
   "FLEXMINI"
 ];
-var GATEWAY_MODEL_PREFIXES2 = [
+var GATEWAY_MODEL_PREFIXES3 = [
   "UDM",
   "UCG",
   "UXG",
@@ -1156,7 +1428,7 @@ var GATEWAY_MODEL_PREFIXES2 = [
   "UDMPRO",
   "UDMPROSE"
 ];
-var AP_MODEL_PREFIXES2 = ["UAP", "UAC", "U6", "U7", "UAL", "UAPMESH", "E7", "UWB", "UDB"];
+var AP_MODEL_PREFIXES3 = ["UAP", "UAC", "U6", "U7", "UAL", "UAPMESH", "E7", "UWB", "UDB"];
 function normalizeModelStr(value) {
   return String(value ?? "").toUpperCase().replace(/[^A-Z0-9]/g, "");
 }
@@ -1172,9 +1444,6 @@ function hasIndexedPortId(entityId) {
 function modelStartsWith2(device, prefixes) {
   const candidates = [device?.model, device?.hw_version].filter(Boolean).map(normalizeModelStr);
   return prefixes.some((pfx) => candidates.some((c) => c.startsWith(pfx)));
-}
-function isDefinitelyAP(device) {
-  return modelStartsWith2(device, AP_MODEL_PREFIXES2);
 }
 function isVirtualControllerDevice(device) {
   const model = lower(device?.model);
@@ -1198,99 +1467,9 @@ function hasInfrastructureEntitySignals(entities = []) {
   });
 }
 function getDeviceType(device, entities = []) {
-  const modelKey = resolveModelKey(device);
-  if (modelKey) {
-    if ([
-      "UCGULTRA",
-      "UDR7",
-      "UDRULT",
-      "UCGMAX",
-      "UCGFIBER",
-      "UDM",
-      "UDR",
-      "UDMPRO",
-      "UDMPROSE",
-      "UDM67A",
-      "UXGPRO",
-      "UXGL",
-      "UGW3",
-      "UGW4"
-    ].includes(modelKey)) {
-      return "gateway";
-    }
-    if ([
-      "USC8",
-      "US8P60",
-      "US8P150",
-      "US16P150",
-      "USMINI",
-      "USF5P",
-      "USWFLEX25G5",
-      "USWFLEX25G8",
-      "USWFLEX25G8POE",
-      "USL8LP",
-      "USL8LPB",
-      "USL16LP",
-      "USL16LPB",
-      "USL16P",
-      "USL24",
-      "USL24P",
-      "USW24P",
-      "USL48",
-      "USL48P",
-      "USW48P",
-      "US24PRO",
-      "US24PRO2",
-      "US48PRO",
-      "US48PRO2",
-      "USPM16",
-      "USPM16P",
-      "USPM24",
-      "USPM24P",
-      "USPM48",
-      "USPM48P",
-      "US68P",
-      "US624P",
-      "US648P",
-      "USXG24",
-      "USWINDUSTRIAL",
-      "USL8A",
-      "USAGGPRO",
-      "USWULTRA",
-      "USWULTRA60W",
-      "USWULTRA210W"
-    ].includes(modelKey)) {
-      return "switch";
-    }
-  }
-  if (modelStartsWith2(device, SWITCH_MODEL_PREFIXES2)) return "switch";
-  if (modelStartsWith2(device, GATEWAY_MODEL_PREFIXES2)) return "gateway";
-  if (isDefinitelyAP(device)) return "access_point";
-  if (modelStartsWith2(device, AP_MODEL_PREFIXES2)) return "access_point";
-  const hasAccessPointSignals = entities.some((entity) => {
-    const id = lower(entity?.entity_id);
-    if (!id) return false;
-    return id.endsWith("_clients") || id.includes("_clients_") || id.endsWith("_uptime") || id.includes("_is_online") || id.includes("_connected");
-  });
-  if (hasAccessPointSignals && hasUbiquitiManufacturer(device)) return "access_point";
-  const hasPorts = entities.some((e) => hasIndexedPortId(e.entity_id));
-  if (hasPorts) return "switch";
-  if (hasUbiquitiManufacturer(device)) {
-    const model = lower(device?.model);
-    const name = lower(device?.name_by_user || device?.name);
-    if (model.includes("udm") || model.includes("ucg") || model.includes("uxg") || model.includes("ugw") || name.includes("gateway")) {
-      return "gateway";
-    }
-    if (model.includes("usw") || model.includes("usl") || model.includes("us8") || model.includes("usc8") || name.includes("switch")) {
-      return "switch";
-    }
-    if (model.includes("uap") || model.includes("uac") || model.includes("u6") || model.includes("u7") || model.includes("ap") || model.includes("in-wall") || model.includes("iw") || model.includes("mesh") || model.includes("nanohd") || name.includes("access point") || name.includes("ap ")) {
-      return "access_point";
-    }
-    if (name.includes("gateway") || name.includes("router")) return "gateway";
-    if (name.includes("switch")) return "switch";
-  }
-  return "unknown";
+  const identity = buildNormalizedDeviceIdentity(device);
+  const capabilities = buildDeviceCapabilities(entities, identity);
+  return classifyDeviceType(identity, capabilities, entities, device);
 }
 function getWSErrorCode(err) {
   if (err?.code != null) return err.code;
@@ -1347,14 +1526,17 @@ async function getAllData(hass) {
   if (inflight) return inflight;
   const promise = (async () => {
     const fallbackDevices = cached?.data?.devices || [];
-    const fallbackEntities = flattenEntitiesByDevice(cached?.data?.entitiesByDevice);
+    const fallbackEntities = flattenEntitiesByDevice(
+      cached?.data?.allEntitiesByDevice || cached?.data?.entitiesByDevice
+    );
     const fallbackConfigEntries = cached?.data?.configEntries || [];
     const [devices, rawEntities, configEntries] = await Promise.all([
       safeCallWS(hass, { type: "config/device_registry/list" }, fallbackDevices),
       safeCallWS(hass, { type: "config/entity_registry/list" }, fallbackEntities),
       safeCallWS(hass, { type: "config/config_entries" }, fallbackConfigEntries)
     ]);
-    const entities = (rawEntities || []).filter((e) => !e.disabled_by && !e.hidden_by);
+    const allEntities = rawEntities || [];
+    const entities = allEntities.filter((e) => !e.disabled_by && !e.hidden_by);
     const entitiesByDevice = /* @__PURE__ */ new Map();
     for (const entity of entities) {
       if (!entity.device_id) continue;
@@ -1363,9 +1545,18 @@ async function getAllData(hass) {
       }
       entitiesByDevice.get(entity.device_id).push(entity);
     }
+    const allEntitiesByDevice = /* @__PURE__ */ new Map();
+    for (const entity of allEntities) {
+      if (!entity.device_id) continue;
+      if (!allEntitiesByDevice.has(entity.device_id)) {
+        allEntitiesByDevice.set(entity.device_id, []);
+      }
+      allEntitiesByDevice.get(entity.device_id).push(entity);
+    }
     const data = {
       devices: devices || [],
       entitiesByDevice,
+      allEntitiesByDevice,
       configEntries: configEntries || []
     };
     if ((data.devices?.length || 0) > 0 || entities.length > 0) {
@@ -1386,9 +1577,9 @@ function isUnifiDevice(device, unifiEntryIds, entities) {
   if (Array.isArray(device?.config_entries) && device.config_entries.some((id) => unifiEntryIds.has(id))) {
     if (hasInfraSignals || !!resolveModelKey(device)) return true;
     if (modelStartsWith2(device, [
-      ...SWITCH_MODEL_PREFIXES2,
-      ...GATEWAY_MODEL_PREFIXES2,
-      ...AP_MODEL_PREFIXES2
+      ...SWITCH_MODEL_PREFIXES3,
+      ...GATEWAY_MODEL_PREFIXES3,
+      ...AP_MODEL_PREFIXES3
     ])) {
       return true;
     }
@@ -1398,7 +1589,7 @@ function isUnifiDevice(device, unifiEntryIds, entities) {
     return false;
   }
   if (resolveModelKey(device)) return true;
-  if (modelStartsWith2(device, [...SWITCH_MODEL_PREFIXES2, ...GATEWAY_MODEL_PREFIXES2, ...AP_MODEL_PREFIXES2])) {
+  if (modelStartsWith2(device, [...SWITCH_MODEL_PREFIXES3, ...GATEWAY_MODEL_PREFIXES3, ...AP_MODEL_PREFIXES3])) {
     return true;
   }
   if (entities.some((e) => hasIndexedPortId(e.entity_id)) && hasUbiquitiManufacturer(device)) {
@@ -1508,17 +1699,6 @@ function getAccessPointStatEntities(entities) {
     led_color_entity: ledColorEntity
   };
 }
-function normalizeMac(value) {
-  const raw = String(value ?? "").toLowerCase().replace(/[^0-9a-f]/g, "");
-  if (raw.length !== 12) return null;
-  return raw.match(/.{1,2}/g)?.join(":") || null;
-}
-function extractFirstMac(value) {
-  const text = String(value ?? "");
-  const match = text.match(/(?:[0-9a-f]{2}[:-]){5}[0-9a-f]{2}|[0-9a-f]{12}/i);
-  if (!match) return null;
-  return normalizeMac(match[0]);
-}
 function safeEntityState(hass, entityId) {
   if (!entityId) return null;
   const raw = String(hass?.states?.[entityId]?.state ?? "").trim();
@@ -1587,38 +1767,6 @@ function discoverApUplinkEntities(entities) {
   }
   return result;
 }
-function extractDeviceMacs(device) {
-  const macs = /* @__PURE__ */ new Set();
-  const candidates = [device?.connections, device?.identifiers];
-  for (const block of candidates) {
-    if (!Array.isArray(block)) continue;
-    for (const entry of block) {
-      if (!Array.isArray(entry) || entry.length < 2) continue;
-      const [, value] = entry;
-      const mac = extractFirstMac(value);
-      if (mac) macs.add(mac);
-    }
-  }
-  if (macs.size > 0) return macs;
-  const fallback = extractFirstMac(
-    JSON.stringify({
-      connections: device?.connections,
-      identifiers: device?.identifiers,
-      configuration_url: device?.configuration_url
-    })
-  );
-  if (fallback) macs.add(fallback);
-  return macs;
-}
-function findDeviceByMac(devices, mac) {
-  const normalized = normalizeMac(mac);
-  if (!normalized) return null;
-  for (const device of devices || []) {
-    const macs = extractDeviceMacs(device);
-    if (macs.has(normalized)) return device;
-  }
-  return null;
-}
 function resolveAccessPointUplink(hass, entities, allDevices) {
   const discovered = discoverApUplinkEntities(entities);
   const uplinkAttrs = readStateAttributes(hass, discovered.uplink_mac_entity);
@@ -1674,13 +1822,15 @@ function getDeviceRebootEntity(entities) {
   return null;
 }
 async function getUnifiDevices(hass) {
-  const { devices, entitiesByDevice, configEntries } = await getAllData(hass);
+  const { devices, entitiesByDevice, allEntitiesByDevice, configEntries } = await getAllData(hass);
   const unifiEntryIds = extractUnifiEntryIds(configEntries);
   const results = [];
   for (const device of devices || []) {
-    const entities = entitiesByDevice.get(device.id) || [];
+    const entities = allEntitiesByDevice?.get(device.id) || entitiesByDevice.get(device.id) || [];
     if (!isUnifiDevice(device, unifiEntryIds, entities)) continue;
-    const type = getDeviceType(device, entities);
+    const identity = buildNormalizedDeviceIdentity(device);
+    const capabilities = buildDeviceCapabilities(entities, identity);
+    const type = classifyDeviceType(identity, capabilities, entities, device);
     if (type !== "switch" && type !== "gateway" && type !== "access_point") continue;
     results.push({
       id: device.id,
@@ -1730,7 +1880,7 @@ async function getRelevantEntityWarningsForDevice(hass, deviceId) {
     safeCallWS(
       hass,
       { type: "config/entity_registry/list" },
-      flattenEntitiesByDevice(cached?.entitiesByDevice)
+      flattenEntitiesByDevice(cached?.allEntitiesByDevice || cached?.entitiesByDevice)
     )
   ]);
   const device = (devices || []).find((d) => d.id === deviceId);
@@ -1766,11 +1916,11 @@ async function getRelevantEntityWarningsForDevice(hass, deviceId) {
   return { disabled, hidden, disabledCount, hiddenCount };
 }
 function extractPortNumber(entity) {
+  const parsedUid = parseUnifiPortUniqueId(entity?.unique_id);
+  if (parsedUid?.port) return parsedUid.port;
   const uid = normalize(entity.unique_id);
   const uidMatch = findIndexedPortIdMatch(uid) || uid.match(/-(\d+)-[a-z]/i);
   if (uidMatch) return parseInt(uidMatch[1], 10);
-  const macPortMatch = uid.match(/[0-9a-f]{2}_(\d+)$/i);
-  if (macPortMatch) return parseInt(macPortMatch[1], 10);
   const eid = lower(entity.entity_id);
   const eidMatch = findIndexedPortIdMatch(eid);
   if (eidMatch) return parseInt(eidMatch[1], 10);
@@ -2266,13 +2416,16 @@ function filterPortsByLayout(discoveredPorts, layout) {
   return discoveredPorts.filter((port) => allowed.has(port.port));
 }
 async function buildDeviceContext(hass, deviceId, cardConfig = null) {
-  const { devices, entitiesByDevice, configEntries } = await getAllData(hass);
+  const { devices, entitiesByDevice, allEntitiesByDevice, configEntries } = await getAllData(hass);
   const unifiEntryIds = extractUnifiEntryIds(configEntries);
   const device = devices.find((d) => d.id === deviceId);
   if (!device) return null;
+  const allEntities = allEntitiesByDevice?.get(deviceId) || entitiesByDevice.get(deviceId) || [];
   let entities = entitiesByDevice.get(deviceId) || [];
-  if (!isUnifiDevice(device, unifiEntryIds, entities)) return null;
-  const type = getDeviceType(device, entities);
+  if (!isUnifiDevice(device, unifiEntryIds, allEntities)) return null;
+  const identity = buildNormalizedDeviceIdentity(device);
+  const capabilities = buildDeviceCapabilities(allEntities, identity);
+  const type = classifyDeviceType(identity, capabilities, allEntities, device);
   if (type !== "switch" && type !== "gateway" && type !== "access_point") return null;
   const needsUID = entities.filter(
     (e) => !e.unique_id && e.translation_key && PORT_TRANSLATION_KEYS.has(e.translation_key) && (!hasIndexedPortId(e.entity_id) || /(?:^|[_-])sfp[_+]?\d+(?:[_-]|$)/i.test(lower(e.entity_id))) && !/\bport\s+\d+\b/i.test(e.original_name || "")
@@ -2312,6 +2465,8 @@ async function buildDeviceContext(hass, deviceId, cardConfig = null) {
   const apUplink = type === "access_point" ? resolveAccessPointUplink(hass, entities, devices) : null;
   return {
     device,
+    identity,
+    capabilities,
     entities,
     type,
     layout,
@@ -3908,7 +4063,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.66f0757";
+var VERSION = "0.0.0-dev.e07d5da";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var UnifiDeviceCard = class extends HTMLElement {
   static getConfigElement() {

--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.1df2c8f */
+/* UniFi Device Card 0.0.0-dev.0ab4b78 */
 
 // src/model-registry.js
 function range(start, end) {
@@ -4107,7 +4107,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.1df2c8f";
+var VERSION = "0.0.0-dev.0ab4b78";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var LOG_LEVELS = { error: 0, warn: 1, info: 2, debug: 3, trace: 4 };
 var LOG_STYLES = {
@@ -4560,7 +4560,7 @@ var UnifiDeviceCard = class extends HTMLElement {
     if (friendly) return friendly;
     return String(entityId || "").replace(/^device_tracker\./i, "").replace(/_/g, " ").trim();
   }
-  _extractPortFromAttributes(attrs) {
+  _extractPortFromAttributes(attrs, entityId = "") {
     const keys = [
       "port",
       "switch_port",
@@ -4576,6 +4576,13 @@ var UnifiDeviceCard = class extends HTMLElement {
       const match = String(attrs?.[key] ?? "").match(/\d+/);
       if (match) return Number.parseInt(match[0], 10);
     }
+    const textKeys = ["connected_to", "uplink", "uplink_source", "source", "network_path", "connection_path"];
+    for (const key of textKeys) {
+      const match = String(attrs?.[key] ?? "").match(/port\D*(\d+)/i);
+      if (match) return Number.parseInt(match[1], 10);
+    }
+    const idMatch = String(entityId || "").match(/(?:^|[_-])port[_-]?(\d+)(?:[_-]|$)/i);
+    if (idMatch) return Number.parseInt(idMatch[1], 10);
     return null;
   }
   _extractParentMacFromAttributes(attrs) {
@@ -4597,15 +4604,39 @@ var UnifiDeviceCard = class extends HTMLElement {
     }
     return null;
   }
+  _extractParentText(attrs) {
+    const textKeys = [
+      "connected_to",
+      "uplink",
+      "uplink_source",
+      "source",
+      "network_device",
+      "network_path",
+      "connection_path",
+      "switch",
+      "parent"
+    ];
+    return textKeys.map((key) => String(attrs?.[key] ?? "").trim()).filter(Boolean).join(" ").toLowerCase();
+  }
+  _matchesParentDevice(attrs, deviceMac) {
+    const parentMac = this._extractParentMacFromAttributes(attrs);
+    if (parentMac) return parentMac === deviceMac;
+    const parentText = this._extractParentText(attrs);
+    if (!parentText) return false;
+    const deviceName = String(this._ctx?.name || "").toLowerCase().trim();
+    const deviceModel = String(this._ctx?.model || "").toLowerCase().trim();
+    if (deviceName && parentText.includes(deviceName)) return true;
+    if (deviceModel && parentText.includes(deviceModel)) return true;
+    return false;
+  }
   _buildPortClientIndex() {
     const deviceMac = normalizeMac(this._ctx?.identity?.primary_mac);
     if (!deviceMac || !this._hass?.states) return /* @__PURE__ */ new Map();
     const byPort = /* @__PURE__ */ new Map();
     for (const [entityId, obj] of Object.entries(this._hass.states)) {
       const attrs = obj?.attributes || {};
-      const parentMac = this._extractParentMacFromAttributes(attrs);
-      if (parentMac !== deviceMac) continue;
-      const port = this._extractPortFromAttributes(attrs);
+      if (!this._matchesParentDevice(attrs, deviceMac)) continue;
+      const port = this._extractPortFromAttributes(attrs, entityId);
       if (!Number.isInteger(port) || port < 1) continue;
       if (!byPort.has(port)) {
         byPort.set(port, { count: 0, names: /* @__PURE__ */ new Set() });

--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.a4075de */
+/* UniFi Device Card 0.0.0-dev.dfc2044 */
 
 // src/model-registry.js
 function range(start, end) {
@@ -1776,7 +1776,11 @@ function resolveAccessPointUplink(hass, entities, allDevices) {
     "uplink_remote_port",
     "remote_port",
     "port",
-    "uplink_port"
+    "uplink_port",
+    "port_number",
+    "remote_port_number",
+    "uplink_port_number",
+    "uplink_port_id"
   ]);
   const uplinkTypeRaw = lower(
     safeEntityState(hass, discovered.uplink_type_entity) || pickAttribute(uplinkAttrs, [
@@ -4063,7 +4067,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.a4075de";
+var VERSION = "0.0.0-dev.dfc2044";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var UnifiDeviceCard = class extends HTMLElement {
   static getConfigElement() {
@@ -4333,7 +4337,10 @@ var UnifiDeviceCard = class extends HTMLElement {
   _apUplinkText(uplink) {
     if (!uplink) return null;
     const deviceLabel = String(uplink.via_device_name || uplink.via_mac || "").trim();
-    return deviceLabel || null;
+    if (!deviceLabel) return null;
+    const port = String(uplink.remote_port || "").trim();
+    if (port) return `${deviceLabel} \xB7 Port ${port}`;
+    return deviceLabel;
   }
   _escapeAttr(value) {
     return String(value ?? "").replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");

--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.bb38695 */
+/* UniFi Device Card 0.0.0-dev.1df2c8f */
 
 // src/model-registry.js
 function range(start, end) {
@@ -4107,7 +4107,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.bb38695";
+var VERSION = "0.0.0-dev.1df2c8f";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var LOG_LEVELS = { error: 0, warn: 1, info: 2, debug: 3, trace: 4 };
 var LOG_STYLES = {
@@ -4531,8 +4531,13 @@ var UnifiDeviceCard = class extends HTMLElement {
     let bestCount = null;
     let bestNames = [];
     for (const entityId of candidates) {
-      const attrs = stateObj(this._hass, entityId)?.attributes;
+      const obj = stateObj(this._hass, entityId);
+      const attrs = obj?.attributes;
       if (!attrs || typeof attrs !== "object") continue;
+      const stateNum = Number.parseInt(String(obj?.state ?? ""), 10);
+      if (Number.isInteger(stateNum) && stateNum >= 0 && (entityId.includes("clients") || String(attrs?.friendly_name || "").toLowerCase().includes("clients"))) {
+        if (bestCount == null || stateNum > bestCount) bestCount = stateNum;
+      }
       for (const key of numericKeys) {
         const raw = attrs[key];
         const num = Number.parseInt(raw, 10);
@@ -4556,7 +4561,17 @@ var UnifiDeviceCard = class extends HTMLElement {
     return String(entityId || "").replace(/^device_tracker\./i, "").replace(/_/g, " ").trim();
   }
   _extractPortFromAttributes(attrs) {
-    const keys = ["port", "switch_port", "sw_port", "uplink_port", "port_number", "wired_port"];
+    const keys = [
+      "port",
+      "switch_port",
+      "sw_port",
+      "uplink_port",
+      "uplink_remote_port",
+      "remote_port",
+      "network_port",
+      "port_number",
+      "wired_port"
+    ];
     for (const key of keys) {
       const match = String(attrs?.[key] ?? "").match(/\d+/);
       if (match) return Number.parseInt(match[0], 10);
@@ -4564,7 +4579,18 @@ var UnifiDeviceCard = class extends HTMLElement {
     return null;
   }
   _extractParentMacFromAttributes(attrs) {
-    const keys = ["sw_mac", "switch_mac", "uplink_mac", "parent_mac", "network_device_mac"];
+    const keys = [
+      "sw_mac",
+      "switch_mac",
+      "uplink_mac",
+      "uplink_device_mac",
+      "wired_uplink_mac",
+      "switch_uplink_mac",
+      "connected_to_mac",
+      "parent_mac",
+      "parent_device_mac",
+      "network_device_mac"
+    ];
     for (const key of keys) {
       const mac = normalizeMac(attrs?.[key]);
       if (mac) return mac;
@@ -4576,15 +4602,30 @@ var UnifiDeviceCard = class extends HTMLElement {
     if (!deviceMac || !this._hass?.states) return /* @__PURE__ */ new Map();
     const byPort = /* @__PURE__ */ new Map();
     for (const [entityId, obj] of Object.entries(this._hass.states)) {
-      if (!entityId.startsWith("device_tracker.")) continue;
       const attrs = obj?.attributes || {};
       const parentMac = this._extractParentMacFromAttributes(attrs);
       if (parentMac !== deviceMac) continue;
       const port = this._extractPortFromAttributes(attrs);
       if (!Number.isInteger(port) || port < 1) continue;
-      const name = this._extractClientNameFromStateObj(obj, entityId);
-      if (!byPort.has(port)) byPort.set(port, /* @__PURE__ */ new Set());
-      if (name) byPort.get(port).add(name);
+      if (!byPort.has(port)) {
+        byPort.set(port, { count: 0, names: /* @__PURE__ */ new Set() });
+      }
+      const entry = byPort.get(port);
+      if (entityId.startsWith("device_tracker.")) {
+        const name = this._extractClientNameFromStateObj(obj, entityId);
+        if (name) entry.names.add(name);
+      }
+      const stateNum = Number.parseInt(String(obj?.state ?? ""), 10);
+      const friendly = String(attrs?.friendly_name || "").toLowerCase();
+      const looksLikeClientCounter = entityId.includes("clients") || friendly.includes("clients") || friendly.includes("ger\xE4te");
+      if (looksLikeClientCounter && Number.isInteger(stateNum) && stateNum >= 0) {
+        entry.count = Math.max(entry.count, stateNum);
+      }
+      const attrNames = this._toClientNames(attrs?.clients || attrs?.connected_clients || attrs?.client_list);
+      for (const name of attrNames) {
+        entry.names.add(name);
+      }
+      entry.count = Math.max(entry.count, entry.names.size);
     }
     return byPort;
   }
@@ -4903,9 +4944,11 @@ var UnifiDeviceCard = class extends HTMLElement {
     const poeStatus = getPoeStatus(this._hass, slot);
     const poeOn = poeStatus.active;
     const clientInfo = this._getPortClientInfo(slot);
-    const indexedNames = Number.isInteger(slot?.port) && portClientIndex?.has(slot.port) ? Array.from(portClientIndex.get(slot.port)) : [];
+    const indexedPortInfo = Number.isInteger(slot?.port) ? portClientIndex?.get(slot.port) : null;
+    const indexedNames = indexedPortInfo?.names ? Array.from(indexedPortInfo.names) : [];
+    const indexedCount = indexedPortInfo?.count || indexedNames.length;
     const mergedNames = Array.from(/* @__PURE__ */ new Set([...clientInfo?.names || [], ...indexedNames])).slice(0, 8);
-    const mergedCount = Math.max(clientInfo?.count || 0, indexedNames.length);
+    const mergedCount = Math.max(clientInfo?.count || 0, indexedCount);
     const tooltip = [
       slot.port_label || (isSpecial ? slot.label : `${this._t("port_label")} ${slot.label}`),
       this._translateState(getPortLinkText(this._hass, slot)),

--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.ba10883 */
+/* UniFi Device Card 0.0.0-dev.07b3261 */
 
 // src/model-registry.js
 function range(start, end) {
@@ -2563,6 +2563,38 @@ function trafficValue(hass, entityId) {
 function hasTraffic(hass, port) {
   return trafficValue(hass, port?.rx_entity) > 0 || trafficValue(hass, port?.tx_entity) > 0;
 }
+function portObservedClientCount(hass, port) {
+  const candidates = [
+    port?.link_entity,
+    port?.speed_entity,
+    port?.port_switch_entity,
+    port?.rx_entity,
+    port?.tx_entity
+  ].filter(Boolean);
+  const numericKeys = [
+    "connected_clients",
+    "client_count",
+    "clients",
+    "num_clients",
+    "active_clients",
+    "station_count"
+  ];
+  const listKeys = ["clients", "connected_clients", "client_list", "stations", "hosts"];
+  let bestCount = 0;
+  for (const entityId of candidates) {
+    const attrs = stateObj(hass, entityId)?.attributes;
+    if (!attrs || typeof attrs !== "object") continue;
+    for (const key of numericKeys) {
+      const num = Number.parseInt(attrs[key], 10);
+      if (Number.isInteger(num) && num > bestCount) bestCount = num;
+    }
+    for (const key of listKeys) {
+      const value = attrs[key];
+      if (Array.isArray(value) && value.length > bestCount) bestCount = value.length;
+    }
+  }
+  return bestCount;
+}
 function isSfpSpecialPort(port) {
   if (port?.kind !== "special") return false;
   const key = lower(port?.physical_key || port?.key || "");
@@ -2579,7 +2611,15 @@ function isPortConnected(hass, port) {
   }
   const speedMbit = parseLinkSpeedMbit(hass, port.speed_entity);
   if (speedMbit != null) {
-    if (speedMbit > 0) return true;
+    if (speedMbit > 0) {
+      if (!isSfpSpecialPort(port) && !port?.link_entity && speedMbit <= 10) {
+        const hasActiveTraffic = hasTraffic(hass, port);
+        const clientCount = portObservedClientCount(hass, port);
+        const poeActive = getPoeStatus(hass, port).active;
+        if (!hasActiveTraffic && clientCount === 0 && !poeActive) return false;
+      }
+      return true;
+    }
     if (speedMbit <= 0) return false;
   }
   const rx = stateValue(hass, port.rx_entity);
@@ -4067,7 +4107,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.ba10883";
+var VERSION = "0.0.0-dev.07b3261";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var UnifiDeviceCard = class extends HTMLElement {
   static getConfigElement() {

--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.47a6788 */
+/* UniFi Device Card 0.0.0-dev.bb38695 */
 
 // src/model-registry.js
 function range(start, end) {
@@ -4107,7 +4107,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.47a6788";
+var VERSION = "0.0.0-dev.bb38695";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var LOG_LEVELS = { error: 0, warn: 1, info: 2, debug: 3, trace: 4 };
 var LOG_STYLES = {
@@ -4167,6 +4167,63 @@ var UnifiDeviceCard = class extends HTMLElement {
       message,
       ...args
     );
+  }
+  _numericState(entityId) {
+    if (!entityId || !this._hass?.states) return null;
+    const raw = this._hass.states[entityId]?.state;
+    if (raw == null || raw === "unknown" || raw === "unavailable") return null;
+    const n = Number.parseFloat(String(raw).replace(",", "."));
+    return Number.isFinite(n) ? n : null;
+  }
+  _buildPortDebugSnapshot(ctx) {
+    if (!ctx || ctx.type !== "switch" && ctx.type !== "gateway") {
+      return {
+        summary: null,
+        ports: []
+      };
+    }
+    const slotData = this._buildSlotData(ctx);
+    const ports = [...slotData?.specials || [], ...slotData?.numbered || []].filter((slot) => Number.isInteger(slot?.port)).sort((a, b) => a.port - b.port);
+    let connected = 0;
+    let poePorts = 0;
+    let trafficPorts = 0;
+    let poeTotalW = 0;
+    const details = ports.map((slot) => {
+      const linkUp = isPortConnected(this._hass, slot);
+      if (linkUp) connected += 1;
+      const poeStatus = getPoeStatus(this._hass, slot);
+      if (poeStatus.active) poePorts += 1;
+      const poeNum = this._numericState(slot?.poe_power_entity);
+      if (poeNum != null && poeNum > 0) poeTotalW += poeNum;
+      const rx = this._numericState(slot?.rx_entity) || 0;
+      const tx = this._numericState(slot?.tx_entity) || 0;
+      const traffic = rx + tx;
+      if (traffic > 0) trafficPorts += 1;
+      return {
+        port: slot.port,
+        link: linkUp ? "up" : "down",
+        speed: getPortSpeedText(this._hass, slot) || null,
+        poe: poeStatus.active ? poeStatus.power || "on" : "off",
+        rx,
+        tx
+      };
+    });
+    const topTraffic = [...details].sort((a, b) => b.rx + b.tx - (a.rx + a.tx)).filter((row) => row.rx + row.tx > 0).slice(0, 5).map((row) => ({
+      port: row.port,
+      rx: row.rx,
+      tx: row.tx
+    }));
+    return {
+      summary: {
+        ports_total: ports.length,
+        ports_connected: connected,
+        ports_with_poe: poePorts,
+        poe_total_w: Number(poeTotalW.toFixed(2)),
+        ports_with_traffic: trafficPorts
+      },
+      ports: details,
+      top_traffic: topTraffic
+    };
   }
   connectedCallback() {
     if (this._resizeObserver) return;
@@ -4709,11 +4766,17 @@ var UnifiDeviceCard = class extends HTMLElement {
       if (token !== this._loadToken) return;
       this._ctx = ctx;
       this._loadedDeviceId = currentId;
+      const portSnapshot = this._buildPortDebugSnapshot(ctx);
       this._log("info", "context loaded", {
         type: ctx?.type || null,
         model: ctx?.model || null,
-        identity_mac: ctx?.identity?.primary_mac || null
+        identity_mac: ctx?.identity?.primary_mac || null,
+        ...portSnapshot.summary || {},
+        top_traffic: portSnapshot.top_traffic || []
       });
+      if (this._shouldLog("debug") && portSnapshot.ports?.length) {
+        this._log("debug", "port snapshot", portSnapshot.ports);
+      }
       const { specials, numbered } = this._buildSlotData(ctx);
       const first = specials[0] || numbered[0] || null;
       this._selectedKey = first?.key || null;

--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.8ac8089 */
+/* UniFi Device Card 0.0.0-dev.114bef3 */
 
 // src/model-registry.js
 function range(start, end) {
@@ -18,9 +18,9 @@ function apModel(displayModel) {
     specialSlots: []
   };
 }
-var AP_MODEL_PREFIXES = ["UAP", "U6", "U7", "UAL", "UAPMESH", "E7", "UWB", "UDB"];
+var AP_MODEL_PREFIXES = ["UAP", "UAC", "U6", "U7", "UAL", "UAPMESH", "E7", "UWB", "UDB"];
 var SWITCH_MODEL_PREFIXES = ["USW", "USL", "USPM", "USXG", "USF", "US8", "USC8", "US16", "US24", "US48", "USMINI", "FLEXMINI", "USM"];
-var GATEWAY_MODEL_PREFIXES = ["UDM", "UCG", "UXG", "UGW", "UDR"];
+var GATEWAY_MODEL_PREFIXES = ["UDM", "UCG", "UXG", "UGW", "UDR", "UDR7", "UDRULT", "UDMPRO", "UDMPROSE"];
 function modelStartsWith(device, prefixes) {
   const candidates = [device?.model, device?.hw_version].filter(Boolean).map(normalizeModelKey);
   return prefixes.some((pfx) => candidates.some((candidate) => candidate.startsWith(pfx)));
@@ -1340,15 +1340,13 @@ function buildDeviceCapabilities(entities, identity) {
 function normalizeModel(value) {
   return String(value ?? "").toUpperCase().replace(/[^A-Z0-9]/g, "");
 }
-var EXTRA_GATEWAY_PREFIXES = ["UDR7", "UDRULT", "UDMPRO", "UDMPROSE"];
-var EXTRA_AP_PREFIXES = ["UAC"];
 function startsWithAny(value, prefixes) {
   return prefixes.some((prefix) => value.startsWith(prefix));
 }
 function fromModel(model) {
-  if (startsWithAny(model, [...GATEWAY_MODEL_PREFIXES, ...EXTRA_GATEWAY_PREFIXES])) return "gateway";
+  if (startsWithAny(model, GATEWAY_MODEL_PREFIXES)) return "gateway";
   if (startsWithAny(model, SWITCH_MODEL_PREFIXES)) return "switch";
-  if (startsWithAny(model, [...AP_MODEL_PREFIXES, ...EXTRA_AP_PREFIXES])) return "access_point";
+  if (startsWithAny(model, AP_MODEL_PREFIXES)) return "access_point";
   return null;
 }
 function classifyDeviceType(identity, capabilities, entities = [], device = null) {
@@ -1403,8 +1401,6 @@ function hasUbiquitiManufacturer(device) {
   const m = lower(device?.manufacturer);
   return m.includes("ubiquiti") || m.includes("unifi");
 }
-var EXTRA_GATEWAY_PREFIXES2 = ["UDR7", "UDRULT", "UDMPRO", "UDMPROSE"];
-var EXTRA_AP_PREFIXES2 = ["UAC"];
 function normalizeModelStr(value) {
   return String(value ?? "").toUpperCase().replace(/[^A-Z0-9]/g, "");
 }
@@ -1555,9 +1551,7 @@ function isUnifiDevice(device, unifiEntryIds, entities) {
     if (modelStartsWith2(device, [
       ...SWITCH_MODEL_PREFIXES,
       ...GATEWAY_MODEL_PREFIXES,
-      ...EXTRA_GATEWAY_PREFIXES2,
-      ...AP_MODEL_PREFIXES,
-      ...EXTRA_AP_PREFIXES2
+      ...AP_MODEL_PREFIXES
     ])) {
       return true;
     }
@@ -1570,9 +1564,7 @@ function isUnifiDevice(device, unifiEntryIds, entities) {
   if (modelStartsWith2(device, [
     ...SWITCH_MODEL_PREFIXES,
     ...GATEWAY_MODEL_PREFIXES,
-    ...EXTRA_GATEWAY_PREFIXES2,
-    ...AP_MODEL_PREFIXES,
-    ...EXTRA_AP_PREFIXES2
+    ...AP_MODEL_PREFIXES
   ])) {
     return true;
   }
@@ -4091,7 +4083,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.8ac8089";
+var VERSION = "0.0.0-dev.114bef3";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var LOG_LEVELS = { error: 0, warn: 1, info: 2, debug: 3, trace: 4 };
 var LOG_STYLES = {

--- a/src/capabilities.js
+++ b/src/capabilities.js
@@ -1,0 +1,109 @@
+import { parseUnifiDeviceUniqueId, parseUnifiObjectUniqueId, parseUnifiPortUniqueId } from "./unique-id.js";
+import { sameMac } from "./identity.js";
+
+// Capability builder:
+// converts raw entity-registry entries into a per-device capability map
+// with active/disabled/hidden counters for diagnostics and rendering decisions.
+
+function emptyBucket() {
+  return { active: 0, disabled: 0, hidden: 0 };
+}
+
+function statusKey(entity) {
+  if (entity?.disabled_by) return "disabled";
+  if (entity?.hidden_by) return "hidden";
+  return "active";
+}
+
+function inferCapability(entity, identity) {
+  const domain = String(entity?.entity_id || "").split(".")[0] || "";
+  const tk = String(entity?.translation_key || "").toLowerCase();
+  const uniqueId = entity?.unique_id || "";
+
+  const portInfo = parseUnifiPortUniqueId(uniqueId);
+  if (portInfo && sameMac(portInfo.mac, identity?.primary_mac)) {
+    if (portInfo.feature === "port_control") return "port_control";
+    if (portInfo.feature === "power_cycle") return "power_cycle";
+    if (portInfo.feature === "poe_power") return "poe_power";
+    if (portInfo.feature === "port_rx") return "port_rx";
+    if (portInfo.feature === "port_tx") return "port_tx";
+    if (portInfo.feature === "link_speed") return "link_speed";
+  }
+
+  const deviceInfo = parseUnifiDeviceUniqueId(uniqueId);
+  if (deviceInfo && sameMac(deviceInfo.mac, identity?.primary_mac)) {
+    if (deviceInfo.feature === "uplink_mac") return "uplink_mac";
+    if (deviceInfo.feature === "restart") return "restart";
+    if (deviceInfo.feature === "client_rx") return "client_rx";
+    if (deviceInfo.feature === "client_tx") return "client_tx";
+    if (deviceInfo.feature === "client_link_speed") return "link_speed";
+  }
+
+  const objectInfo = parseUnifiObjectUniqueId(uniqueId);
+  if (objectInfo?.feature === "wlan_control" || tk === "wlan_control") return "wlan_control";
+  if (objectInfo?.feature === "firewall_policy" || tk === "firewall_policy_control") {
+    return "firewall_policy";
+  }
+
+  if (domain === "button" && (tk === "restart" || tk === "reboot" || tk === "power_cycle")) {
+    return tk === "power_cycle" ? "power_cycle" : "restart";
+  }
+  if (domain === "sensor" && tk === "port_bandwidth_rx") return "port_rx";
+  if (domain === "sensor" && tk === "port_bandwidth_tx") return "port_tx";
+  if (domain === "sensor" && tk === "client_bandwidth_rx") return "client_rx";
+  if (domain === "sensor" && tk === "client_bandwidth_tx") return "client_tx";
+  if (domain === "sensor" && (tk === "port_link_speed" || tk === "link_speed")) return "link_speed";
+  if (domain === "sensor" && (tk === "poe_power" || tk === "port_poe_power" || tk === "poe_power_consumption")) {
+    return "poe_power";
+  }
+  if (domain === "switch" && tk === "poe_port_control") return "port_control";
+  if (domain === "sensor" && tk === "device_uplink_mac") return "uplink_mac";
+
+  return null;
+}
+
+export function buildDeviceCapabilities(entities, identity) {
+  const counts = {
+    restart: emptyBucket(),
+    ports: emptyBucket(),
+    port_control: emptyBucket(),
+    power_cycle: emptyBucket(),
+    poe_power: emptyBucket(),
+    port_rx: emptyBucket(),
+    port_tx: emptyBucket(),
+    client_rx: emptyBucket(),
+    client_tx: emptyBucket(),
+    link_speed: emptyBucket(),
+    uplink_mac: emptyBucket(),
+    ap_stats: emptyBucket(),
+    led_control: emptyBucket(),
+    wlan_control: emptyBucket(),
+    firewall_policy: emptyBucket(),
+  };
+
+  for (const entity of entities || []) {
+    const status = statusKey(entity);
+    const cap = inferCapability(entity, identity);
+
+    if (cap && counts[cap]) counts[cap][status] += 1;
+
+    const portInfo = parseUnifiPortUniqueId(entity?.unique_id || "");
+    if (portInfo && (!identity?.primary_mac || sameMac(portInfo.mac, identity?.primary_mac))) {
+      counts.ports[status] += 1;
+    }
+
+    const id = String(entity?.entity_id || "").toLowerCase();
+    if (id.startsWith("light.") && (id.includes("led") || String(entity?.translation_key || "").includes("led"))) {
+      counts.led_control[status] += 1;
+    }
+    if (id.startsWith("sensor.") && (id.includes("_clients") || id.includes("_uptime"))) {
+      counts.ap_stats[status] += 1;
+    }
+  }
+
+  const out = { counts };
+  for (const [key, bucket] of Object.entries(counts)) {
+    out[key] = (bucket.active + bucket.disabled + bucket.hidden) > 0;
+  }
+  return out;
+}

--- a/src/classify.js
+++ b/src/classify.js
@@ -1,0 +1,69 @@
+import { resolveModelKey } from "./model-registry.js";
+
+// Device classifier:
+// prioritizes registry identity/capabilities first,
+// then falls back to model-registry and lightweight name heuristics.
+
+function normalizeModel(value) {
+  return String(value ?? "").toUpperCase().replace(/[^A-Z0-9]/g, "");
+}
+
+const SWITCH_MODEL_PREFIXES = ["USW", "USL", "USPM", "USXG", "USF", "US8", "USC8", "US16", "US24", "US48", "USMINI", "FLEXMINI"];
+const GATEWAY_MODEL_PREFIXES = ["UDM", "UCG", "UXG", "UGW", "UDR7", "UDRULT", "UDMPRO", "UDMPROSE"];
+const AP_MODEL_PREFIXES = ["UAP", "UAC", "U6", "U7", "UAL", "UAPMESH", "E7", "UWB", "UDB"];
+
+function startsWithAny(value, prefixes) {
+  return prefixes.some((prefix) => value.startsWith(prefix));
+}
+
+function fromModel(model) {
+  if (startsWithAny(model, GATEWAY_MODEL_PREFIXES)) return "gateway";
+  if (startsWithAny(model, SWITCH_MODEL_PREFIXES)) return "switch";
+  if (startsWithAny(model, AP_MODEL_PREFIXES)) return "access_point";
+  return null;
+}
+
+export function classifyDeviceType(identity, capabilities, entities = [], device = null) {
+  const model = normalizeModel(identity?.model || identity?.hw_version || "");
+  const manufacturer = String(identity?.manufacturer || "").toLowerCase();
+  const name = String(identity?.name || "").toLowerCase();
+  const translationKeys = new Set((entities || []).map((entity) => String(entity?.translation_key || "").toLowerCase()));
+
+  const registryType = fromModel(model);
+  if (registryType) return registryType;
+
+  const gatewaySignals =
+    model.startsWith("UXG") ||
+    model.startsWith("UDM") ||
+    model.startsWith("UCG") ||
+    model.startsWith("UGW") ||
+    name.includes("gateway") ||
+    name.includes("router");
+  if (gatewaySignals) return "gateway";
+
+  if (capabilities?.ap_stats || capabilities?.uplink_mac) return "access_point";
+  if (capabilities?.ports || capabilities?.port_control || capabilities?.poe_power) return "switch";
+
+  const modelKey = resolveModelKey(device || identity || {});
+  if (modelKey) {
+    if (["UDM", "UDR", "UDMPRO", "UDMPROSE", "UXGPRO", "UXGL", "UGW3", "UGW4", "UCGULTRA", "UCGMAX", "UCGFIBER"].includes(modelKey)) {
+      return "gateway";
+    }
+    if (["USMINI", "USWULTRA", "US8P60", "US8P150", "USL8LP", "USL16LP", "US24PRO", "US48PRO"].includes(modelKey) || modelKey.startsWith("US")) {
+      return "switch";
+    }
+  }
+
+  if (manufacturer.includes("ubiquiti") || manufacturer.includes("unifi")) {
+    if (name.includes("switch")) return "switch";
+    if (name.includes("access point") || name.includes(" ap")) return "access_point";
+  }
+
+  if (translationKeys.has("port_control") || translationKeys.has("poe_port_control")) return "switch";
+  if (translationKeys.has("device_uplink_mac")) return "access_point";
+
+  const entityIds = (entities || []).map((e) => String(e?.entity_id || "").toLowerCase());
+  if (entityIds.some((id) => id.includes("_port_") || id.includes("_sfp_"))) return "switch";
+
+  return "unknown";
+}

--- a/src/classify.js
+++ b/src/classify.js
@@ -1,4 +1,9 @@
-import { resolveModelKey } from "./model-registry.js";
+import {
+  AP_MODEL_PREFIXES,
+  GATEWAY_MODEL_PREFIXES,
+  resolveModelKey,
+  SWITCH_MODEL_PREFIXES,
+} from "./model-registry.js";
 
 // Device classifier:
 // prioritizes registry identity/capabilities first,
@@ -8,18 +13,17 @@ function normalizeModel(value) {
   return String(value ?? "").toUpperCase().replace(/[^A-Z0-9]/g, "");
 }
 
-const SWITCH_MODEL_PREFIXES = ["USW", "USL", "USPM", "USXG", "USF", "US8", "USC8", "US16", "US24", "US48", "USMINI", "FLEXMINI"];
-const GATEWAY_MODEL_PREFIXES = ["UDM", "UCG", "UXG", "UGW", "UDR7", "UDRULT", "UDMPRO", "UDMPROSE"];
-const AP_MODEL_PREFIXES = ["UAP", "UAC", "U6", "U7", "UAL", "UAPMESH", "E7", "UWB", "UDB"];
+const EXTRA_GATEWAY_PREFIXES = ["UDR7", "UDRULT", "UDMPRO", "UDMPROSE"];
+const EXTRA_AP_PREFIXES = ["UAC"];
 
 function startsWithAny(value, prefixes) {
   return prefixes.some((prefix) => value.startsWith(prefix));
 }
 
 function fromModel(model) {
-  if (startsWithAny(model, GATEWAY_MODEL_PREFIXES)) return "gateway";
+  if (startsWithAny(model, [...GATEWAY_MODEL_PREFIXES, ...EXTRA_GATEWAY_PREFIXES])) return "gateway";
   if (startsWithAny(model, SWITCH_MODEL_PREFIXES)) return "switch";
-  if (startsWithAny(model, AP_MODEL_PREFIXES)) return "access_point";
+  if (startsWithAny(model, [...AP_MODEL_PREFIXES, ...EXTRA_AP_PREFIXES])) return "access_point";
   return null;
 }
 

--- a/src/classify.js
+++ b/src/classify.js
@@ -13,17 +13,14 @@ function normalizeModel(value) {
   return String(value ?? "").toUpperCase().replace(/[^A-Z0-9]/g, "");
 }
 
-const EXTRA_GATEWAY_PREFIXES = ["UDR7", "UDRULT", "UDMPRO", "UDMPROSE"];
-const EXTRA_AP_PREFIXES = ["UAC"];
-
 function startsWithAny(value, prefixes) {
   return prefixes.some((prefix) => value.startsWith(prefix));
 }
 
 function fromModel(model) {
-  if (startsWithAny(model, [...GATEWAY_MODEL_PREFIXES, ...EXTRA_GATEWAY_PREFIXES])) return "gateway";
+  if (startsWithAny(model, GATEWAY_MODEL_PREFIXES)) return "gateway";
   if (startsWithAny(model, SWITCH_MODEL_PREFIXES)) return "switch";
-  if (startsWithAny(model, [...AP_MODEL_PREFIXES, ...EXTRA_AP_PREFIXES])) return "access_point";
+  if (startsWithAny(model, AP_MODEL_PREFIXES)) return "access_point";
   return null;
 }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -74,9 +74,6 @@ function hasUbiquitiManufacturer(device) {
   return m.includes("ubiquiti") || m.includes("unifi");
 }
 
-const EXTRA_GATEWAY_PREFIXES = ["UDR7", "UDRULT", "UDMPRO", "UDMPROSE"];
-const EXTRA_AP_PREFIXES = ["UAC"];
-
 function normalizeModelStr(value) {
   return String(value ?? "").toUpperCase().replace(/[^A-Z0-9]/g, "");
 }
@@ -102,7 +99,7 @@ function modelStartsWith(device, prefixes) {
 }
 
 function isDefinitelyAP(device) {
-  return modelStartsWith(device, [...AP_MODEL_PREFIXES, ...EXTRA_AP_PREFIXES]);
+  return modelStartsWith(device, AP_MODEL_PREFIXES);
 }
 
 function isVirtualControllerDevice(device) {
@@ -299,9 +296,7 @@ function isUnifiDevice(device, unifiEntryIds, entities) {
       modelStartsWith(device, [
         ...SWITCH_MODEL_PREFIXES,
         ...GATEWAY_MODEL_PREFIXES,
-        ...EXTRA_GATEWAY_PREFIXES,
         ...AP_MODEL_PREFIXES,
-        ...EXTRA_AP_PREFIXES,
       ])
     ) {
       return true;
@@ -319,9 +314,7 @@ function isUnifiDevice(device, unifiEntryIds, entities) {
   if (modelStartsWith(device, [
     ...SWITCH_MODEL_PREFIXES,
     ...GATEWAY_MODEL_PREFIXES,
-    ...EXTRA_GATEWAY_PREFIXES,
     ...AP_MODEL_PREFIXES,
-    ...EXTRA_AP_PREFIXES,
   ])) {
     return true;
   }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -3,6 +3,15 @@ import {
   getDeviceLayout,
   resolveModelKey,
 } from "./model-registry.js";
+// Shared architecture modules:
+// identity => canonical device identity + MAC helpers
+// capabilities => per-device feature matrix
+// classify => device type decision
+// unique-id => stable UniFi unique_id parsing helpers
+import { buildNormalizedDeviceIdentity, extractFirstMac, findDeviceByMac } from "./identity.js";
+import { buildDeviceCapabilities } from "./capabilities.js";
+import { classifyDeviceType } from "./classify.js";
+import { parseUnifiPortUniqueId } from "./unique-id.js";
 
 // ─────────────────────────────────────────────────
 // String utilities
@@ -157,143 +166,9 @@ function hasInfrastructureEntitySignals(entities = []) {
 }
 
 export function getDeviceType(device, entities = []) {
-  const modelKey = resolveModelKey(device);
-  if (modelKey) {
-    if (
-      [
-        "UCGULTRA",
-        "UDR7",
-        "UDRULT",
-        "UCGMAX",
-        "UCGFIBER",
-        "UDM",
-        "UDR",
-        "UDMPRO",
-        "UDMPROSE",
-        "UDM67A",
-        "UXGPRO",
-        "UXGL",
-        "UGW3",
-        "UGW4",
-      ].includes(modelKey)
-    ) {
-      return "gateway";
-    }
-
-    if (
-      [
-        "USC8",
-        "US8P60",
-        "US8P150",
-        "US16P150",
-        "USMINI",
-        "USF5P",
-        "USWFLEX25G5",
-        "USWFLEX25G8",
-        "USWFLEX25G8POE",
-        "USL8LP",
-        "USL8LPB",
-        "USL16LP",
-        "USL16LPB",
-        "USL16P",
-        "USL24",
-        "USL24P",
-        "USW24P",
-        "USL48",
-        "USL48P",
-        "USW48P",
-        "US24PRO",
-        "US24PRO2",
-        "US48PRO",
-        "US48PRO2",
-        "USPM16",
-        "USPM16P",
-        "USPM24",
-        "USPM24P",
-        "USPM48",
-        "USPM48P",
-        "US68P",
-        "US624P",
-        "US648P",
-        "USXG24",
-        "USWINDUSTRIAL",
-        "USL8A",
-        "USAGGPRO",
-        "USWULTRA",
-        "USWULTRA60W",
-        "USWULTRA210W",
-      ].includes(modelKey)
-    ) {
-      return "switch";
-    }
-  }
-
-  if (modelStartsWith(device, SWITCH_MODEL_PREFIXES)) return "switch";
-  if (modelStartsWith(device, GATEWAY_MODEL_PREFIXES)) return "gateway";
-  if (isDefinitelyAP(device)) return "access_point";
-  if (modelStartsWith(device, AP_MODEL_PREFIXES)) return "access_point";
-
-  const hasAccessPointSignals = entities.some((entity) => {
-    const id = lower(entity?.entity_id);
-    if (!id) return false;
-    return (
-      id.endsWith("_clients") ||
-      id.includes("_clients_") ||
-      id.endsWith("_uptime") ||
-      id.includes("_is_online") ||
-      id.includes("_connected")
-    );
-  });
-  if (hasAccessPointSignals && hasUbiquitiManufacturer(device)) return "access_point";
-
-  const hasPorts = entities.some((e) => hasIndexedPortId(e.entity_id));
-  if (hasPorts) return "switch";
-
-  if (hasUbiquitiManufacturer(device)) {
-    const model = lower(device?.model);
-    const name = lower(device?.name_by_user || device?.name);
-
-    if (
-      model.includes("udm") ||
-      model.includes("ucg") ||
-      model.includes("uxg") ||
-      model.includes("ugw") ||
-      name.includes("gateway")
-    ) {
-      return "gateway";
-    }
-
-    if (
-      model.includes("usw") ||
-      model.includes("usl") ||
-      model.includes("us8") ||
-      model.includes("usc8") ||
-      name.includes("switch")
-    ) {
-      return "switch";
-    }
-
-    if (
-      model.includes("uap") ||
-      model.includes("uac") ||
-      model.includes("u6") ||
-      model.includes("u7") ||
-      model.includes("ap") ||
-      model.includes("in-wall") ||
-      model.includes("iw") ||
-      model.includes("mesh") ||
-      model.includes("nanohd") ||
-      name.includes("access point") ||
-      name.includes("ap ")
-    ) {
-      return "access_point";
-    }
-
-    if (name.includes("gateway") || name.includes("router")) return "gateway";
-    if (name.includes("switch")) return "switch";
-  }
-
-  return "unknown";
+  const identity = buildNormalizedDeviceIdentity(device);
+  const capabilities = buildDeviceCapabilities(entities, identity);
+  return classifyDeviceType(identity, capabilities, entities, device);
 }
 
 // ─────────────────────────────────────────────────
@@ -377,7 +252,9 @@ export async function getAllData(hass) {
 
   const promise = (async () => {
     const fallbackDevices = cached?.data?.devices || [];
-    const fallbackEntities = flattenEntitiesByDevice(cached?.data?.entitiesByDevice);
+    const fallbackEntities = flattenEntitiesByDevice(
+      cached?.data?.allEntitiesByDevice || cached?.data?.entitiesByDevice
+    );
     const fallbackConfigEntries = cached?.data?.configEntries || [];
 
     const [devices, rawEntities, configEntries] = await Promise.all([
@@ -386,7 +263,8 @@ export async function getAllData(hass) {
       safeCallWS(hass, { type: "config/config_entries" }, fallbackConfigEntries),
     ]);
 
-    const entities = (rawEntities || []).filter((e) => !e.disabled_by && !e.hidden_by);
+    const allEntities = rawEntities || [];
+    const entities = allEntities.filter((e) => !e.disabled_by && !e.hidden_by);
 
     const entitiesByDevice = new Map();
     for (const entity of entities) {
@@ -397,9 +275,19 @@ export async function getAllData(hass) {
       entitiesByDevice.get(entity.device_id).push(entity);
     }
 
+    const allEntitiesByDevice = new Map();
+    for (const entity of allEntities) {
+      if (!entity.device_id) continue;
+      if (!allEntitiesByDevice.has(entity.device_id)) {
+        allEntitiesByDevice.set(entity.device_id, []);
+      }
+      allEntitiesByDevice.get(entity.device_id).push(entity);
+    }
+
     const data = {
       devices: devices || [],
       entitiesByDevice,
+      allEntitiesByDevice,
       configEntries: configEntries || [],
     };
 
@@ -632,21 +520,6 @@ export function getAccessPointStatEntities(entities) {
   };
 }
 
-function normalizeMac(value) {
-  const raw = String(value ?? "")
-    .toLowerCase()
-    .replace(/[^0-9a-f]/g, "");
-  if (raw.length !== 12) return null;
-  return raw.match(/.{1,2}/g)?.join(":") || null;
-}
-
-function extractFirstMac(value) {
-  const text = String(value ?? "");
-  const match = text.match(/(?:[0-9a-f]{2}[:-]){5}[0-9a-f]{2}|[0-9a-f]{12}/i);
-  if (!match) return null;
-  return normalizeMac(match[0]);
-}
-
 function safeEntityState(hass, entityId) {
   if (!entityId) return null;
   const raw = String(hass?.states?.[entityId]?.state ?? "").trim();
@@ -750,44 +623,6 @@ function discoverApUplinkEntities(entities) {
   }
 
   return result;
-}
-
-function extractDeviceMacs(device) {
-  const macs = new Set();
-  const candidates = [device?.connections, device?.identifiers];
-
-  for (const block of candidates) {
-    if (!Array.isArray(block)) continue;
-    for (const entry of block) {
-      if (!Array.isArray(entry) || entry.length < 2) continue;
-      const [, value] = entry;
-      const mac = extractFirstMac(value);
-      if (mac) macs.add(mac);
-    }
-  }
-
-  if (macs.size > 0) return macs;
-
-  const fallback = extractFirstMac(
-    JSON.stringify({
-      connections: device?.connections,
-      identifiers: device?.identifiers,
-      configuration_url: device?.configuration_url,
-    })
-  );
-  if (fallback) macs.add(fallback);
-  return macs;
-}
-
-function findDeviceByMac(devices, mac) {
-  const normalized = normalizeMac(mac);
-  if (!normalized) return null;
-
-  for (const device of devices || []) {
-    const macs = extractDeviceMacs(device);
-    if (macs.has(normalized)) return device;
-  }
-  return null;
 }
 
 function resolveAccessPointUplink(hass, entities, allDevices) {
@@ -903,15 +738,17 @@ export function getDeviceRebootEntity(entities) {
 // ─────────────────────────────────────────────────
 
 export async function getUnifiDevices(hass) {
-  const { devices, entitiesByDevice, configEntries } = await getAllData(hass);
+  const { devices, entitiesByDevice, allEntitiesByDevice, configEntries } = await getAllData(hass);
   const unifiEntryIds = extractUnifiEntryIds(configEntries);
 
   const results = [];
   for (const device of devices || []) {
-    const entities = entitiesByDevice.get(device.id) || [];
+    const entities = allEntitiesByDevice?.get(device.id) || entitiesByDevice.get(device.id) || [];
     if (!isUnifiDevice(device, unifiEntryIds, entities)) continue;
 
-    const type = getDeviceType(device, entities);
+    const identity = buildNormalizedDeviceIdentity(device);
+    const capabilities = buildDeviceCapabilities(entities, identity);
+    const type = classifyDeviceType(identity, capabilities, entities, device);
     if (type !== "switch" && type !== "gateway" && type !== "access_point") continue;
 
     results.push({
@@ -1015,7 +852,7 @@ export async function getRelevantEntityWarningsForDevice(hass, deviceId) {
     safeCallWS(
       hass,
       { type: "config/entity_registry/list" },
-      flattenEntitiesByDevice(cached?.entitiesByDevice)
+      flattenEntitiesByDevice(cached?.allEntitiesByDevice || cached?.entitiesByDevice)
     ),
   ]);
 
@@ -1066,17 +903,13 @@ export const getDeviceWarningInfo = getRelevantEntityWarningsForDevice;
 // ─────────────────────────────────────────────────
 
 function extractPortNumber(entity) {
+  const parsedUid = parseUnifiPortUniqueId(entity?.unique_id);
+  if (parsedUid?.port) return parsedUid.port;
+
   const uid = normalize(entity.unique_id);
   const uidMatch = findIndexedPortIdMatch(uid) || uid.match(/-(\d+)-[a-z]/i);
 
   if (uidMatch) return parseInt(uidMatch[1], 10);
-
-  // UniFi HA integration unique_ids use "translation_key-{mac}_{portNum}" format.
-  // e.g. "port_link_speed-f4:92:bf:92:19:d5_23" → port 23.
-  // Must be checked before entity_id fallback to prevent SFP entities (whose
-  // entity_id contains "_sfp_1_") from mapping to the wrong port number.
-  const macPortMatch = uid.match(/[0-9a-f]{2}_(\d+)$/i);
-  if (macPortMatch) return parseInt(macPortMatch[1], 10);
 
   const eid = lower(entity.entity_id);
   const eidMatch = findIndexedPortIdMatch(eid);
@@ -1830,16 +1663,19 @@ function filterPortsByLayout(discoveredPorts, layout) {
 }
 
 async function buildDeviceContext(hass, deviceId, cardConfig = null) {
-  const { devices, entitiesByDevice, configEntries } = await getAllData(hass);
+  const { devices, entitiesByDevice, allEntitiesByDevice, configEntries } = await getAllData(hass);
   const unifiEntryIds = extractUnifiEntryIds(configEntries);
 
   const device = devices.find((d) => d.id === deviceId);
   if (!device) return null;
 
+  const allEntities = allEntitiesByDevice?.get(deviceId) || entitiesByDevice.get(deviceId) || [];
   let entities = entitiesByDevice.get(deviceId) || [];
-  if (!isUnifiDevice(device, unifiEntryIds, entities)) return null;
+  if (!isUnifiDevice(device, unifiEntryIds, allEntities)) return null;
 
-  const type = getDeviceType(device, entities);
+  const identity = buildNormalizedDeviceIdentity(device);
+  const capabilities = buildDeviceCapabilities(allEntities, identity);
+  const type = classifyDeviceType(identity, capabilities, allEntities, device);
   if (type !== "switch" && type !== "gateway" && type !== "access_point") return null;
 
   const needsUID = entities.filter(
@@ -1896,6 +1732,8 @@ async function buildDeviceContext(hass, deviceId, cardConfig = null) {
 
   return {
     device,
+    identity,
+    capabilities,
     entities,
     type,
     layout,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -635,6 +635,10 @@ function resolveAccessPointUplink(hass, entities, allDevices) {
     "remote_port",
     "port",
     "uplink_port",
+    "port_number",
+    "remote_port_number",
+    "uplink_port_number",
+    "uplink_port_id",
   ]);
   const uplinkTypeRaw = lower(
     safeEntityState(hass, discovered.uplink_type_entity) || pickAttribute(uplinkAttrs, [

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1857,6 +1857,45 @@ function hasTraffic(hass, port) {
   return trafficValue(hass, port?.rx_entity) > 0 || trafficValue(hass, port?.tx_entity) > 0;
 }
 
+function portObservedClientCount(hass, port) {
+  const candidates = [
+    port?.link_entity,
+    port?.speed_entity,
+    port?.port_switch_entity,
+    port?.rx_entity,
+    port?.tx_entity,
+  ].filter(Boolean);
+
+  const numericKeys = [
+    "connected_clients",
+    "client_count",
+    "clients",
+    "num_clients",
+    "active_clients",
+    "station_count",
+  ];
+
+  const listKeys = ["clients", "connected_clients", "client_list", "stations", "hosts"];
+  let bestCount = 0;
+
+  for (const entityId of candidates) {
+    const attrs = stateObj(hass, entityId)?.attributes;
+    if (!attrs || typeof attrs !== "object") continue;
+
+    for (const key of numericKeys) {
+      const num = Number.parseInt(attrs[key], 10);
+      if (Number.isInteger(num) && num > bestCount) bestCount = num;
+    }
+
+    for (const key of listKeys) {
+      const value = attrs[key];
+      if (Array.isArray(value) && value.length > bestCount) bestCount = value.length;
+    }
+  }
+
+  return bestCount;
+}
+
 function isSfpSpecialPort(port) {
   if (port?.kind !== "special") return false;
 
@@ -1895,7 +1934,19 @@ export function isPortConnected(hass, port) {
 
   const speedMbit = parseLinkSpeedMbit(hass, port.speed_entity);
   if (speedMbit != null) {
-    if (speedMbit > 0) return true;
+    if (speedMbit > 0) {
+      // RJ45 ghost-link guard:
+      // Some setups report persistent 10 Mbit on idle/disconnected copper ports.
+      // If no explicit link sensor exists and we have neither traffic, clients, nor PoE activity,
+      // treat 10 Mbit as not connected to avoid false "up" LEDs.
+      if (!isSfpSpecialPort(port) && !port?.link_entity && speedMbit <= 10) {
+        const hasActiveTraffic = hasTraffic(hass, port);
+        const clientCount = portObservedClientCount(hass, port);
+        const poeActive = getPoeStatus(hass, port).active;
+        if (!hasActiveTraffic && clientCount === 0 && !poeActive) return false;
+      }
+      return true;
+    }
     if (speedMbit <= 0) return false;
   }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,7 +1,10 @@
 import {
+  AP_MODEL_PREFIXES,
   applyPortsPerRowOverride,
+  GATEWAY_MODEL_PREFIXES,
   getDeviceLayout,
   resolveModelKey,
+  SWITCH_MODEL_PREFIXES,
 } from "./model-registry.js";
 // Shared architecture modules:
 // identity => canonical device identity + MAC helpers
@@ -71,33 +74,8 @@ function hasUbiquitiManufacturer(device) {
   return m.includes("ubiquiti") || m.includes("unifi");
 }
 
-const SWITCH_MODEL_PREFIXES = [
-  "USW",
-  "USL",
-  "USPM",
-  "USXG",
-  "USF",
-  "US8",
-  "USC8",
-  "US16",
-  "US24",
-  "US48",
-  "USMINI",
-  "FLEXMINI",
-];
-
-const GATEWAY_MODEL_PREFIXES = [
-  "UDM",
-  "UCG",
-  "UXG",
-  "UGW",
-  "UDR7",
-  "UDRULT",
-  "UDMPRO",
-  "UDMPROSE",
-];
-
-const AP_MODEL_PREFIXES = ["UAP", "UAC", "U6", "U7", "UAL", "UAPMESH", "E7", "UWB", "UDB"];
+const EXTRA_GATEWAY_PREFIXES = ["UDR7", "UDRULT", "UDMPRO", "UDMPROSE"];
+const EXTRA_AP_PREFIXES = ["UAC"];
 
 function normalizeModelStr(value) {
   return String(value ?? "").toUpperCase().replace(/[^A-Z0-9]/g, "");
@@ -124,7 +102,7 @@ function modelStartsWith(device, prefixes) {
 }
 
 function isDefinitelyAP(device) {
-  return modelStartsWith(device, AP_MODEL_PREFIXES);
+  return modelStartsWith(device, [...AP_MODEL_PREFIXES, ...EXTRA_AP_PREFIXES]);
 }
 
 function isVirtualControllerDevice(device) {
@@ -321,7 +299,9 @@ function isUnifiDevice(device, unifiEntryIds, entities) {
       modelStartsWith(device, [
         ...SWITCH_MODEL_PREFIXES,
         ...GATEWAY_MODEL_PREFIXES,
+        ...EXTRA_GATEWAY_PREFIXES,
         ...AP_MODEL_PREFIXES,
+        ...EXTRA_AP_PREFIXES,
       ])
     ) {
       return true;
@@ -336,7 +316,13 @@ function isUnifiDevice(device, unifiEntryIds, entities) {
 
   if (resolveModelKey(device)) return true;
 
-  if (modelStartsWith(device, [...SWITCH_MODEL_PREFIXES, ...GATEWAY_MODEL_PREFIXES, ...AP_MODEL_PREFIXES])) {
+  if (modelStartsWith(device, [
+    ...SWITCH_MODEL_PREFIXES,
+    ...GATEWAY_MODEL_PREFIXES,
+    ...EXTRA_GATEWAY_PREFIXES,
+    ...AP_MODEL_PREFIXES,
+    ...EXTRA_AP_PREFIXES,
+  ])) {
     return true;
   }
 

--- a/src/identity.js
+++ b/src/identity.js
@@ -1,0 +1,103 @@
+// Identity helpers:
+// - normalize MACs
+// - extract primary MAC from HA device connections
+// - build canonical device identity object used across the card
+
+function normalizeText(value) {
+  return String(value ?? "").trim();
+}
+
+export function normalizeMac(value) {
+  const raw = String(value ?? "")
+    .toLowerCase()
+    .replace(/[^0-9a-f]/g, "");
+  if (raw.length !== 12) return null;
+  return raw.match(/.{1,2}/g)?.join(":") || null;
+}
+
+export function extractFirstMac(value) {
+  const text = String(value ?? "");
+  const match = text.match(/(?:[0-9a-f]{2}[:-]){5}[0-9a-f]{2}|[0-9a-f]{12}/i);
+  if (!match) return null;
+  return normalizeMac(match[0]);
+}
+
+export function sameMac(a, b) {
+  const left = normalizeMac(a);
+  const right = normalizeMac(b);
+  return !!left && !!right && left === right;
+}
+
+export function extractPrimaryMacFromConnections(connections) {
+  if (!Array.isArray(connections)) return null;
+
+  for (const entry of connections) {
+    if (!Array.isArray(entry) || entry.length < 2) continue;
+    const [type, value] = entry;
+    const key = String(type ?? "").toLowerCase();
+    if (key !== "mac") continue;
+    const mac = extractFirstMac(value);
+    if (mac) return mac;
+  }
+
+  for (const entry of connections) {
+    if (!Array.isArray(entry) || entry.length < 2) continue;
+    const mac = extractFirstMac(entry[1]);
+    if (mac) return mac;
+  }
+
+  return null;
+}
+
+export function buildNormalizedDeviceIdentity(device) {
+  return {
+    device_id: device?.id || null,
+    model: normalizeText(device?.model),
+    manufacturer: normalizeText(device?.manufacturer),
+    name: normalizeText(device?.name_by_user || device?.name),
+    hw_version: normalizeText(device?.hw_version),
+    sw_version: normalizeText(device?.sw_version),
+    primary_mac: extractPrimaryMacFromConnections(device?.connections),
+    config_entries: Array.isArray(device?.config_entries) ? device.config_entries : [],
+  };
+}
+
+function extractDeviceMacs(device) {
+  const macs = new Set();
+  const candidates = [device?.connections, device?.identifiers];
+
+  for (const block of candidates) {
+    if (!Array.isArray(block)) continue;
+    for (const entry of block) {
+      if (!Array.isArray(entry) || entry.length < 2) continue;
+      const [, value] = entry;
+      const mac = extractFirstMac(value);
+      if (mac) macs.add(mac);
+    }
+  }
+
+  const primaryMac = extractPrimaryMacFromConnections(device?.connections);
+  if (primaryMac) macs.add(primaryMac);
+
+  return macs;
+}
+
+export function findDeviceByMac(devices, mac) {
+  const normalized = normalizeMac(mac);
+  if (!normalized) return null;
+
+  for (const device of devices || []) {
+    const macs = extractDeviceMacs(device);
+    if (macs.has(normalized)) return device;
+  }
+  return null;
+}
+
+export function findEntitiesByMac(entities, mac) {
+  const normalized = normalizeMac(mac);
+  if (!normalized) return [];
+  return (entities || []).filter((entity) => {
+    const uniqueIdMac = extractFirstMac(entity?.unique_id);
+    return uniqueIdMac === normalized;
+  });
+}

--- a/src/model-registry.js
+++ b/src/model-registry.js
@@ -28,9 +28,9 @@ function apModel(displayModel) {
   };
 }
 
-const AP_MODEL_PREFIXES = ["UAP", "U6", "U7", "UAL", "UAPMESH", "E7", "UWB", "UDB"];
-const SWITCH_MODEL_PREFIXES = ["USW", "USL", "USPM", "USXG", "USF", "US8", "USC8", "US16", "US24", "US48", "USMINI", "FLEXMINI", "USM"];
-const GATEWAY_MODEL_PREFIXES = ["UDM", "UCG", "UXG", "UGW", "UDR"];
+export const AP_MODEL_PREFIXES = ["UAP", "U6", "U7", "UAL", "UAPMESH", "E7", "UWB", "UDB"];
+export const SWITCH_MODEL_PREFIXES = ["USW", "USL", "USPM", "USXG", "USF", "US8", "USC8", "US16", "US24", "US48", "USMINI", "FLEXMINI", "USM"];
+export const GATEWAY_MODEL_PREFIXES = ["UDM", "UCG", "UXG", "UGW", "UDR"];
 
 function modelStartsWith(device, prefixes) {
   const candidates = [device?.model, device?.hw_version]

--- a/src/model-registry.js
+++ b/src/model-registry.js
@@ -28,9 +28,9 @@ function apModel(displayModel) {
   };
 }
 
-export const AP_MODEL_PREFIXES = ["UAP", "U6", "U7", "UAL", "UAPMESH", "E7", "UWB", "UDB"];
+export const AP_MODEL_PREFIXES = ["UAP", "UAC", "U6", "U7", "UAL", "UAPMESH", "E7", "UWB", "UDB"];
 export const SWITCH_MODEL_PREFIXES = ["USW", "USL", "USPM", "USXG", "USF", "US8", "USC8", "US16", "US24", "US48", "USMINI", "FLEXMINI", "USM"];
-export const GATEWAY_MODEL_PREFIXES = ["UDM", "UCG", "UXG", "UGW", "UDR"];
+export const GATEWAY_MODEL_PREFIXES = ["UDM", "UCG", "UXG", "UGW", "UDR", "UDR7", "UDRULT", "UDMPRO", "UDMPROSE"];
 
 function modelStartsWith(device, prefixes) {
   const candidates = [device?.model, device?.hw_version]

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -340,7 +340,11 @@ class UnifiDeviceCard extends HTMLElement {
   _apUplinkText(uplink) {
     if (!uplink) return null;
     const deviceLabel = String(uplink.via_device_name || uplink.via_mac || "").trim();
-    return deviceLabel || null;
+    if (!deviceLabel) return null;
+
+    const port = String(uplink.remote_port || "").trim();
+    if (port) return `${deviceLabel} · Port ${port}`;
+    return deviceLabel;
   }
 
   _escapeAttr(value) {

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -13,6 +13,7 @@ import {
   parseLinkSpeedMbit,
   stateObj,
 } from "./helpers.js";
+import { normalizeMac } from "./identity.js";
 import { t } from "./translations.js";
 import "./unifi-device-card-editor.js";
 
@@ -436,6 +437,56 @@ class UnifiDeviceCard extends HTMLElement {
     return { count, names: bestNames.slice(0, 8) };
   }
 
+  _extractClientNameFromStateObj(obj, entityId) {
+    const attrs = obj?.attributes || {};
+    const friendly = String(attrs.friendly_name || "").trim();
+    if (friendly) return friendly;
+    return String(entityId || "")
+      .replace(/^device_tracker\./i, "")
+      .replace(/_/g, " ")
+      .trim();
+  }
+
+  _extractPortFromAttributes(attrs) {
+    const keys = ["port", "switch_port", "sw_port", "uplink_port", "port_number", "wired_port"];
+    for (const key of keys) {
+      const match = String(attrs?.[key] ?? "").match(/\d+/);
+      if (match) return Number.parseInt(match[0], 10);
+    }
+    return null;
+  }
+
+  _extractParentMacFromAttributes(attrs) {
+    const keys = ["sw_mac", "switch_mac", "uplink_mac", "parent_mac", "network_device_mac"];
+    for (const key of keys) {
+      const mac = normalizeMac(attrs?.[key]);
+      if (mac) return mac;
+    }
+    return null;
+  }
+
+  _buildPortClientIndex() {
+    const deviceMac = normalizeMac(this._ctx?.identity?.primary_mac);
+    if (!deviceMac || !this._hass?.states) return new Map();
+
+    const byPort = new Map();
+    for (const [entityId, obj] of Object.entries(this._hass.states)) {
+      if (!entityId.startsWith("device_tracker.")) continue;
+      const attrs = obj?.attributes || {};
+      const parentMac = this._extractParentMacFromAttributes(attrs);
+      if (parentMac !== deviceMac) continue;
+
+      const port = this._extractPortFromAttributes(attrs);
+      if (!Number.isInteger(port) || port < 1) continue;
+
+      const name = this._extractClientNameFromStateObj(obj, entityId);
+      if (!byPort.has(port)) byPort.set(port, new Set());
+      if (name) byPort.get(port).add(name);
+    }
+
+    return byPort;
+  }
+
   _buildSlotData(ctx) {
     const discovered = Array.isArray(ctx?.numberedPorts) ? ctx.numberedPorts : [];
     const numberedRaw = mergePortsWithLayout(ctx?.layout, discovered);
@@ -843,7 +894,7 @@ class UnifiDeviceCard extends HTMLElement {
     `;
   }
 
-  _renderPortButton(slot, selectedKey) {
+  _renderPortButton(slot, selectedKey, portClientIndex = null) {
     const isSpecial = slot.kind === "special";
     const mediaType = this._portMediaType(slot);
     const isSfp = mediaType !== "rj45";
@@ -853,13 +904,18 @@ class UnifiDeviceCard extends HTMLElement {
     const poeOn = poeStatus.active;
 
     const clientInfo = this._getPortClientInfo(slot);
+    const indexedNames = Number.isInteger(slot?.port) && portClientIndex?.has(slot.port)
+      ? Array.from(portClientIndex.get(slot.port))
+      : [];
+    const mergedNames = Array.from(new Set([...(clientInfo?.names || []), ...indexedNames])).slice(0, 8);
+    const mergedCount = Math.max(clientInfo?.count || 0, indexedNames.length);
     const tooltip = [
       slot.port_label || (isSpecial ? slot.label : `${this._t("port_label")} ${slot.label}`),
       this._translateState(getPortLinkText(this._hass, slot)),
       linkUp ? getPortSpeedText(this._hass, slot) : null,
       poeOn ? `${this._t("poe")}${poeStatus.power ? ` ${poeStatus.power}` : " ON"}` : null,
-      clientInfo ? `${this._t("clients")}: ${clientInfo.count}` : null,
-      clientInfo?.names?.length ? clientInfo.names.join(", ") : null,
+      mergedCount > 0 ? `${this._t("clients")}: ${mergedCount}` : null,
+      mergedNames.length ? mergedNames.join(", ") : null,
     ].filter((v) => v && v !== "—").join(" · ");
 
     const classes = [
@@ -1727,6 +1783,7 @@ class UnifiDeviceCard extends HTMLElement {
 
     const visibleNumbered = normalizedNumbered.filter((slot) => !specialPortsInUse.has(slot.port));
     const reverseFrontpanel = this._rotate180Enabled(ctx);
+    const portClientIndex = this._buildPortClientIndex();
     const baseRows = this._buildEffectiveRows(ctx, visibleNumbered);
     const effectiveRows = reverseFrontpanel
       ? baseRows.map((row) => [...row].reverse()).reverse()
@@ -1734,7 +1791,7 @@ class UnifiDeviceCard extends HTMLElement {
     const renderedSpecials = reverseFrontpanel ? [...allSpecials].reverse() : allSpecials;
 
     const specialRow = renderedSpecials.length
-      ? `<div class="special-row">${renderedSpecials.map((s) => this._renderPortButton(s, selected?.key)).join("")}</div>`
+      ? `<div class="special-row">${renderedSpecials.map((s) => this._renderPortButton(s, selected?.key, portClientIndex)).join("")}</div>`
       : "";
 
     const layoutRows = effectiveRows
@@ -1742,7 +1799,7 @@ class UnifiDeviceCard extends HTMLElement {
         const items = rowPorts
           .map((portNumber) => visibleNumbered.find((p) => p.port === portNumber))
           .filter(Boolean)
-          .map((slot) => this._renderPortButton(slot, selected?.key))
+          .map((slot) => this._renderPortButton(slot, selected?.key, portClientIndex))
           .join("");
 
         const cols = Math.max(1, rowPorts.length);

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -343,6 +343,99 @@ class UnifiDeviceCard extends HTMLElement {
     return deviceLabel || null;
   }
 
+  _escapeAttr(value) {
+    return String(value ?? "")
+      .replace(/&/g, "&amp;")
+      .replace(/"/g, "&quot;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;");
+  }
+
+  _apUplinkTooltip(uplink) {
+    if (!uplink) return "";
+    const lines = [];
+    const kind = String(uplink.kind || "").toLowerCase();
+
+    if (kind === "mesh") lines.push("Mesh Uplink");
+    else if (kind === "wired") lines.push("Wired Uplink");
+    else lines.push("Uplink");
+
+    if (uplink.via_device_name) lines.push(`Device: ${uplink.via_device_name}`);
+    if (uplink.remote_port) lines.push(`Port: ${uplink.remote_port}`);
+    if (uplink.via_mac) lines.push(`MAC: ${uplink.via_mac}`);
+
+    return lines.join(" · ");
+  }
+
+  _toClientNames(value) {
+    if (!Array.isArray(value)) return [];
+    const out = [];
+    for (const entry of value) {
+      if (typeof entry === "string" && entry.trim()) {
+        out.push(entry.trim());
+        continue;
+      }
+      if (entry && typeof entry === "object") {
+        const name =
+          entry.name ||
+          entry.hostname ||
+          entry.client_name ||
+          entry.display_name ||
+          entry.mac ||
+          "";
+        if (String(name).trim()) out.push(String(name).trim());
+      }
+    }
+    return out;
+  }
+
+  _getPortClientInfo(slot) {
+    const candidates = new Set([
+      slot?.link_entity,
+      slot?.speed_entity,
+      slot?.port_switch_entity,
+      slot?.poe_power_entity,
+      slot?.rx_entity,
+      slot?.tx_entity,
+      ...(Array.isArray(slot?.raw_entities) ? slot.raw_entities : []),
+    ].filter(Boolean));
+
+    const numericKeys = [
+      "connected_clients",
+      "client_count",
+      "clients",
+      "num_clients",
+      "active_clients",
+      "station_count",
+    ];
+    const listKeys = ["clients", "connected_clients", "client_list", "stations", "hosts"];
+
+    let bestCount = null;
+    let bestNames = [];
+
+    for (const entityId of candidates) {
+      const attrs = stateObj(this._hass, entityId)?.attributes;
+      if (!attrs || typeof attrs !== "object") continue;
+
+      for (const key of numericKeys) {
+        const raw = attrs[key];
+        const num = Number.parseInt(raw, 10);
+        if (Number.isInteger(num) && num >= 0 && (bestCount == null || num > bestCount)) {
+          bestCount = num;
+        }
+      }
+
+      for (const key of listKeys) {
+        const names = this._toClientNames(attrs[key]);
+        if (names.length > bestNames.length) bestNames = names;
+      }
+    }
+
+    if ((bestCount == null || bestCount === 0) && bestNames.length === 0) return null;
+    const count = bestCount != null ? bestCount : bestNames.length;
+    return { count, names: bestNames.slice(0, 8) };
+  }
+
   _buildSlotData(ctx) {
     const discovered = Array.isArray(ctx?.numberedPorts) ? ctx.numberedPorts : [];
     const numberedRaw = mergePortsWithLayout(ctx?.layout, discovered);
@@ -759,11 +852,14 @@ class UnifiDeviceCard extends HTMLElement {
     const poeStatus = getPoeStatus(this._hass, slot);
     const poeOn = poeStatus.active;
 
+    const clientInfo = this._getPortClientInfo(slot);
     const tooltip = [
       slot.port_label || (isSpecial ? slot.label : `${this._t("port_label")} ${slot.label}`),
       this._translateState(getPortLinkText(this._hass, slot)),
       linkUp ? getPortSpeedText(this._hass, slot) : null,
       poeOn ? `${this._t("poe")}${poeStatus.power ? ` ${poeStatus.power}` : " ON"}` : null,
+      clientInfo ? `${this._t("clients")}: ${clientInfo.count}` : null,
+      clientInfo?.names?.length ? clientInfo.names.join(", ") : null,
     ].filter((v) => v && v !== "—").join(" · ");
 
     const classes = [
@@ -806,7 +902,7 @@ class UnifiDeviceCard extends HTMLElement {
         </div>
       `;
 
-    return `<button class="${classes}" data-key="${slot.key}" title="${tooltip}">
+    return `<button class="${classes}" data-key="${slot.key}" title="${this._escapeAttr(tooltip)}">
       <div class="port-housing">
         ${housing}
       </div>
@@ -1545,6 +1641,7 @@ class UnifiDeviceCard extends HTMLElement {
       const uptime = this._apUptimeState(this._ctx?.uptime_entity);
       const clients = this._wholeNumberState(this._ctx?.clients_entity);
       const apUplink = this._apUplinkText(this._ctx?.ap_uplink);
+      const apUplinkTooltip = this._apUplinkTooltip(this._ctx?.ap_uplink);
       const { ledEntity, ledEnabled, ringColor } = this._apLedState();
 
       const headerTitle = this._title();
@@ -1594,7 +1691,7 @@ class UnifiDeviceCard extends HTMLElement {
               ${apUplink ? `
               <div class="detail-item">
                 <div class="detail-label">${this._t("uplink")}</div>
-                <div class="detail-value">${apUplink}</div>
+                <div class="detail-value" title="${this._escapeAttr(apUplinkTooltip)}">${apUplink}</div>
               </div>` : ""}
             </div>
           </div>

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -340,11 +340,7 @@ class UnifiDeviceCard extends HTMLElement {
   _apUplinkText(uplink) {
     if (!uplink) return null;
     const deviceLabel = String(uplink.via_device_name || uplink.via_mac || "").trim();
-    if (!deviceLabel) return null;
-
-    const port = String(uplink.remote_port || "").trim();
-    if (port) return `${deviceLabel} · Port ${port}`;
-    return deviceLabel;
+    return deviceLabel || null;
   }
 
   _escapeAttr(value) {

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -19,6 +19,16 @@ import "./unifi-device-card-editor.js";
 
 const VERSION = __VERSION__;
 const DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
+const LOG_LEVELS = { error: 0, warn: 1, info: 2, debug: 3, trace: 4 };
+const LOG_STYLES = {
+  badge: "background:#00AEEF;color:#fff;padding:2px 6px;border-radius:2px;font-weight:700;",
+  version: "background:#2a2a2a;color:#fff;padding:2px 6px;border-radius:2px;font-weight:700;",
+  error: "color:#ff5f56;font-weight:700;",
+  warn: "color:#ffbd2e;font-weight:700;",
+  info: "color:#9effa1;font-weight:700;",
+  debug: "color:#8ab4f8;font-weight:700;",
+  trace: "color:#caa7ff;font-weight:700;",
+};
 
 class UnifiDeviceCard extends HTMLElement {
   static getConfigElement() {
@@ -42,6 +52,37 @@ class UnifiDeviceCard extends HTMLElement {
     this._lastMeasuredWidth = 0;
     this._lastMeasuredPanelWidth = 0;
     this._cardSize = 8;
+    this._instanceId = Math.random().toString(36).slice(2, 7);
+  }
+
+  _configuredLogLevel() {
+    const raw = String(this._config?.log_level || "").toLowerCase().trim();
+    if (raw && Object.prototype.hasOwnProperty.call(LOG_LEVELS, raw)) return raw;
+    if (this._config?.debug === true) return "debug";
+    return "warn";
+  }
+
+  _shouldLog(level) {
+    const target = LOG_LEVELS[this._configuredLogLevel()];
+    const current = LOG_LEVELS[level];
+    if (current == null || target == null) return false;
+    return current <= target;
+  }
+
+  _log(level, message, ...args) {
+    if (!this._shouldLog(level)) return;
+    const fn = level === "error" ? "error" : level === "warn" ? "warn" : "log";
+    const levelLabel = level.toUpperCase();
+    const device = this._config?.device_id ? ` ${this._config.device_id}` : "";
+    const header = `%cUNIFI-DEVICE-CARD%c ${levelLabel}%c${device} #${this._instanceId}`;
+    console[fn](
+      header,
+      LOG_STYLES.badge,
+      LOG_STYLES[level] || LOG_STYLES.info,
+      LOG_STYLES.version,
+      message,
+      ...args
+    );
   }
 
   connectedCallback() {
@@ -65,6 +106,10 @@ class UnifiDeviceCard extends HTMLElement {
     const newConfig = config || {};
     const newDeviceId = newConfig?.device_id || null;
     this._config = newConfig;
+    this._log("info", "setConfig", {
+      device_id: newDeviceId || null,
+      log_level: this._configuredLogLevel(),
+    });
 
     if (oldDeviceId !== newDeviceId) {
       this._ctx = null;
@@ -84,6 +129,7 @@ class UnifiDeviceCard extends HTMLElement {
     const previousHass = this._hass;
     this._hass = hass;
     this._ensureLoaded();
+    this._log("trace", "hass update");
     if (!previousHass || !this._ctx || this._hasRelevantStateChanges(previousHass, hass)) {
       this._render();
     }
@@ -736,6 +782,7 @@ class UnifiDeviceCard extends HTMLElement {
     if (this._loading) return;
 
     this._loading = true;
+    this._log("debug", "loading device context");
     this._render();
     const token = ++this._loadToken;
 
@@ -745,12 +792,17 @@ class UnifiDeviceCard extends HTMLElement {
 
       this._ctx = ctx;
       this._loadedDeviceId = currentId;
+      this._log("info", "context loaded", {
+        type: ctx?.type || null,
+        model: ctx?.model || null,
+        identity_mac: ctx?.identity?.primary_mac || null,
+      });
 
       const { specials, numbered } = this._buildSlotData(ctx);
       const first = specials[0] || numbered[0] || null;
       this._selectedKey = first?.key || null;
     } catch (err) {
-      console.error("[unifi-device-card] Failed to load device context", err);
+      this._log("error", "Failed to load device context", err);
       if (token !== this._loadToken) return;
       this._ctx = null;
       this._loadedDeviceId = null;
@@ -768,11 +820,13 @@ class UnifiDeviceCard extends HTMLElement {
   async _toggleEntity(entityId) {
     if (!entityId || !this._hass) return;
     const [domain] = entityId.split(".");
+    this._log("debug", "toggle entity", entityId);
     await this._hass.callService(domain, "toggle", { entity_id: entityId });
   }
 
   async _pressButton(entityId) {
     if (!entityId || !this._hass) return;
+    this._log("debug", "press button", entityId);
     await this._hass.callService("button", "press", { entity_id: entityId });
   }
 
@@ -1993,5 +2047,9 @@ window.customCards.push({
 
 if (!window[DEV_LOG_FLAG]) {
   window[DEV_LOG_FLAG] = true;
-  console.info(`[UNIFI-DEVICE-CARD] Version ${VERSION}`);
+  console.log(
+    `%cUNIFI-DEVICE-CARD%c v${VERSION}`,
+    LOG_STYLES.badge,
+    LOG_STYLES.version
+  );
 }

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -534,8 +534,18 @@ class UnifiDeviceCard extends HTMLElement {
     let bestNames = [];
 
     for (const entityId of candidates) {
-      const attrs = stateObj(this._hass, entityId)?.attributes;
+      const obj = stateObj(this._hass, entityId);
+      const attrs = obj?.attributes;
       if (!attrs || typeof attrs !== "object") continue;
+
+      const stateNum = Number.parseInt(String(obj?.state ?? ""), 10);
+      if (
+        Number.isInteger(stateNum) &&
+        stateNum >= 0 &&
+        (entityId.includes("clients") || String(attrs?.friendly_name || "").toLowerCase().includes("clients"))
+      ) {
+        if (bestCount == null || stateNum > bestCount) bestCount = stateNum;
+      }
 
       for (const key of numericKeys) {
         const raw = attrs[key];
@@ -567,7 +577,17 @@ class UnifiDeviceCard extends HTMLElement {
   }
 
   _extractPortFromAttributes(attrs) {
-    const keys = ["port", "switch_port", "sw_port", "uplink_port", "port_number", "wired_port"];
+    const keys = [
+      "port",
+      "switch_port",
+      "sw_port",
+      "uplink_port",
+      "uplink_remote_port",
+      "remote_port",
+      "network_port",
+      "port_number",
+      "wired_port",
+    ];
     for (const key of keys) {
       const match = String(attrs?.[key] ?? "").match(/\d+/);
       if (match) return Number.parseInt(match[0], 10);
@@ -576,7 +596,18 @@ class UnifiDeviceCard extends HTMLElement {
   }
 
   _extractParentMacFromAttributes(attrs) {
-    const keys = ["sw_mac", "switch_mac", "uplink_mac", "parent_mac", "network_device_mac"];
+    const keys = [
+      "sw_mac",
+      "switch_mac",
+      "uplink_mac",
+      "uplink_device_mac",
+      "wired_uplink_mac",
+      "switch_uplink_mac",
+      "connected_to_mac",
+      "parent_mac",
+      "parent_device_mac",
+      "network_device_mac",
+    ];
     for (const key of keys) {
       const mac = normalizeMac(attrs?.[key]);
       if (mac) return mac;
@@ -590,7 +621,6 @@ class UnifiDeviceCard extends HTMLElement {
 
     const byPort = new Map();
     for (const [entityId, obj] of Object.entries(this._hass.states)) {
-      if (!entityId.startsWith("device_tracker.")) continue;
       const attrs = obj?.attributes || {};
       const parentMac = this._extractParentMacFromAttributes(attrs);
       if (parentMac !== deviceMac) continue;
@@ -598,9 +628,32 @@ class UnifiDeviceCard extends HTMLElement {
       const port = this._extractPortFromAttributes(attrs);
       if (!Number.isInteger(port) || port < 1) continue;
 
-      const name = this._extractClientNameFromStateObj(obj, entityId);
-      if (!byPort.has(port)) byPort.set(port, new Set());
-      if (name) byPort.get(port).add(name);
+      if (!byPort.has(port)) {
+        byPort.set(port, { count: 0, names: new Set() });
+      }
+      const entry = byPort.get(port);
+
+      if (entityId.startsWith("device_tracker.")) {
+        const name = this._extractClientNameFromStateObj(obj, entityId);
+        if (name) entry.names.add(name);
+      }
+
+      const stateNum = Number.parseInt(String(obj?.state ?? ""), 10);
+      const friendly = String(attrs?.friendly_name || "").toLowerCase();
+      const looksLikeClientCounter =
+        entityId.includes("clients") ||
+        friendly.includes("clients") ||
+        friendly.includes("geräte");
+      if (looksLikeClientCounter && Number.isInteger(stateNum) && stateNum >= 0) {
+        entry.count = Math.max(entry.count, stateNum);
+      }
+
+      const attrNames = this._toClientNames(attrs?.clients || attrs?.connected_clients || attrs?.client_list);
+      for (const name of attrNames) {
+        entry.names.add(name);
+      }
+
+      entry.count = Math.max(entry.count, entry.names.size);
     }
 
     return byPort;
@@ -1037,11 +1090,11 @@ class UnifiDeviceCard extends HTMLElement {
     const poeOn = poeStatus.active;
 
     const clientInfo = this._getPortClientInfo(slot);
-    const indexedNames = Number.isInteger(slot?.port) && portClientIndex?.has(slot.port)
-      ? Array.from(portClientIndex.get(slot.port))
-      : [];
+    const indexedPortInfo = Number.isInteger(slot?.port) ? portClientIndex?.get(slot.port) : null;
+    const indexedNames = indexedPortInfo?.names ? Array.from(indexedPortInfo.names) : [];
+    const indexedCount = indexedPortInfo?.count || indexedNames.length;
     const mergedNames = Array.from(new Set([...(clientInfo?.names || []), ...indexedNames])).slice(0, 8);
-    const mergedCount = Math.max(clientInfo?.count || 0, indexedNames.length);
+    const mergedCount = Math.max(clientInfo?.count || 0, indexedCount);
     const tooltip = [
       slot.port_label || (isSpecial ? slot.label : `${this._t("port_label")} ${slot.label}`),
       this._translateState(getPortLinkText(this._hass, slot)),

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -85,6 +85,79 @@ class UnifiDeviceCard extends HTMLElement {
     );
   }
 
+  _numericState(entityId) {
+    if (!entityId || !this._hass?.states) return null;
+    const raw = this._hass.states[entityId]?.state;
+    if (raw == null || raw === "unknown" || raw === "unavailable") return null;
+    const n = Number.parseFloat(String(raw).replace(",", "."));
+    return Number.isFinite(n) ? n : null;
+  }
+
+  _buildPortDebugSnapshot(ctx) {
+    if (!ctx || (ctx.type !== "switch" && ctx.type !== "gateway")) {
+      return {
+        summary: null,
+        ports: [],
+      };
+    }
+
+    const slotData = this._buildSlotData(ctx);
+    const ports = [...(slotData?.specials || []), ...(slotData?.numbered || [])]
+      .filter((slot) => Number.isInteger(slot?.port))
+      .sort((a, b) => a.port - b.port);
+
+    let connected = 0;
+    let poePorts = 0;
+    let trafficPorts = 0;
+    let poeTotalW = 0;
+
+    const details = ports.map((slot) => {
+      const linkUp = isPortConnected(this._hass, slot);
+      if (linkUp) connected += 1;
+
+      const poeStatus = getPoeStatus(this._hass, slot);
+      if (poeStatus.active) poePorts += 1;
+      const poeNum = this._numericState(slot?.poe_power_entity);
+      if (poeNum != null && poeNum > 0) poeTotalW += poeNum;
+
+      const rx = this._numericState(slot?.rx_entity) || 0;
+      const tx = this._numericState(slot?.tx_entity) || 0;
+      const traffic = rx + tx;
+      if (traffic > 0) trafficPorts += 1;
+
+      return {
+        port: slot.port,
+        link: linkUp ? "up" : "down",
+        speed: getPortSpeedText(this._hass, slot) || null,
+        poe: poeStatus.active ? (poeStatus.power || "on") : "off",
+        rx,
+        tx,
+      };
+    });
+
+    const topTraffic = [...details]
+      .sort((a, b) => (b.rx + b.tx) - (a.rx + a.tx))
+      .filter((row) => (row.rx + row.tx) > 0)
+      .slice(0, 5)
+      .map((row) => ({
+        port: row.port,
+        rx: row.rx,
+        tx: row.tx,
+      }));
+
+    return {
+      summary: {
+        ports_total: ports.length,
+        ports_connected: connected,
+        ports_with_poe: poePorts,
+        poe_total_w: Number(poeTotalW.toFixed(2)),
+        ports_with_traffic: trafficPorts,
+      },
+      ports: details,
+      top_traffic: topTraffic,
+    };
+  }
+
   connectedCallback() {
     if (this._resizeObserver) return;
     this._resizeObserver = new ResizeObserver(() => {
@@ -792,11 +865,17 @@ class UnifiDeviceCard extends HTMLElement {
 
       this._ctx = ctx;
       this._loadedDeviceId = currentId;
+      const portSnapshot = this._buildPortDebugSnapshot(ctx);
       this._log("info", "context loaded", {
         type: ctx?.type || null,
         model: ctx?.model || null,
         identity_mac: ctx?.identity?.primary_mac || null,
+        ...(portSnapshot.summary || {}),
+        top_traffic: portSnapshot.top_traffic || [],
       });
+      if (this._shouldLog("debug") && portSnapshot.ports?.length) {
+        this._log("debug", "port snapshot", portSnapshot.ports);
+      }
 
       const { specials, numbered } = this._buildSlotData(ctx);
       const first = specials[0] || numbered[0] || null;

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -576,7 +576,7 @@ class UnifiDeviceCard extends HTMLElement {
       .trim();
   }
 
-  _extractPortFromAttributes(attrs) {
+  _extractPortFromAttributes(attrs, entityId = "") {
     const keys = [
       "port",
       "switch_port",
@@ -592,6 +592,13 @@ class UnifiDeviceCard extends HTMLElement {
       const match = String(attrs?.[key] ?? "").match(/\d+/);
       if (match) return Number.parseInt(match[0], 10);
     }
+    const textKeys = ["connected_to", "uplink", "uplink_source", "source", "network_path", "connection_path"];
+    for (const key of textKeys) {
+      const match = String(attrs?.[key] ?? "").match(/port\D*(\d+)/i);
+      if (match) return Number.parseInt(match[1], 10);
+    }
+    const idMatch = String(entityId || "").match(/(?:^|[_-])port[_-]?(\d+)(?:[_-]|$)/i);
+    if (idMatch) return Number.parseInt(idMatch[1], 10);
     return null;
   }
 
@@ -615,6 +622,39 @@ class UnifiDeviceCard extends HTMLElement {
     return null;
   }
 
+  _extractParentText(attrs) {
+    const textKeys = [
+      "connected_to",
+      "uplink",
+      "uplink_source",
+      "source",
+      "network_device",
+      "network_path",
+      "connection_path",
+      "switch",
+      "parent",
+    ];
+    return textKeys
+      .map((key) => String(attrs?.[key] ?? "").trim())
+      .filter(Boolean)
+      .join(" ")
+      .toLowerCase();
+  }
+
+  _matchesParentDevice(attrs, deviceMac) {
+    const parentMac = this._extractParentMacFromAttributes(attrs);
+    if (parentMac) return parentMac === deviceMac;
+
+    const parentText = this._extractParentText(attrs);
+    if (!parentText) return false;
+
+    const deviceName = String(this._ctx?.name || "").toLowerCase().trim();
+    const deviceModel = String(this._ctx?.model || "").toLowerCase().trim();
+    if (deviceName && parentText.includes(deviceName)) return true;
+    if (deviceModel && parentText.includes(deviceModel)) return true;
+    return false;
+  }
+
   _buildPortClientIndex() {
     const deviceMac = normalizeMac(this._ctx?.identity?.primary_mac);
     if (!deviceMac || !this._hass?.states) return new Map();
@@ -622,10 +662,9 @@ class UnifiDeviceCard extends HTMLElement {
     const byPort = new Map();
     for (const [entityId, obj] of Object.entries(this._hass.states)) {
       const attrs = obj?.attributes || {};
-      const parentMac = this._extractParentMacFromAttributes(attrs);
-      if (parentMac !== deviceMac) continue;
+      if (!this._matchesParentDevice(attrs, deviceMac)) continue;
 
-      const port = this._extractPortFromAttributes(attrs);
+      const port = this._extractPortFromAttributes(attrs, entityId);
       if (!Number.isInteger(port) || port < 1) continue;
 
       if (!byPort.has(port)) {

--- a/src/unique-id.js
+++ b/src/unique-id.js
@@ -1,0 +1,76 @@
+import { normalizeMac } from "./identity.js";
+
+// unique_id parsers:
+// - port-scoped UniFi entities (port-<mac>_<n>, power_cycle-<mac>_<n>, ...)
+// - device-scoped UniFi entities (device_restart-<mac>, device_uplink_mac-<mac>, ...)
+// - object-scoped UniFi entities (wlan-*, firewall_policy-*, ...)
+
+const PORT_FEATURE_PREFIXES = {
+  port: "port_control",
+  power_cycle: "power_cycle",
+  poe_power: "poe_power",
+  port_rx: "port_rx",
+  port_tx: "port_tx",
+  port_bandwidth_rx: "port_rx",
+  port_bandwidth_tx: "port_tx",
+  port_link_speed: "link_speed",
+};
+
+const DEVICE_FEATURE_PREFIXES = {
+  device_restart: "restart",
+  device_uplink_mac: "uplink_mac",
+  rx: "client_rx",
+  tx: "client_tx",
+  wired_speed: "client_link_speed",
+};
+
+export function parseUnifiPortUniqueId(uniqueId) {
+  const raw = String(uniqueId ?? "").trim().toLowerCase();
+  if (!raw) return null;
+
+  const match = raw.match(/^([a-z0-9_]+)-([0-9a-f:]{17}|[0-9a-f]{12})_(\d+)$/i);
+  if (!match) return null;
+
+  const [, prefix, macRaw, portRaw] = match;
+  const feature = PORT_FEATURE_PREFIXES[prefix] || null;
+  const mac = normalizeMac(macRaw);
+  const port = Number.parseInt(portRaw, 10);
+
+  if (!feature || !mac || !Number.isInteger(port)) return null;
+  return { feature, mac, port };
+}
+
+export function parseUnifiDeviceUniqueId(uniqueId) {
+  const raw = String(uniqueId ?? "").trim().toLowerCase();
+  if (!raw) return null;
+
+  const match = raw.match(/^([a-z0-9_]+)-([0-9a-f:]{17}|[0-9a-f]{12})$/i);
+  if (!match) return null;
+
+  const [, prefix, macRaw] = match;
+  const feature = DEVICE_FEATURE_PREFIXES[prefix] || null;
+  const mac = normalizeMac(macRaw);
+  if (!feature || !mac) return null;
+
+  return { feature, mac };
+}
+
+export function parseUnifiObjectUniqueId(uniqueId) {
+  const raw = String(uniqueId ?? "").trim().toLowerCase();
+  if (!raw) return null;
+
+  const match = raw.match(/^(wlan|qr_code|regenerate_password|firewall_policy)-(.+)$/i);
+  if (!match) return null;
+
+  const [, prefix, objectId] = match;
+  const featureMap = {
+    wlan: "wlan_control",
+    qr_code: "wlan_qr_code",
+    regenerate_password: "wlan_regenerate_password",
+    firewall_policy: "firewall_policy",
+  };
+  return {
+    feature: featureMap[prefix] || null,
+    object_id: objectId || null,
+  };
+}


### PR DESCRIPTION
### Motivation
- Split and centralize device identity, MAC parsing, unique_id parsing, capability inference and classification into dedicated modules to improve accuracy and maintainability.
- Improve device-type and port detection by using entity `unique_id` patterns and full entity registry data (including disabled/hidden entries) for more reliable mapping.
- Remove duplicated heuristics and normalize MAC and identity handling across code paths.

### Description
- Added new modules: `src/identity.js`, `src/unique-id.js`, `src/capabilities.js`, and `src/classify.js` which provide MAC normalization, unique_id parsers, per-device capability counting, and device type classification respectively.
- Updated `src/helpers.js` and other callers to consume the new modules and to build a normalized `identity` and `capabilities` for devices, using `buildNormalizedDeviceIdentity`, `buildDeviceCapabilities`, and `classifyDeviceType` where appropriate.
- Changed `getAllData` to return both filtered active entities and `allEntitiesByDevice` (including disabled/hidden) and updated `getUnifiDevices`, `getDeviceContext`, and related flows to use `allEntitiesByDevice` for detection and classification.
- Improved port/feature parsing by using `parseUnifiPortUniqueId` and `parseUnifiDeviceUniqueId`, and simplified `extractDeviceMacs`/`findDeviceByMac` logic centralized in `identity.js`.
- Regenerated distribution file with version bump (`VERSION` updated) and removed duplicate helper implementations from the built bundle.

### Testing
- Built the project to regenerate the distribution (`npm run build`), which completed successfully and updated `dist/unifi-device-card.js`.
- No automated unit tests were executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0802b07208333b345501b8af668ed)