### PR TITLE
fix: stabilize SFP links and respect explicit row layout

### DIFF
--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.1723b41 */
+/* UniFi Device Card 0.0.0-dev.f8cb179 */
 
 // src/model-registry.js
 function range(start, end) {
@@ -2586,6 +2586,19 @@ function isSfpSpecialPort(port) {
   const key = lower(port?.physical_key || port?.key || "");
   return key.startsWith("sfp_") || key.startsWith("sfp28_");
 }
+function isSfpLikePort(port) {
+  if (isSfpSpecialPort(port)) return true;
+  const text = [
+    port?.key,
+    port?.physical_key,
+    port?.label,
+    port?.speed_entity,
+    port?.rx_entity,
+    port?.tx_entity,
+    port?.link_entity
+  ].filter(Boolean).join(" ").toLowerCase();
+  return text.includes("sfp") || text.includes("10g");
+}
 function isPortConnected(hass, port) {
   if (port.link_entity) {
     const s = lower(stateValue(hass, port.link_entity));
@@ -2598,11 +2611,14 @@ function isPortConnected(hass, port) {
   const speedMbit = parseLinkSpeedMbit(hass, port.speed_entity);
   if (speedMbit != null) {
     if (speedMbit > 0) {
-      if (!isSfpSpecialPort(port) && !port?.link_entity && speedMbit <= 10) {
+      if (!isSfpLikePort(port) && !port?.link_entity && speedMbit <= 10) {
         const hasActiveTraffic = hasTraffic(hass, port);
         const clientCount = portObservedClientCount(hass, port);
         const poeActive = getPoeStatus(hass, port).active;
         if (!hasActiveTraffic && clientCount === 0 && !poeActive) return false;
+      }
+      if (isSfpLikePort(port) && !port?.link_entity && (port?.rx_entity || port?.tx_entity)) {
+        if (!hasTraffic(hass, port)) return false;
       }
       return true;
     }
@@ -4093,7 +4109,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.1723b41";
+var VERSION = "0.0.0-dev.f8cb179";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var LOG_LEVELS = { error: 0, warn: 1, info: 2, debug: 3, trace: 4 };
 var LOG_STYLES = {
@@ -4126,6 +4142,7 @@ var UnifiDeviceCard = class extends HTMLElement {
     this._lastMeasuredPanelWidth = 0;
     this._cardSize = 8;
     this._instanceId = Math.random().toString(36).slice(2, 7);
+    this._sfpConnectedSeen = /* @__PURE__ */ new Set();
   }
   _configuredLogLevel() {
     const raw = String(this._config?.log_level || "").toLowerCase().trim();
@@ -4175,7 +4192,7 @@ var UnifiDeviceCard = class extends HTMLElement {
     let trafficPorts = 0;
     let poeTotalW = 0;
     const details = ports.map((slot) => {
-      const linkUp = isPortConnected(this._hass, slot);
+      const linkUp = this._isPortConnected(slot);
       if (linkUp) connected += 1;
       const poeStatus = getPoeStatus(this._hass, slot);
       if (poeStatus.active) poePorts += 1;
@@ -4352,14 +4369,17 @@ var UnifiDeviceCard = class extends HTMLElement {
     return Math.max(0, panelWidth - paddingLeft - paddingRight);
   }
   _maxFittableColumns() {
+    const configuredPPR = Number.parseInt(this._config?.ports_per_row, 10);
+    if (Number.isFinite(configuredPPR) && configuredPPR > 0) return Infinity;
     const portSize = this._portSize();
     const panelContentWidth = this._measuredFrontPanelContentWidth();
     const hostWidth = this._measuredCardWidth();
     if (!panelContentWidth && !hostWidth) return Infinity;
-    const horizontalPadding = 40;
+    const horizontalPadding = 24;
     const gap = 6;
+    const slotWidth = Math.max(1, portSize - 2);
     const available = panelContentWidth > 0 ? panelContentWidth : Math.max(180, hostWidth - horizontalPadding);
-    return Math.max(1, Math.floor((available + gap) / (portSize + gap)));
+    return Math.max(1, Math.floor((available + gap) / (slotWidth + gap)));
   }
   _wholeNumberState(entityId) {
     if (!entityId || !this._hass) return "\u2014";
@@ -4808,6 +4828,10 @@ var UnifiDeviceCard = class extends HTMLElement {
     if (!ctx || ctx.type !== "switch" && ctx.type !== "gateway") return false;
     if (ctx?.layout?.rj45_odd_even === true) return true;
     if (ctx?.layout?.rj45_odd_even === false) return false;
+    const frontStyle = String(ctx?.layout?.frontStyle || "");
+    if (["dual-row", "six-grid", "eight-grid", "quad-row"].includes(frontStyle)) {
+      return false;
+    }
     const portCount = (numbered || []).filter((slot) => Number.isInteger(slot?.port)).length;
     return portCount > 8;
   }
@@ -4922,8 +4946,31 @@ var UnifiDeviceCard = class extends HTMLElement {
       value: formatState(this._hass, item.entity)
     }));
   }
+  /**
+   * Wrapper around the module-level isPortConnected() that adds sticky-state
+   * tracking for SFP-like ports.  When a port has been observed with live
+   * traffic, short polling-interval gaps where rx/tx momentarily reads 0 will
+   * no longer flip the LED off.  The sticky state is cleared only when the
+   * link speed itself drops to 0 (cable genuinely removed).
+   */
+  _isPortConnected(port) {
+    if (isSfpLikePort(port)) {
+      const key = port?.key || port?.physical_key;
+      if (key) {
+        if (hasTraffic(this._hass, port)) this._sfpConnectedSeen.add(key);
+        const result = isPortConnected(this._hass, port);
+        if (!result && this._sfpConnectedSeen.has(key)) {
+          const speedMbit = parseLinkSpeedMbit(this._hass, port?.speed_entity);
+          if (speedMbit == null || speedMbit > 0) return true;
+          this._sfpConnectedSeen.delete(key);
+        }
+        return result;
+      }
+    }
+    return isPortConnected(this._hass, port);
+  }
   _connectedCount(allSlots) {
-    return allSlots.filter((s) => isPortConnected(this._hass, s)).length;
+    return allSlots.filter((s) => this._isPortConnected(s)).length;
   }
   _isDeviceOnline() {
     const onlineEntity = this._ctx?.online_entity;
@@ -4939,7 +4986,7 @@ var UnifiDeviceCard = class extends HTMLElement {
     return parseLinkSpeedMbit(this._hass, port?.speed_entity);
   }
   _linkLedClass(port) {
-    const connected = isPortConnected(this._hass, port);
+    const connected = this._isPortConnected(port);
     if (!connected) return "off";
     const speed = this._speedValueMbit(port);
     if (speed == null) return "green";
@@ -4986,7 +5033,7 @@ var UnifiDeviceCard = class extends HTMLElement {
     const mediaType = this._portMediaType(slot);
     const isSfp = mediaType !== "rj45";
     const isWan = this._isWanLike(slot);
-    const linkUp = isPortConnected(this._hass, slot);
+    const linkUp = this._isPortConnected(slot);
     const poeStatus = getPoeStatus(this._hass, slot);
     const poeOn = poeStatus.active;
     const clientInfo = this._getPortClientInfo(slot);
@@ -5891,7 +5938,7 @@ var UnifiDeviceCard = class extends HTMLElement {
     const panelContentHtml = panelPortsHtml || `<div class="muted" style="padding:8px 0">${this._t("no_ports")}</div>`;
     let detail = `<div class="muted">${this._t("no_ports")}</div>`;
     if (selected) {
-      const linkUp = isPortConnected(this._hass, selected);
+      const linkUp = this._isPortConnected(selected);
       const linkText = getPortLinkText(this._hass, selected);
       const speedText = getPortSpeedText(this._hass, selected);
       const poeStatus = getPoeStatus(this._hass, selected);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1824,7 +1824,7 @@ export function getPoeStatus(hass, port) {
   };
 }
 
-function trafficValue(hass, entityId) {
+export function trafficValue(hass, entityId) {
   const raw = stateValue(hass, entityId);
   if (raw == null || raw === "unavailable" || raw === "unknown") return 0;
 
@@ -1832,7 +1832,7 @@ function trafficValue(hass, entityId) {
   return Number.isFinite(num) ? num : 0;
 }
 
-function hasTraffic(hass, port) {
+export function hasTraffic(hass, port) {
   return trafficValue(hass, port?.rx_entity) > 0 || trafficValue(hass, port?.tx_entity) > 0;
 }
 
@@ -1882,6 +1882,28 @@ function isSfpSpecialPort(port) {
   return key.startsWith("sfp_") || key.startsWith("sfp28_");
 }
 
+/**
+ * Returns true if the port is SFP-like, either by slot kind or by entity naming.
+ * Catches cases like the UDMPRO where SFP ports are numbered but named "sfp_1" /
+ * "sfp_2" in their entity IDs rather than being declared as special slots.
+ */
+export function isSfpLikePort(port) {
+  if (isSfpSpecialPort(port)) return true;
+  const text = [
+    port?.key,
+    port?.physical_key,
+    port?.label,
+    port?.speed_entity,
+    port?.rx_entity,
+    port?.tx_entity,
+    port?.link_entity,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  return text.includes("sfp") || text.includes("10g");
+}
+
 export function isPortConnected(hass, port) {
   if (port.link_entity) {
     const s = lower(stateValue(hass, port.link_entity));
@@ -1918,11 +1940,17 @@ export function isPortConnected(hass, port) {
       // Some setups report persistent 10 Mbit on idle/disconnected copper ports.
       // If no explicit link sensor exists and we have neither traffic, clients, nor PoE activity,
       // treat 10 Mbit as not connected to avoid false "up" LEDs.
-      if (!isSfpSpecialPort(port) && !port?.link_entity && speedMbit <= 10) {
+      if (!isSfpLikePort(port) && !port?.link_entity && speedMbit <= 10) {
         const hasActiveTraffic = hasTraffic(hass, port);
         const clientCount = portObservedClientCount(hass, port);
         const poeActive = getPoeStatus(hass, port).active;
         if (!hasActiveTraffic && clientCount === 0 && !poeActive) return false;
+      }
+      // SFP ghost-link guard (extended): some gateways report rated speed on SFP
+      // ports when the module is seated but no cable is connected. Use traffic
+      // presence as the definitive test when an explicit link sensor is absent.
+      if (isSfpLikePort(port) && !port?.link_entity && (port?.rx_entity || port?.tx_entity)) {
+        if (!hasTraffic(hass, port)) return false;
       }
       return true;
     }

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -6,6 +6,8 @@ import {
   getPoeStatus,
   getPortLinkText,
   getPortSpeedText,
+  hasTraffic,
+  isSfpLikePort,
   isOn,
   isPortConnected,
   mergePortsWithLayout,
@@ -53,6 +55,10 @@ class UnifiDeviceCard extends HTMLElement {
     this._lastMeasuredPanelWidth = 0;
     this._cardSize = 8;
     this._instanceId = Math.random().toString(36).slice(2, 7);
+    // Keys of SFP-like ports that have been observed with live traffic.
+    // Used by _isPortConnected() to avoid false "offline" flickers on
+    // polling-interval gaps where rx/tx momentarily reads 0.
+    this._sfpConnectedSeen = new Set();
   }
 
   _configuredLogLevel() {
@@ -112,7 +118,7 @@ class UnifiDeviceCard extends HTMLElement {
     let poeTotalW = 0;
 
     const details = ports.map((slot) => {
-      const linkUp = isPortConnected(this._hass, slot);
+      const linkUp = this._isPortConnected(slot);
       if (linkUp) connected += 1;
 
       const poeStatus = getPoeStatus(this._hass, slot);
@@ -329,17 +335,24 @@ class UnifiDeviceCard extends HTMLElement {
   }
 
   _maxFittableColumns() {
+    // When the user has explicitly set ports_per_row, honour it unconditionally.
+    // The measured panel width must not override an intentional layout choice.
+    const configuredPPR = Number.parseInt(this._config?.ports_per_row, 10);
+    if (Number.isFinite(configuredPPR) && configuredPPR > 0) return Infinity;
+
     const portSize = this._portSize();
     const panelContentWidth = this._measuredFrontPanelContentWidth();
     const hostWidth = this._measuredCardWidth();
     if (!panelContentWidth && !hostWidth) return Infinity;
 
-    const horizontalPadding = 40;
+    // Use a tighter slot estimate so measured width does not under-count columns.
+    const horizontalPadding = 24;
     const gap = 6;
+    const slotWidth = Math.max(1, portSize - 2);
     const available = panelContentWidth > 0
       ? panelContentWidth
       : Math.max(180, hostWidth - horizontalPadding);
-    return Math.max(1, Math.floor((available + gap) / (portSize + gap)));
+    return Math.max(1, Math.floor((available + gap) / (slotWidth + gap)));
   }
 
   _wholeNumberState(entityId) {
@@ -929,8 +942,17 @@ class UnifiDeviceCard extends HTMLElement {
 
   _shouldUseOddEvenRows(ctx, numbered) {
     if (!ctx || (ctx.type !== "switch" && ctx.type !== "gateway")) return false;
+    // Explicit per-layout overrides always win.
     if (ctx?.layout?.rj45_odd_even === true) return true;
     if (ctx?.layout?.rj45_odd_even === false) return false;
+    // Devices with an explicit multi-row frontStyle (six-grid, eight-grid, dual-row,
+    // quad-row) already define their own row groupings.  Applying odd/even reordering
+    // on top would break those groupings (e.g. a USW Pro 24 ending up with 6 columns
+    // instead of the declared 6-per-row layout).
+    const frontStyle = String(ctx?.layout?.frontStyle || "");
+    if (["dual-row", "six-grid", "eight-grid", "quad-row"].includes(frontStyle)) {
+      return false;
+    }
     const portCount = (numbered || []).filter((slot) => Number.isInteger(slot?.port)).length;
     return portCount > 8;
   }
@@ -1071,8 +1093,34 @@ class UnifiDeviceCard extends HTMLElement {
       }));
   }
 
+  /**
+   * Wrapper around the module-level isPortConnected() that adds sticky-state
+   * tracking for SFP-like ports.  When a port has been observed with live
+   * traffic, short polling-interval gaps where rx/tx momentarily reads 0 will
+   * no longer flip the LED off.  The sticky state is cleared only when the
+   * link speed itself drops to 0 (cable genuinely removed).
+   */
+  _isPortConnected(port) {
+    if (isSfpLikePort(port)) {
+      const key = port?.key || port?.physical_key;
+      if (key) {
+        if (hasTraffic(this._hass, port)) this._sfpConnectedSeen.add(key);
+        const result = isPortConnected(this._hass, port);
+        if (!result && this._sfpConnectedSeen.has(key)) {
+          // Port was live before — only go dark if speed actually reached 0.
+          const speedMbit = parseLinkSpeedMbit(this._hass, port?.speed_entity);
+          if (speedMbit == null || speedMbit > 0) return true;
+          // Speed is 0: cable removed. Clear sticky state.
+          this._sfpConnectedSeen.delete(key);
+        }
+        return result;
+      }
+    }
+    return isPortConnected(this._hass, port);
+  }
+
   _connectedCount(allSlots) {
-    return allSlots.filter((s) => isPortConnected(this._hass, s)).length;
+    return allSlots.filter((s) => this._isPortConnected(s)).length;
   }
 
   _isDeviceOnline() {
@@ -1093,7 +1141,7 @@ class UnifiDeviceCard extends HTMLElement {
   }
 
   _linkLedClass(port) {
-    const connected = isPortConnected(this._hass, port);
+    const connected = this._isPortConnected(port);
     if (!connected) return "off";
 
     const speed = this._speedValueMbit(port);
@@ -1156,7 +1204,7 @@ class UnifiDeviceCard extends HTMLElement {
     const mediaType = this._portMediaType(slot);
     const isSfp = mediaType !== "rj45";
     const isWan = this._isWanLike(slot);
-    const linkUp = isPortConnected(this._hass, slot);
+    const linkUp = this._isPortConnected(slot);
     const poeStatus = getPoeStatus(this._hass, slot);
     const poeOn = poeStatus.active;
 
@@ -2102,7 +2150,7 @@ class UnifiDeviceCard extends HTMLElement {
     let detail = `<div class="muted">${this._t("no_ports")}</div>`;
 
     if (selected) {
-      const linkUp = isPortConnected(this._hass, selected);
+      const linkUp = this._isPortConnected(selected);
       const linkText = getPortLinkText(this._hass, selected);
       const speedText = getPortSpeedText(this._hass, selected);
       const poeStatus = getPoeStatus(this._hass, selected);


### PR DESCRIPTION
## Summary
- extend SFP ghost-link guard to SFP-like ports identified by entity naming
- add sticky SFP connected state to prevent polling-dip flapping
- keep explicit multi-row layouts contiguous by disabling odd/even auto mode for fixed grid styles
- respect configured `ports_per_row` in fit calculations

## Notes
- no Home Assistant core restart is required for JS-only updates; hard refresh is sufficient