### PR TITLE
Respect explicit `special_ports` config and avoid overriding with layout defaults

### DIFF
--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.18c9838 */
+/* UniFi Device Card 0.0.0-dev.7a1aaa6 */
 
 // src/model-registry.js
 function range(start, end) {
@@ -3457,6 +3457,14 @@ function collectDefaultSpecialPorts(layout) {
     )
   ).sort((a, b) => a - b);
 }
+function hasExplicitSpecialPorts(config) {
+  return Object.prototype.hasOwnProperty.call(config || {}, "special_ports");
+}
+function resolveSelectedSpecialPorts(config, layout) {
+  const configured = normalizeSpecialPortNumbers(config?.special_ports);
+  if (hasExplicitSpecialPorts(config)) return configured;
+  return collectDefaultSpecialPorts(layout);
+}
 var UnifiDeviceCardEditor = class extends HTMLElement {
   constructor() {
     super();
@@ -3578,6 +3586,9 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
   }
   _emitConfig(partial) {
     const next = { ...this._config, ...partial };
+    const hadExplicitSpecialPorts = hasExplicitSpecialPorts(this._config);
+    const hasIncomingSpecialPorts = hasExplicitSpecialPorts(partial);
+    const keepExplicitSpecialPorts = hasIncomingSpecialPorts || hadExplicitSpecialPorts;
     if (!next.name) delete next.name;
     if (!next.background_color) delete next.background_color;
     next.background_opacity = clampOpacity(next.background_opacity);
@@ -3590,10 +3601,16 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
     next.custom_special_ports = normalizeSpecialPortNumbers(next.custom_special_ports);
     if (!next.custom_special_ports.length) delete next.custom_special_ports;
     next.special_ports = normalizeSpecialPortNumbers(next.special_ports);
-    if (!next.special_ports.length && next.edit_special_ports === true) {
+    if (!next.special_ports.length && next.edit_special_ports === true && !keepExplicitSpecialPorts) {
       next.special_ports = collectDefaultSpecialPorts(this._deviceCtx?.layout);
     }
-    if (!next.special_ports.length) delete next.special_ports;
+    if (!next.special_ports.length) {
+      if (next.edit_special_ports === true && keepExplicitSpecialPorts) {
+        next.special_ports = [];
+      } else {
+        delete next.special_ports;
+      }
+    }
     if (next.edit_special_ports !== true) delete next.edit_special_ports;
     if (next.show_name !== false) delete next.show_name;
     if (next.show_panel !== false) delete next.show_panel;
@@ -3686,10 +3703,11 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
   _onEditSpecialPortsChange(ev) {
     const enabled = !!ev.target.checked;
     const defaults = collectDefaultSpecialPorts(this._deviceCtx?.layout);
+    const hasConfiguredSpecialPorts = hasExplicitSpecialPorts(this._config);
     const current = normalizeSpecialPortNumbers(this._config?.special_ports);
     this._emitConfig({
       edit_special_ports: enabled ? true : void 0,
-      special_ports: enabled ? current.length ? current : defaults : void 0,
+      special_ports: enabled ? hasConfiguredSpecialPorts ? current : defaults : void 0,
       custom_special_ports: void 0
     });
   }
@@ -3698,7 +3716,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
     if (!button) return;
     const port = Number.parseInt(button.dataset.port, 10);
     if (!Number.isInteger(port) || port < 1) return;
-    const current = normalizeSpecialPortNumbers(this._config?.special_ports);
+    const current = resolveSelectedSpecialPorts(this._config, this._deviceCtx?.layout);
     const next = current.includes(port) ? current.filter((p) => p !== port) : [...current, port];
     this._emitConfig({
       special_ports: normalizeSpecialPortNumbers(next)
@@ -3971,11 +3989,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
       /* @__PURE__ */ new Set([...collectLayoutPorts(this._deviceCtx?.layout), ...discoveredPorts])
     ).sort((a, b) => a - b);
     const customSpecialPortOptions = selectableSpecialPorts;
-    const defaultSpecialPorts = collectDefaultSpecialPorts(this._deviceCtx?.layout);
-    const selectedSpecialPorts = editSpecialPorts ? (() => {
-      const configured = normalizeSpecialPortNumbers(this._config?.special_ports);
-      return configured.length ? configured : defaultSpecialPorts;
-    })() : [];
+    const selectedSpecialPorts = editSpecialPorts ? resolveSelectedSpecialPorts(this._config, this._deviceCtx?.layout) : [];
     this.shadowRoot.innerHTML = `
       ${this._styles()}
       <div class="wrap">
@@ -4109,7 +4123,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.18c9838";
+var VERSION = "0.0.0-dev.7a1aaa6";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var LOG_LEVELS = { error: 0, warn: 1, info: 2, debug: 3, trace: 4 };
 var LOG_STYLES = {
@@ -4771,7 +4785,8 @@ var UnifiDeviceCard = class extends HTMLElement {
   _applySpecialPortSelection(specials, numbered) {
     const specialPortDefaults = specials.map((slot) => slot?.port).filter((port) => Number.isInteger(port));
     const hasEditMode = this._config?.edit_special_ports === true;
-    const selectedPorts = hasEditMode ? Array.isArray(this._config?.special_ports) ? this._normalizePortList(this._config?.special_ports) : this._normalizePortList(specialPortDefaults) : this._normalizePortList([
+    const hasExplicitSpecialPorts2 = hasEditMode && Object.prototype.hasOwnProperty.call(this._config || {}, "special_ports");
+    const selectedPorts = hasEditMode ? hasExplicitSpecialPorts2 ? this._normalizePortList(this._config?.special_ports) : this._normalizePortList(specialPortDefaults) : this._normalizePortList([
       ...specialPortDefaults,
       ...this._normalizePortList(this._config?.custom_special_ports)
     ]);

--- a/src/unifi-device-card-editor.js
+++ b/src/unifi-device-card-editor.js
@@ -139,6 +139,16 @@ function collectDefaultSpecialPorts(layout) {
   ).sort((a, b) => a - b);
 }
 
+function hasExplicitSpecialPorts(config) {
+  return Object.prototype.hasOwnProperty.call(config || {}, "special_ports");
+}
+
+function resolveSelectedSpecialPorts(config, layout) {
+  const configured = normalizeSpecialPortNumbers(config?.special_ports);
+  if (hasExplicitSpecialPorts(config)) return configured;
+  return collectDefaultSpecialPorts(layout);
+}
+
 class UnifiDeviceCardEditor extends HTMLElement {
   constructor() {
     super();
@@ -279,6 +289,9 @@ class UnifiDeviceCardEditor extends HTMLElement {
 
   _emitConfig(partial) {
     const next = { ...this._config, ...partial };
+    const hadExplicitSpecialPorts = hasExplicitSpecialPorts(this._config);
+    const hasIncomingSpecialPorts = hasExplicitSpecialPorts(partial);
+    const keepExplicitSpecialPorts = hasIncomingSpecialPorts || hadExplicitSpecialPorts;
 
     if (!next.name) delete next.name;
     if (!next.background_color) delete next.background_color;
@@ -292,10 +305,20 @@ class UnifiDeviceCardEditor extends HTMLElement {
     next.custom_special_ports = normalizeSpecialPortNumbers(next.custom_special_ports);
     if (!next.custom_special_ports.length) delete next.custom_special_ports;
     next.special_ports = normalizeSpecialPortNumbers(next.special_ports);
-    if (!next.special_ports.length && next.edit_special_ports === true) {
+    if (
+      !next.special_ports.length &&
+      next.edit_special_ports === true &&
+      !keepExplicitSpecialPorts
+    ) {
       next.special_ports = collectDefaultSpecialPorts(this._deviceCtx?.layout);
     }
-    if (!next.special_ports.length) delete next.special_ports;
+    if (!next.special_ports.length) {
+      if (next.edit_special_ports === true && keepExplicitSpecialPorts) {
+        next.special_ports = [];
+      } else {
+        delete next.special_ports;
+      }
+    }
     if (next.edit_special_ports !== true) delete next.edit_special_ports;
     if (next.show_name !== false) delete next.show_name;
     if (next.show_panel !== false) delete next.show_panel;
@@ -408,11 +431,14 @@ class UnifiDeviceCardEditor extends HTMLElement {
   _onEditSpecialPortsChange(ev) {
     const enabled = !!ev.target.checked;
     const defaults = collectDefaultSpecialPorts(this._deviceCtx?.layout);
+    const hasConfiguredSpecialPorts = hasExplicitSpecialPorts(this._config);
     const current = normalizeSpecialPortNumbers(this._config?.special_ports);
 
     this._emitConfig({
       edit_special_ports: enabled ? true : undefined,
-      special_ports: enabled ? (current.length ? current : defaults) : undefined,
+      special_ports: enabled
+        ? (hasConfiguredSpecialPorts ? current : defaults)
+        : undefined,
       custom_special_ports: undefined,
     });
   }
@@ -424,7 +450,7 @@ class UnifiDeviceCardEditor extends HTMLElement {
     const port = Number.parseInt(button.dataset.port, 10);
     if (!Number.isInteger(port) || port < 1) return;
 
-    const current = normalizeSpecialPortNumbers(this._config?.special_ports);
+    const current = resolveSelectedSpecialPorts(this._config, this._deviceCtx?.layout);
     const next = current.includes(port)
       ? current.filter((p) => p !== port)
       : [...current, port];
@@ -758,12 +784,8 @@ class UnifiDeviceCardEditor extends HTMLElement {
       new Set([...collectLayoutPorts(this._deviceCtx?.layout), ...discoveredPorts])
     ).sort((a, b) => a - b);
     const customSpecialPortOptions = selectableSpecialPorts;
-    const defaultSpecialPorts = collectDefaultSpecialPorts(this._deviceCtx?.layout);
     const selectedSpecialPorts = editSpecialPorts
-      ? (() => {
-          const configured = normalizeSpecialPortNumbers(this._config?.special_ports);
-          return configured.length ? configured : defaultSpecialPorts;
-        })()
+      ? resolveSelectedSpecialPorts(this._config, this._deviceCtx?.layout)
       : [];
 
     this.shadowRoot.innerHTML = `

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -855,9 +855,11 @@ class UnifiDeviceCard extends HTMLElement {
       .map((slot) => slot?.port)
       .filter((port) => Number.isInteger(port));
     const hasEditMode = this._config?.edit_special_ports === true;
+    const hasExplicitSpecialPorts =
+      hasEditMode && Object.prototype.hasOwnProperty.call(this._config || {}, "special_ports");
 
     const selectedPorts = hasEditMode
-      ? (Array.isArray(this._config?.special_ports)
+      ? (hasExplicitSpecialPorts
           ? this._normalizePortList(this._config?.special_ports)
           : this._normalizePortList(specialPortDefaults))
       : this._normalizePortList([


### PR DESCRIPTION
### Motivation

- Prevent the editor and renderer from unintentionally re-populating `special_ports` from layout defaults when the user has explicitly set or cleared `special_ports` in the config.

### Description

- Add `hasExplicitSpecialPorts` and `resolveSelectedSpecialPorts` helpers and wire them into the editor and runtime to distinguish explicit `special_ports` keys from implicit/default selections.
- Update `_emitConfig` in `unifi-device-card-editor` to preserve an explicit `special_ports: []` when `edit_special_ports` is enabled instead of re-inserting layout defaults; also normalize `custom_special_ports` consistently.
- Update `_onEditSpecialPortsChange` and `_onSpecialPortToggle` in the editor to use the new resolution logic so toggles and port toggles respect explicit config values.
- Update `_applySpecialPortSelection` in `unifi-device-card.js` to prefer an explicit `special_ports` array when `edit_special_ports` is enabled, otherwise fall back to defaults plus `custom_special_ports`.
- Bump development build identifier in `dist/unifi-device-card.js`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e606289eec83339be37f5c48f964b0)