### PR TITLE
fix: clear SFP sticky state when speed entity is absent or unavailable

### DIFF
--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.1adc75a */
+/* UniFi Device Card 0.0.0-dev.267cd72 */
 
 // src/model-registry.js
 function range(start, end) {
@@ -4123,7 +4123,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.1adc75a";
+var VERSION = "0.0.0-dev.267cd72";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var LOG_LEVELS = { error: 0, warn: 1, info: 2, debug: 3, trace: 4 };
 var LOG_STYLES = {
@@ -4976,7 +4976,7 @@ var UnifiDeviceCard = class extends HTMLElement {
         const result = isPortConnected(this._hass, port);
         if (!result && this._sfpConnectedSeen.has(key)) {
           const speedMbit = parseLinkSpeedMbit(this._hass, port?.speed_entity);
-          if (speedMbit == null || speedMbit > 0) return true;
+          if (speedMbit != null && speedMbit > 0) return true;
           this._sfpConnectedSeen.delete(key);
         }
         return result;

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -1109,10 +1109,13 @@ class UnifiDeviceCard extends HTMLElement {
         if (hasTraffic(this._hass, port)) this._sfpConnectedSeen.add(key);
         const result = isPortConnected(this._hass, port);
         if (!result && this._sfpConnectedSeen.has(key)) {
-          // Port was live before — only go dark if speed actually reached 0.
+          // Port was live before — only keep sticky when speed entity confirms
+          // the link is still up (> 0). A null means no speed entity exists so
+          // we cannot distinguish a poll-dip from a real disconnect; let it fall
+          // through. A value of 0 means the cable was removed.
           const speedMbit = parseLinkSpeedMbit(this._hass, port?.speed_entity);
-          if (speedMbit == null || speedMbit > 0) return true;
-          // Speed is 0: cable removed. Clear sticky state.
+          if (speedMbit != null && speedMbit > 0) return true;
+          // Speed is 0 or unavailable: clear sticky state.
           this._sfpConnectedSeen.delete(key);
         }
         return result;


### PR DESCRIPTION
Addresses review comment from PR #126 (discussion_r3108754669).

## Problem
In `_isPortConnected()`, the sticky-state guard used the condition:
```js
if (speedMbit == null || speedMbit > 0) return true;
```
This meant ports with **no `speed_entity`** (where `parseLinkSpeedMbit` returns `null`) would permanently stay "green" after their first traffic burst. The sticky state could never be cleared for those ports, which regresses link-state accuracy on the no-speed/no-link SFP path.

## Fix
Only preserve the sticky state when the speed entity is present **and** reports a positive value. When `speedMbit` is `null` the entity is absent or unavailable — we cannot distinguish a polling dip from a real disconnect, so we clear sticky state and fall through.

```js
// Before (broken):
if (speedMbit == null || speedMbit > 0) return true;

// After (fixed):
if (speedMbit != null && speedMbit > 0) return true;
```