### PR TITLE
Fix extraneous closing </div> in editor template (src + dist)

### DIFF
--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -4078,8 +4078,6 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
           <label>${this._t("editor_ports_per_row_label")}</label>
           <input id="ports_per_row" type="text" inputmode="numeric" value="${portsPerRow}">
           <div class="hint">${this._t("editor_ports_per_row_hint")}</div>
-        </div>
-
         </div>` : ""}
 
         ${isSwitchOrGateway ? `

--- a/src/unifi-device-card-editor.js
+++ b/src/unifi-device-card-editor.js
@@ -849,8 +849,6 @@ class UnifiDeviceCardEditor extends HTMLElement {
           <label>${this._t("editor_ports_per_row_label")}</label>
           <input id="ports_per_row" type="text" inputmode="numeric" value="${portsPerRow}">
           <div class="hint">${this._t("editor_ports_per_row_hint")}</div>
-        </div>
-
         </div>` : ""}
 
         ${isSwitchOrGateway ? `


### PR DESCRIPTION
### Motivation
- Remove a stray closing `</div>` that produced incorrect HTML nesting in the device editor template and could cause layout/render issues.

### Description
- Deleted the extra closing `</div>` in `src/unifi-device-card-editor.js` and updated the corresponding built file `dist/unifi-device-card.js` so the conditional editor block is correctly nested.

### Testing
- Ran the project build with `npm run build` to regenerate `dist` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e67785af388333804ef388e518b3ce)