### PR TITLE
AP-Compact-Ansicht: dynamische Skalierung bei schmaler Breite

### DIFF
--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.6.2 */
+/* UniFi Device Card 0.0.0-dev.6e36a75 */
 
 // src/model-registry.js
 function range(start, end) {
@@ -4175,7 +4175,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.6.2";
+var VERSION = "0.0.0-dev.6e36a75";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var LOG_LEVELS = { error: 0, warn: 1, info: 2, debug: 3, trace: 4 };
 var LOG_STYLES = {
@@ -5406,10 +5406,14 @@ var UnifiDeviceCard = class extends HTMLElement {
       }
 
       .frontpanel.ap-disc {
+        --udc-ap-effective-scale: min(
+          var(--udc-ap-scale),
+          max(0.6, calc((100% - 28px) / 225))
+        );
         background: var(--udc-chrome-bg, linear-gradient(160deg, var(--udc-surface) 0%, var(--udc-bg) 100%));
         display: grid;
         place-items: center;
-        min-height: calc((225px * var(--udc-ap-scale)) + 34px);
+        min-height: calc((225px * var(--udc-ap-effective-scale)) + 34px);
         border-bottom: 1px solid var(--udc-border);
         position: relative;
         overflow: hidden;
@@ -5417,8 +5421,8 @@ var UnifiDeviceCard = class extends HTMLElement {
       }
 
       .ap-device {
-        width: calc(225px * var(--udc-ap-scale));
-        height: calc(225px * var(--udc-ap-scale));
+        width: calc(225px * var(--udc-ap-effective-scale));
+        height: calc(225px * var(--udc-ap-effective-scale));
         border-radius: 50%;
         background: radial-gradient(circle at 30% 28%, #e9edf4 0%, #cfd5df 52%, #b6becb 100%);
         box-shadow:
@@ -5430,10 +5434,10 @@ var UnifiDeviceCard = class extends HTMLElement {
       }
 
       .ap-ring {
-        width: calc(92px * var(--udc-ap-scale));
-        height: calc(92px * var(--udc-ap-scale));
+        width: calc(92px * var(--udc-ap-effective-scale));
+        height: calc(92px * var(--udc-ap-effective-scale));
         border-radius: 50%;
-        border: max(2px, calc(4px * var(--udc-ap-scale))) solid var(--ap-ring-color, #a5adb8);
+        border: max(2px, calc(4px * var(--udc-ap-effective-scale))) solid var(--ap-ring-color, #a5adb8);
         box-shadow: 0 0 11px rgba(165,173,184,.35);
         display: grid;
         place-items: center;
@@ -5454,7 +5458,7 @@ var UnifiDeviceCard = class extends HTMLElement {
 
       .ap-logo {
         color: rgba(82, 89, 102, .55);
-        font-size: calc(42px * var(--udc-ap-scale));
+        font-size: calc(42px * var(--udc-ap-effective-scale));
         font-weight: 700;
         font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
         line-height: 1;

--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.6e36a75 */
+/* UniFi Device Card 0.0.0-dev.82ed81b */
 
 // src/model-registry.js
 function range(start, end) {
@@ -4175,7 +4175,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.6e36a75";
+var VERSION = "0.0.0-dev.82ed81b";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var LOG_LEVELS = { error: 0, warn: 1, info: 2, debug: 3, trace: 4 };
 var LOG_STYLES = {
@@ -5408,7 +5408,7 @@ var UnifiDeviceCard = class extends HTMLElement {
       .frontpanel.ap-disc {
         --udc-ap-effective-scale: min(
           var(--udc-ap-scale),
-          max(0.6, calc((100% - 28px) / 225))
+          max(0.6, calc((100% - 28px) / 225px))
         );
         background: var(--udc-chrome-bg, linear-gradient(160deg, var(--udc-surface) 0%, var(--udc-bg) 100%));
         display: grid;

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -1523,10 +1523,14 @@ class UnifiDeviceCard extends HTMLElement {
       }
 
       .frontpanel.ap-disc {
+        --udc-ap-effective-scale: min(
+          var(--udc-ap-scale),
+          max(0.6, calc((100% - 28px) / 225))
+        );
         background: var(--udc-chrome-bg, linear-gradient(160deg, var(--udc-surface) 0%, var(--udc-bg) 100%));
         display: grid;
         place-items: center;
-        min-height: calc((225px * var(--udc-ap-scale)) + 34px);
+        min-height: calc((225px * var(--udc-ap-effective-scale)) + 34px);
         border-bottom: 1px solid var(--udc-border);
         position: relative;
         overflow: hidden;
@@ -1534,8 +1538,8 @@ class UnifiDeviceCard extends HTMLElement {
       }
 
       .ap-device {
-        width: calc(225px * var(--udc-ap-scale));
-        height: calc(225px * var(--udc-ap-scale));
+        width: calc(225px * var(--udc-ap-effective-scale));
+        height: calc(225px * var(--udc-ap-effective-scale));
         border-radius: 50%;
         background: radial-gradient(circle at 30% 28%, #e9edf4 0%, #cfd5df 52%, #b6becb 100%);
         box-shadow:
@@ -1547,10 +1551,10 @@ class UnifiDeviceCard extends HTMLElement {
       }
 
       .ap-ring {
-        width: calc(92px * var(--udc-ap-scale));
-        height: calc(92px * var(--udc-ap-scale));
+        width: calc(92px * var(--udc-ap-effective-scale));
+        height: calc(92px * var(--udc-ap-effective-scale));
         border-radius: 50%;
-        border: max(2px, calc(4px * var(--udc-ap-scale))) solid var(--ap-ring-color, #a5adb8);
+        border: max(2px, calc(4px * var(--udc-ap-effective-scale))) solid var(--ap-ring-color, #a5adb8);
         box-shadow: 0 0 11px rgba(165,173,184,.35);
         display: grid;
         place-items: center;
@@ -1571,7 +1575,7 @@ class UnifiDeviceCard extends HTMLElement {
 
       .ap-logo {
         color: rgba(82, 89, 102, .55);
-        font-size: calc(42px * var(--udc-ap-scale));
+        font-size: calc(42px * var(--udc-ap-effective-scale));
         font-weight: 700;
         font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
         line-height: 1;

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -1525,7 +1525,7 @@ class UnifiDeviceCard extends HTMLElement {
       .frontpanel.ap-disc {
         --udc-ap-effective-scale: min(
           var(--udc-ap-scale),
-          max(0.6, calc((100% - 28px) / 225))
+          max(0.6, calc((100% - 28px) / 225px))
         );
         background: var(--udc-chrome-bg, linear-gradient(160deg, var(--udc-surface) 0%, var(--udc-bg) 100%));
         display: grid;


### PR DESCRIPTION
### Motivation
- Die AP-Darstellung in der Compact-/mobilen Ansicht wurde bei schmalen Kartenbreiten abgeschnitten, weil nur der äußere Bereich skaliert wurde; das soll behoben werden.
- Ziel ist, die konfigurierte `ap_scale` als obere Grenze zu erhalten, aber bei engen Layouts proportional nach unten zu skalieren, damit das gesamte AP-Element sichtbar bleibt.

### Description
- Neue CSS-Variable `--udc-ap-effective-scale` eingeführt, die `--udc-ap-scale` als Obergrenze nimmt und bei Bedarf auf die verfügbare Breite herunterrechnet (`min(var(--udc-ap-scale), max(0.6, calc((100% - 28px) / 225)))`).
- Die effektive Skalierung wird konsistent auf das AP-Panel angewendet (AP-Container `min-height`, `.ap-device` Breite/Höhe, `.ap-ring` Größe und Border, sowie `.ap-logo` Schriftgröße).
- Änderungen in `src/unifi-device-card.js` vorgenommen und das Build-Artefakt `dist/unifi-device-card.js` entsprechend neu generiert.

### Testing
- `node --check src/unifi-device-card.js` wurde ausgeführt und hat erfolgreich bestanden.
- `npm run build` wurde ausgeführt und hat erfolgreich gebaut sowie `dist/unifi-device-card.js` aktualisiert.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e72212c1808333a57bf3fb0152fd1a)