### PR TITLE
Fix AP effective-scale expression to remain unitless

### DIFF
--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.6e36a75 */
+/* UniFi Device Card 0.0.0-dev.82ed81b */
 
 // src/model-registry.js
 function range(start, end) {
@@ -4175,7 +4175,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.6e36a75";
+var VERSION = "0.0.0-dev.82ed81b";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var LOG_LEVELS = { error: 0, warn: 1, info: 2, debug: 3, trace: 4 };
 var LOG_STYLES = {
@@ -5408,7 +5408,7 @@ var UnifiDeviceCard = class extends HTMLElement {
       .frontpanel.ap-disc {
         --udc-ap-effective-scale: min(
           var(--udc-ap-scale),
-          max(0.6, calc((100% - 28px) / 225))
+          max(0.6, calc((100% - 28px) / 225px))
         );
         background: var(--udc-chrome-bg, linear-gradient(160deg, var(--udc-surface) 0%, var(--udc-bg) 100%));
         display: grid;

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -1525,7 +1525,7 @@ class UnifiDeviceCard extends HTMLElement {
       .frontpanel.ap-disc {
         --udc-ap-effective-scale: min(
           var(--udc-ap-scale),
-          max(0.6, calc((100% - 28px) / 225))
+          max(0.6, calc((100% - 28px) / 225px))
         );
         background: var(--udc-chrome-bg, linear-gradient(160deg, var(--udc-surface) 0%, var(--udc-bg) 100%));
         display: grid;


### PR DESCRIPTION
### Motivation
- Prevent mixing CSS value types in `max(0.6, …)` so the AP compact-view scale comparison remains valid by ensuring the computed divisor is treated as a length expression rather than a bare number.

### Description
- Change in `src/unifi-device-card.js`: update `--udc-ap-effective-scale` calculation from `max(0.6, calc((100% - 28px) / 225))` to `max(0.6, calc((100% - 28px) / 225px))` so the expression stays unit-compatible.
- Regenerate `dist/unifi-device-card.js` so the distribution build reflects the same fix.

### Testing
- Ran `node --check src/unifi-device-card.js` and it succeeded.
- Ran `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e738841b288333b627e07406f92690)