### PR TITLE
Add compact AP scaling and CSS variable; update dev version

### DIFF
--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.6e36a75 */
+/* UniFi Device Card 0.0.0-dev.054d5be */
 
 // src/model-registry.js
 function range(start, end) {
@@ -4175,7 +4175,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.6e36a75";
+var VERSION = "0.0.0-dev.054d5be";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var LOG_LEVELS = { error: 0, warn: 1, info: 2, debug: 3, trace: 4 };
 var LOG_STYLES = {
@@ -4406,6 +4406,16 @@ var UnifiDeviceCard = class extends HTMLElement {
     const raw = Number.parseInt(this._config?.ap_scale, 10);
     if (!Number.isFinite(raw)) return 100;
     return Math.min(140, Math.max(60, raw));
+  }
+  _apCompactScaleLimit() {
+    const cardWidth = this._measuredCardWidth();
+    if (!Number.isFinite(cardWidth) || cardWidth <= 0) return 1;
+    const compactThreshold = 340;
+    if (cardWidth >= compactThreshold) return 1;
+    const available = Math.max(0, cardWidth - 28);
+    const scale = available / 225;
+    if (!Number.isFinite(scale)) return 1;
+    return Math.max(0.6, Math.min(1, scale));
   }
   _maxPortColumns() {
     const rows = this._ctx?.layout?.rows || [];
@@ -5406,10 +5416,7 @@ var UnifiDeviceCard = class extends HTMLElement {
       }
 
       .frontpanel.ap-disc {
-        --udc-ap-effective-scale: min(
-          var(--udc-ap-scale),
-          max(0.6, calc((100% - 28px) / 225))
-        );
+        --udc-ap-effective-scale: min(var(--udc-ap-scale), var(--udc-ap-compact-scale, 1));
         background: var(--udc-chrome-bg, linear-gradient(160deg, var(--udc-surface) 0%, var(--udc-bg) 100%));
         display: grid;
         place-items: center;
@@ -5923,7 +5930,7 @@ var UnifiDeviceCard = class extends HTMLElement {
       const headerTitle2 = this._title();
       const headerMetrics2 = this._headerMetrics();
       this.shadowRoot.innerHTML = `${this._styles()}
-        <ha-card class="ap-card" style="--udc-card-bg: ${this._cardBgStyle()}; --udc-chrome-bg: ${this._cardChromeBgStyle()}; --ap-ring-color: ${ringColor}; --udc-port-size: ${this._effectivePortSize()}px; --udc-ap-scale: ${this._apScale() / 100}">
+        <ha-card class="ap-card" style="--udc-card-bg: ${this._cardBgStyle()}; --udc-chrome-bg: ${this._cardChromeBgStyle()}; --ap-ring-color: ${ringColor}; --udc-port-size: ${this._effectivePortSize()}px; --udc-ap-scale: ${this._apScale() / 100}; --udc-ap-compact-scale: ${this._apCompactScaleLimit()}">
           <div class="header">
             <div class="header-info">
               ${headerTitle2 ? `<div class="title">${headerTitle2}</div>` : ""}

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -301,6 +301,19 @@ class UnifiDeviceCard extends HTMLElement {
     return Math.min(140, Math.max(60, raw));
   }
 
+  _apCompactScaleLimit() {
+    const cardWidth = this._measuredCardWidth();
+    if (!Number.isFinite(cardWidth) || cardWidth <= 0) return 1;
+
+    const compactThreshold = 340;
+    if (cardWidth >= compactThreshold) return 1;
+
+    const available = Math.max(0, cardWidth - 28);
+    const scale = available / 225;
+    if (!Number.isFinite(scale)) return 1;
+    return Math.max(0.6, Math.min(1, scale));
+  }
+
   _maxPortColumns() {
     const rows = this._ctx?.layout?.rows || [];
     const maxRowCols = rows.reduce((max, row) => Math.max(max, row.length || 0), 0);
@@ -1523,10 +1536,7 @@ class UnifiDeviceCard extends HTMLElement {
       }
 
       .frontpanel.ap-disc {
-        --udc-ap-effective-scale: min(
-          var(--udc-ap-scale),
-          max(0.6, calc((100% - 28px) / 225))
-        );
+        --udc-ap-effective-scale: min(var(--udc-ap-scale), var(--udc-ap-compact-scale, 1));
         background: var(--udc-chrome-bg, linear-gradient(160deg, var(--udc-surface) 0%, var(--udc-bg) 100%));
         display: grid;
         place-items: center;
@@ -2043,7 +2053,7 @@ class UnifiDeviceCard extends HTMLElement {
       const headerMetrics = this._headerMetrics();
 
       this.shadowRoot.innerHTML = `${this._styles()}
-        <ha-card class="ap-card" style="--udc-card-bg: ${this._cardBgStyle()}; --udc-chrome-bg: ${this._cardChromeBgStyle()}; --ap-ring-color: ${ringColor}; --udc-port-size: ${this._effectivePortSize()}px; --udc-ap-scale: ${this._apScale() / 100}">
+        <ha-card class="ap-card" style="--udc-card-bg: ${this._cardBgStyle()}; --udc-chrome-bg: ${this._cardChromeBgStyle()}; --ap-ring-color: ${ringColor}; --udc-port-size: ${this._effectivePortSize()}px; --udc-ap-scale: ${this._apScale() / 100}; --udc-ap-compact-scale: ${this._apCompactScaleLimit()}">
           <div class="header">
             <div class="header-info">
               ${headerTitle ? `<div class="title">${headerTitle}</div>` : ""}


### PR DESCRIPTION
### Motivation
- Improve rendering of access point artwork on narrow cards by limiting the AP disc size dynamically. 
- Make the compact-scale calculation available as a CSS variable so the layout can use a simple `var()` instead of complex `calc()` expressions.

### Description
- Add `_apCompactScaleLimit()` which measures the card width and returns a compact scale clamped between `0.6` and `1` with a `compactThreshold` of `340` pixels.
- Inject `--udc-ap-compact-scale` on the AP card element inline using the computed `_apCompactScaleLimit()` value.
- Replace the previous inline `calc((100% - 28px) / 225)` CSS clamp with `--udc-ap-compact-scale` in `.frontpanel.ap-disc` to simplify CSS and respect the JS-measured limit.
- Bump the development `VERSION` string in both `src` and generated `dist` output to reflect the change and update the built artifact `dist/unifi-device-card.js` accordingly.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e738841b288333b627e07406f92690)