### PR TITLE
Ensure AP LED stays blue unless model explicitly defines apLedDefaultColor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Add AP-only `ap_compact_view` option with an editor checkbox to render AP cards in a compact side-by-side layout
 - Hide the AP size slider while compact view is enabled and extend AP size range to 25–140 for normal AP view
 
+### 🐛 Bug Fixes
+- Added per-model AP LED fallback colors so legacy models (`UAP`, `UAP-LR`, `UAP-Outdoor5`) use green when no LED RGB/color entity is available.
+
 ## [0.6.2] - 2026-04-20
 
 ### ✨ Improvements

--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.ddb1416 */
+/* UniFi Device Card 0.0.0-dev.b92c9c0 */
 
 // src/model-registry.js
 function range(start, end) {
@@ -80,8 +80,9 @@ var MODEL_REGISTRY = {
   // ══════════════════════════════════════════════════════════════════════════
   // ACCESS POINTS
   // ══════════════════════════════════════════════════════════════════════════
-  UAP: apModel("UAP"),
-  UAPLR: apModel("UAP-LR"),
+  UAP: { ...apModel("UAP"), apLedDefaultColor: "#33d35d" },
+  UAPLR: { ...apModel("UAP-LR"), apLedDefaultColor: "#33d35d" },
+  UAPOUTDOOR5: { ...apModel("UAP-Outdoor5"), apLedDefaultColor: "#33d35d" },
   UAPPRO: apModel("UAP-Pro"),
   UAPAC: apModel("UAP AC"),
   UAPACLITE: apModel("UAP AC Lite"),
@@ -4210,7 +4211,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.ddb1416";
+var VERSION = "0.0.0-dev.b92c9c0";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var LOG_LEVELS = { error: 0, warn: 1, info: 2, debug: 3, trace: 4 };
 var LOG_STYLES = {
@@ -4584,7 +4585,8 @@ var UnifiDeviceCard = class extends HTMLElement {
   _apLedState() {
     const ledEntity = this._ctx?.led_switch_entity;
     const ledEnabled = ledEntity ? isOn(this._hass, ledEntity) : this._isDeviceOnline();
-    const ringColor = ledEnabled ? this._apLedColorValue() || "#0000ff" : "#868b93";
+    const defaultColor = this._ctx?.layout?.apLedDefaultColor ?? "#0000ff";
+    const ringColor = ledEnabled ? this._apLedColorValue() || defaultColor : "#868b93";
     return { ledEntity, ledEnabled, ringColor };
   }
   _apUplinkText(uplink) {

--- a/src/model-registry.js
+++ b/src/model-registry.js
@@ -122,8 +122,9 @@ export const MODEL_REGISTRY = {
   // ══════════════════════════════════════════════════════════════════════════
   // ACCESS POINTS
   // ══════════════════════════════════════════════════════════════════════════
-  UAP: apModel("UAP"),
-  UAPLR: apModel("UAP-LR"),
+  UAP: { ...apModel("UAP"), apLedDefaultColor: "#33d35d" },
+  UAPLR: { ...apModel("UAP-LR"), apLedDefaultColor: "#33d35d" },
+  UAPOUTDOOR5: { ...apModel("UAP-Outdoor5"), apLedDefaultColor: "#33d35d" },
   UAPPRO: apModel("UAP-Pro"),
   UAPAC: apModel("UAP AC"),
   UAPACLITE: apModel("UAP AC Lite"),

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -473,7 +473,8 @@ class UnifiDeviceCard extends HTMLElement {
   _apLedState() {
     const ledEntity = this._ctx?.led_switch_entity;
     const ledEnabled = ledEntity ? isOn(this._hass, ledEntity) : this._isDeviceOnline();
-    const ringColor = ledEnabled ? (this._apLedColorValue() || "#0000ff") : "#868b93";
+    const defaultColor = this._ctx?.layout?.apLedDefaultColor ?? "#0000ff";
+    const ringColor = ledEnabled ? (this._apLedColorValue() || defaultColor) : "#868b93";
     return { ledEntity, ledEnabled, ringColor };
   }
 


### PR DESCRIPTION
## Summary
- adjusted AP model defaults so `apLedDefaultColor` is no longer injected globally for every AP model
- kept explicit green fallback assignments only for `UAP`, `UAPLR`, and `UAPOUTDOOR5` in `src/model-registry.js`
- updated AP LED fallback resolution to use nullish coalescing in `src/unifi-device-card.js`:
  - `layout.apLedDefaultColor ?? "#0000ff"`
- rebuilt `dist/unifi-device-card.js`

## Result
Blue remains the standard default for AP LED ring color unless a model explicitly has `apLedDefaultColor` in the model registry.

## Validation
- `npm run build`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e745c78b4483338d135629bb6fd569)