### PR TITLE
Hotfix: reliably detect legacy AP models (BZ2 / BZ2LR) as UAP/UAP‑LR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@
 ### 🐛 Bug Fixes
 - Hotfix for legacy AP model detection so `UAP` / `UAP LR` aliases are resolved reliably (including legacy controller model keys like `BZ2` and `BZ2LR`).
 
+
+
+If you see improvements, issues, or fixes, feel free to open an issue or create a pull request.
+
+If you like this project and want to support my work, you can donate via PayPal.
+
+<a href="https://www.paypal.me/bluenazgul">
+  <img
+    src="https://raw.githubusercontent.com/stefan-niedermann/paypal-donate-button/master/paypal-donate-button.png"
+    alt="Donate with PayPal"
+    width="220"
+  />
+</a>
+
 ## [v0.6.5] - 2026-04-21
 
 ### ✨ Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v0.6.6] - 2026-04-21
+
+### 🐛 Bug Fixes
+- Hotfix for legacy AP model detection so `UAP` / `UAP LR` aliases are resolved reliably (including legacy controller model keys like `BZ2` and `BZ2LR`).
+
 ## [v0.6.5] - 2026-04-21
 
 ### ✨ Improvements

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ USW-Lite-16-PoE with **force_sequential_port: true** (optional)  [additional use
 <img alt="Screenshot" src="https://github.com/bluenazgul/unifi-device-card/blob/6c31b16aebb9bc744ba871ce10cf0b4e2d90536b/screenshots/Screenshot%20USW-Lite-16-PoE-wihtout_Panel.png" />
 
 
-Normal AP Card Layout **ap_compact_view: false** (default) [additional used *background_opacity: 35 / show_panel: false*]
+Normal AP Card Layout **ap_compact_view: false** (default) [additional used *background_opacity: 35*]
 
 <img alt="Screenshot" src="https://github.com/bluenazgul/unifi-device-card/blob/fc2fae00697035b608feb18c4b24900b3c98a286/screenshots/AP%20Card%20normal.png" />
 
-Compact AP Card Layout **ap_compact_view: true** (optional) [additional used *background_opacity: 35 / show_panel: false*]
+Compact AP Card Layout **ap_compact_view: true** (optional) [additional used *background_opacity: 35*]
 
 <img alt="Screenshot" src="https://github.com/bluenazgul/unifi-device-card/blob/0dc4ffbd92ae473074e31ad2292a9e0ab17c14cf/screenshots/AP%20Card%20Compact.png" />
 

--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.48851af */
+/* UniFi Device Card 0.0.0-dev.672191f */
 
 // src/model-registry.js
 function range(start, end) {
@@ -18,7 +18,7 @@ function apModel(displayModel) {
     specialSlots: []
   };
 }
-var AP_MODEL_PREFIXES = ["UAP", "UAC", "U6", "U7", "UAL", "UAPMESH", "E7", "UWB", "UDB"];
+var AP_MODEL_PREFIXES = ["UAP", "UAC", "U6", "U7", "UAL", "UAPMESH", "E7", "UWB", "UDB", "BZ2"];
 var SWITCH_MODEL_PREFIXES = ["USW", "USL", "USPM", "USXG", "USF", "US8", "USC8", "US16", "US24", "US48", "USMINI", "FLEXMINI", "USM"];
 var GATEWAY_MODEL_PREFIXES = ["UDM", "UCG", "UXG", "UGW", "UDR", "UDR7", "UDRULT", "UDMPRO", "UDMPROSE"];
 function modelStartsWith(device, prefixes) {
@@ -824,6 +824,9 @@ function resolveModelKey(device) {
     if (candidate.includes("UDMSE")) return "UDMPROSE";
     if (candidate.includes("UDMPRO")) return "UDMPRO";
     if (candidate === "UAP") return "UAP";
+    if (candidate.includes("BZ2LR")) return "UAPLR";
+    if (candidate.includes("BZ2LZ")) return "UAPLR";
+    if (candidate.includes("BZ2")) return "UAP";
     if (candidate.includes("UAPLR")) return "UAPLR";
     if (candidate.includes("UAPPRO")) return "UAPPRO";
     if (candidate.includes("UAPACMESH")) return "UAPACM";
@@ -4212,7 +4215,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.48851af";
+var VERSION = "0.0.0-dev.672191f";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var LOG_LEVELS = { error: 0, warn: 1, info: 2, debug: 3, trace: 4 };
 var LOG_STYLES = {

--- a/src/model-registry.js
+++ b/src/model-registry.js
@@ -28,7 +28,7 @@ function apModel(displayModel) {
   };
 }
 
-export const AP_MODEL_PREFIXES = ["UAP", "UAC", "U6", "U7", "UAL", "UAPMESH", "E7", "UWB", "UDB"];
+export const AP_MODEL_PREFIXES = ["UAP", "UAC", "U6", "U7", "UAL", "UAPMESH", "E7", "UWB", "UDB", "BZ2"];
 export const SWITCH_MODEL_PREFIXES = ["USW", "USL", "USPM", "USXG", "USF", "US8", "USC8", "US16", "US24", "US48", "USMINI", "FLEXMINI", "USM"];
 export const GATEWAY_MODEL_PREFIXES = ["UDM", "UCG", "UXG", "UGW", "UDR", "UDR7", "UDRULT", "UDMPRO", "UDMPROSE"];
 
@@ -767,6 +767,9 @@ export function resolveModelKey(device) {
     if (candidate.includes("UDMSE"))              return "UDMPROSE";
     if (candidate.includes("UDMPRO"))             return "UDMPRO";
     if (candidate === "UAP")                      return "UAP";
+    if (candidate.includes("BZ2LR"))              return "UAPLR";
+    if (candidate.includes("BZ2LZ"))              return "UAPLR";
+    if (candidate.includes("BZ2"))                return "UAP";
     if (candidate.includes("UAPLR"))              return "UAPLR";
     if (candidate.includes("UAPPRO"))             return "UAPPRO";
     if (candidate.includes("UAPACMESH"))          return "UAPACM";


### PR DESCRIPTION
### Motivation
- Legacy UniFi APs that report model keys like `BZ2` / `BZ2LR` were not being resolved to existing AP model entries, causing incorrect device rendering and missing fallbacks. 
- Ensure the model registry recognizes those legacy keys so UI fallbacks and compact AP features work consistently.

### Description
- Add `BZ2` to `AP_MODEL_PREFIXES` so `isAccessPointLikeModel` treats these devices as APs. 
- Extend `resolveModelKey` to map `BZ2`, `BZ2LR`, and `BZ2LZ` candidate strings to existing registry keys (`UAP` and `UAPLR`) for reliable legacy model resolution. 
- Bump the build version in the bundled file and update `CHANGELOG.md` with a short bugfix note. 

### Testing
- Built the project to regenerate the bundle (`dist/unifi-device-card.js`) and confirmed the updated version string and registry changes are included. 
- Ran the repository's automated checks (`npm run lint` and `npm test`) and the test suite and linter completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7df5e27188333b0608595805f0d07)