### PR TITLE
Improve fallback model classification for U5O and USG-XG-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### 🐛 Bug Fixes
+- Classify `USG-XG-8` (`USGXG8` → `UGWXG`) reliably as gateway in fallback type detection.
+- Classify legacy `U5O` alias (`UAP-Outdoor5`) reliably as access point in fallback type detection.
+
 ## [v0.6.7]
 
 ### ✨ Improvements

--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.6.7 */
+/* UniFi Device Card 0.0.0-dev.a93169f */
 
 // src/model-registry.js
 function range(start, end) {
@@ -18,7 +18,7 @@ function apModel(displayModel) {
     specialSlots: []
   };
 }
-var AP_MODEL_PREFIXES = ["UAP", "UAC", "U6", "U7", "UAL", "UAPMESH", "E7", "UWB", "UDB", "BZ2"];
+var AP_MODEL_PREFIXES = ["UAP", "UAC", "U6", "U7", "UAL", "UAPMESH", "E7", "UWB", "UDB", "BZ2", "U5O"];
 var SWITCH_MODEL_PREFIXES = ["USW", "USL", "USPM", "USXG", "USF", "US8", "USC8", "US16", "US24", "US48", "USMINI", "FLEXMINI", "USM"];
 var GATEWAY_MODEL_PREFIXES = ["UDM", "UCG", "UXG", "UGW", "UDR", "UDR7", "UDRULT", "UDMPRO", "UDMPROSE"];
 function modelStartsWith(device, prefixes) {
@@ -1414,8 +1414,11 @@ function classifyDeviceType(identity, capabilities, entities = [], device = null
   if (capabilities?.ports || capabilities?.port_control || capabilities?.poe_power) return "switch";
   const modelKey = resolveModelKey(device || identity || {});
   if (modelKey) {
-    if (["UDM", "UDR", "UDMPRO", "UDMPROSE", "UXGPRO", "UXGL", "UGW3", "UGW4", "UCGULTRA", "UCGMAX", "UCGFIBER"].includes(modelKey)) {
+    if (["UDM", "UDR", "UDMPRO", "UDMPROSE", "UXGPRO", "UXGL", "UGW3", "UGW4", "UGWXG", "UCGULTRA", "UCGMAX", "UCGFIBER"].includes(modelKey)) {
       return "gateway";
+    }
+    if (modelKey.startsWith("UAP") || modelKey.startsWith("U6") || modelKey.startsWith("U7") || modelKey === "E7") {
+      return "access_point";
     }
     if (["USMINI", "USWULTRA", "US8P60", "US8P150", "USL8LP", "USL16LP", "US24PRO", "US48PRO"].includes(modelKey) || modelKey.startsWith("US")) {
       return "switch";
@@ -4294,7 +4297,7 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
 customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
 
 // src/unifi-device-card.js
-var VERSION = "0.6.7";
+var VERSION = "0.0.0-dev.a93169f";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var LOG_LEVELS = { error: 0, warn: 1, info: 2, debug: 3, trace: 4 };
 var LOG_STYLES = {

--- a/src/classify.js
+++ b/src/classify.js
@@ -47,8 +47,11 @@ export function classifyDeviceType(identity, capabilities, entities = [], device
 
   const modelKey = resolveModelKey(device || identity || {});
   if (modelKey) {
-    if (["UDM", "UDR", "UDMPRO", "UDMPROSE", "UXGPRO", "UXGL", "UGW3", "UGW4", "UCGULTRA", "UCGMAX", "UCGFIBER"].includes(modelKey)) {
+    if (["UDM", "UDR", "UDMPRO", "UDMPROSE", "UXGPRO", "UXGL", "UGW3", "UGW4", "UGWXG", "UCGULTRA", "UCGMAX", "UCGFIBER"].includes(modelKey)) {
       return "gateway";
+    }
+    if (modelKey.startsWith("UAP") || modelKey.startsWith("U6") || modelKey.startsWith("U7") || modelKey === "E7") {
+      return "access_point";
     }
     if (["USMINI", "USWULTRA", "US8P60", "US8P150", "USL8LP", "USL16LP", "US24PRO", "US48PRO"].includes(modelKey) || modelKey.startsWith("US")) {
       return "switch";

--- a/src/model-registry.js
+++ b/src/model-registry.js
@@ -28,7 +28,7 @@ function apModel(displayModel) {
   };
 }
 
-export const AP_MODEL_PREFIXES = ["UAP", "UAC", "U6", "U7", "UAL", "UAPMESH", "E7", "UWB", "UDB", "BZ2"];
+export const AP_MODEL_PREFIXES = ["UAP", "UAC", "U6", "U7", "UAL", "UAPMESH", "E7", "UWB", "UDB", "BZ2", "U5O"];
 export const SWITCH_MODEL_PREFIXES = ["USW", "USL", "USPM", "USXG", "USF", "US8", "USC8", "US16", "US24", "US48", "USMINI", "FLEXMINI", "USM"];
 export const GATEWAY_MODEL_PREFIXES = ["UDM", "UCG", "UXG", "UGW", "UDR", "UDR7", "UDRULT", "UDMPRO", "UDMPROSE"];
 


### PR DESCRIPTION
### Motivation
- Improve fallback device type detection so some legacy/edge model keys are classified correctly as gateways or access points.

### Description
- Add `U5O` to `AP_MODEL_PREFIXES` in `src/model-registry.js` so legacy `U5O` / `UAP-Outdoor5` aliases are detected as access points.
- Treat `UGWXG` as a gateway model key in the classifier by adding it to the gateway modelKey list in `src/classify.js` (fixes `USG-XG-8` / `USGXG8` mapping to `UGWXG`).
- Add explicit access point detection for model keys starting with `UAP`, `U6`, `U7`, or equal to `E7` in `src/classify.js` to improve fallback classification.
- Update built artifacts (`dist/unifi-device-card.js`) and `CHANGELOG.md` to reflect the fixes and current dev build version.

### Testing
- Built the distribution with `npm run build` and updated the generated `dist/unifi-device-card.js` successfully.
- Ran unit tests with `npm test`, and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed0a5ec38483339aae008cc0e7a20e)