### PR TITLE
Use Python to build Codex issue prompt and use env vars for workflow summary

### DIFF
--- a/.github/workflows/codex-issue-analysis.yml
+++ b/.github/workflows/codex-issue-analysis.yml
@@ -25,11 +25,19 @@ jobs:
           fetch-depth: 0
 
       - name: Create Codex issue analysis prompt
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
           mkdir -p .github/codex/runtime
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
 
-          cat > .github/codex/runtime/issue-analysis-prompt.md <<'EOF'
-          You are analyzing a GitHub issue for the repository bluenazgul/unifi-device-card.
+          content = """You are analyzing a GitHub issue for the repository bluenazgul/unifi-device-card.
 
           Repository:
           bluenazgul/unifi-device-card
@@ -38,19 +46,19 @@ jobs:
           develop
 
           Issue number:
-          #${{ github.event.issue.number }}
+          #""" + os.environ.get("ISSUE_NUMBER", "") + """
 
           Issue title:
-          ${{ github.event.issue.title }}
+          """ + os.environ.get("ISSUE_TITLE", "") + """
 
           Issue URL:
-          ${{ github.event.issue.html_url }}
+          """ + os.environ.get("ISSUE_URL", "") + """
 
           Issue author:
-          ${{ github.event.issue.user.login }}
+          """ + os.environ.get("ISSUE_AUTHOR", "") + """
 
           Issue body:
-          ${{ github.event.issue.body }}
+          """ + os.environ.get("ISSUE_BODY", "") + """
 
           Before doing the analysis:
           - Read and follow the repository AGENTS.md file if it exists.
@@ -142,7 +150,10 @@ jobs:
           - Do not push anything.
           - Do not modify repository files.
           - Only produce this analysis report.
-          EOF
+          """
+
+          Path(".github/codex/runtime/issue-analysis-prompt.md").write_text(content, encoding="utf-8")
+          PY
 
       - name: Run Codex analysis
         id: run_codex
@@ -156,14 +167,18 @@ jobs:
 
       - name: Add analysis to workflow summary
         if: always()
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
         run: |
-          echo "# Codex Issue Analysis" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Repository: \`${{ github.repository }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Base branch: \`develop\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Issue: [#${{ github.event.issue.number }}](${{ github.event.issue.html_url }})" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Title: ${{ github.event.issue.title }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
+          {
+            printf '# Codex Issue Analysis\n\n'
+            printf -- '- Repository: `%s`\n' "${{ github.repository }}"
+            printf -- '- Base branch: `develop`\n'
+            printf -- '- Issue: [#%s](%s)\n' "$ISSUE_NUMBER" "$ISSUE_URL"
+            printf -- '- Title: %s\n\n' "$ISSUE_TITLE"
+          } >> "$GITHUB_STEP_SUMMARY"
 
           if [ -f codex-issue-analysis.md ]; then
             cat codex-issue-analysis.md >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
### Motivation
- Replace fragile GitHub Actions heredoc interpolation with a deterministic prompt file builder that avoids action templating pitfalls.
- Ensure the workflow summary uses explicit environment variables to reliably render issue metadata in the step summary.

### Description
- Replace the inline `cat` heredoc that wrote `.github/codex/runtime/issue-analysis-prompt.md` with an inline Python script that constructs the prompt and writes the file using environment variables.
- Export issue metadata as `ISSUE_NUMBER`, `ISSUE_TITLE`, `ISSUE_URL`, `ISSUE_AUTHOR`, and `ISSUE_BODY` and consume them when creating the prompt and when building the workflow summary.
- Replace multiple `echo` summary lines with a single `printf` block that references the exported env vars to append a well-formatted header to `GITHUB_STEP_SUMMARY`.
- Keep existing Codex action usage and artifact upload behavior unchanged while adding safer prompt generation and summary formatting.

### Testing
- No automated CI tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed27c7d27c83338e2b9fd7f31b60f1)