### PR TITLE
Guard custom element and customCards registration to avoid duplicate definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix gateway classification for `USG-XG-8` / `UGWXG` aliases so gateway-specific behavior is applied reliably even without gateway-like names.
 - Fix AP classification for legacy `U5O` (`UAP-Outdoor5`) aliases so these devices remain visible in the editor when capability signals are limited.
 - Harden dynamic template rendering in card/editor by consistently escaping interpolated HTML text and attribute values (including warnings, gateway option labels, header/detail metrics, and entity-derived values).
+- Guard custom element registration and Home Assistant `customCards` registration to prevent duplicate-definition errors and duplicate card-list entries when resources are loaded more than once.
 
 
 

--- a/dist/unifi-device-card.js
+++ b/dist/unifi-device-card.js
@@ -1,4 +1,4 @@
-/* UniFi Device Card 0.0.0-dev.4af4f4e */
+/* UniFi Device Card 0.0.0-dev.72afd6a */
 
 // src/model-registry.js
 function range(start, end) {
@@ -4297,10 +4297,12 @@ var UnifiDeviceCardEditor = class extends HTMLElement {
     this._render();
   }
 };
-customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
+if (!customElements.get("unifi-device-card-editor")) {
+  customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
+}
 
 // src/unifi-device-card.js
-var VERSION = "0.0.0-dev.4af4f4e";
+var VERSION = "0.0.0-dev.72afd6a";
 var DEV_LOG_FLAG = "__UNIFI_DEVICE_CARD_VERSION_LOGGED__";
 var LOG_LEVELS = { error: 0, warn: 1, info: 2, debug: 3, trace: 4 };
 var LOG_STYLES = {
@@ -6337,15 +6339,19 @@ var UnifiDeviceCard = class extends HTMLElement {
     this._finalizeRender();
   }
 };
-customElements.define("unifi-device-card", UnifiDeviceCard);
+if (!customElements.get("unifi-device-card")) {
+  customElements.define("unifi-device-card", UnifiDeviceCard);
+}
 window.customCards = window.customCards || [];
-window.customCards.push({
-  type: "unifi-device-card",
-  name: "UniFi Device Card",
-  description: `Lovelace card for UniFi devices (v${VERSION}).`,
-  preview: true,
-  documentationURL: "https://github.com/bluenazgul/unifi-device-card"
-});
+if (!window.customCards.some((card) => card?.type === "unifi-device-card")) {
+  window.customCards.push({
+    type: "unifi-device-card",
+    name: "UniFi Device Card",
+    description: `Lovelace card for UniFi devices (v${VERSION}).`,
+    preview: true,
+    documentationURL: "https://github.com/bluenazgul/unifi-device-card"
+  });
+}
 if (!window[DEV_LOG_FLAG]) {
   window[DEV_LOG_FLAG] = true;
   console.log(

--- a/src/unifi-device-card-editor.js
+++ b/src/unifi-device-card-editor.js
@@ -1028,4 +1028,6 @@ class UnifiDeviceCardEditor extends HTMLElement {
   }
 }
 
-customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
+if (!customElements.get("unifi-device-card-editor")) {
+  customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
+}

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -2393,16 +2393,20 @@ class UnifiDeviceCard extends HTMLElement {
   }
 }
 
-customElements.define("unifi-device-card", UnifiDeviceCard);
+if (!customElements.get("unifi-device-card")) {
+  customElements.define("unifi-device-card", UnifiDeviceCard);
+}
 
 window.customCards = window.customCards || [];
-window.customCards.push({
-  type: "unifi-device-card",
-  name: "UniFi Device Card",
-  description: `Lovelace card for UniFi devices (v${VERSION}).`,
-  preview: true,
-  documentationURL: "https://github.com/bluenazgul/unifi-device-card",
-});
+if (!window.customCards.some((card) => card?.type === "unifi-device-card")) {
+  window.customCards.push({
+    type: "unifi-device-card",
+    name: "UniFi Device Card",
+    description: `Lovelace card for UniFi devices (v${VERSION}).`,
+    preview: true,
+    documentationURL: "https://github.com/bluenazgul/unifi-device-card",
+  });
+}
 
 if (!window[DEV_LOG_FLAG]) {
   window[DEV_LOG_FLAG] = true;


### PR DESCRIPTION
### Motivation
- Prevent runtime errors and duplicate UI entries when the card resources are loaded more than once by guarding registration of custom elements and Home Assistant `customCards` metadata.
- Reflect the change in the distributable and release notes so consumers get a built artifact and changelog entry.

### Description
- Add guards around `customElements.define` calls for `unifi-device-card-editor` and `unifi-device-card` by checking `customElements.get(...)` before registering the element.
- Prevent duplicate Home Assistant card-list entries by only pushing to `window.customCards` if an entry with `type === "unifi-device-card"` does not already exist.
- Update the built bundle `dist/unifi-device-card.js` and bump the development `VERSION` string in the distributable.
- Add a changelog entry describing the new guard to `CHANGELOG.md`.

### Testing
- Built the project with `npm run build` and confirmed the build completed successfully and produced the updated `dist/unifi-device-card.js` file.
- Verified the updated distributable contains the new guards and the `VERSION` bump with no build errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0d6199c8333a34147fb770abc8c)