### PR TITLE
Improve device type classification and guard custom element definition

### DIFF
--- a/src/classify.js
+++ b/src/classify.js
@@ -43,17 +43,21 @@ export function classifyDeviceType(identity, capabilities, entities = [], device
   if (gatewaySignals) return "gateway";
 
   const modelKey = resolveModelKey(device || identity || {});
+  const gatewayModelKeys = ["UDM", "UDR", "UDMPRO", "UDMPROSE", "UXGPRO", "UXGL", "UGW3", "UGW4", "UGWXG", "UCGULTRA", "UCGMAX", "UCGFIBER"];
+  const hasPortSignals = !!(capabilities?.ports || capabilities?.port_control || capabilities?.poe_power);
+  if (modelKey && gatewayModelKeys.includes(modelKey) && hasPortSignals) return "gateway";
+
+  if (capabilities?.ap_stats || capabilities?.uplink_mac) return "access_point";
+  if (hasPortSignals) return "switch";
+
   if (modelKey) {
-    if (["UDM", "UDR", "UDMPRO", "UDMPROSE", "UXGPRO", "UXGL", "UGW3", "UGW4", "UGWXG", "UCGULTRA", "UCGMAX", "UCGFIBER"].includes(modelKey)) {
+    if (gatewayModelKeys.includes(modelKey)) {
       return "gateway";
     }
     if (["USMINI", "USWULTRA", "US8P60", "US8P150", "USL8LP", "USL16LP", "US24PRO", "US48PRO"].includes(modelKey) || modelKey.startsWith("US")) {
       return "switch";
     }
   }
-
-  if (capabilities?.ap_stats || capabilities?.uplink_mac) return "access_point";
-  if (capabilities?.ports || capabilities?.port_control || capabilities?.poe_power) return "switch";
 
   if (manufacturer.includes("ubiquiti") || manufacturer.includes("unifi")) {
     if (name.includes("switch")) return "switch";

--- a/src/unifi-device-card-editor.js
+++ b/src/unifi-device-card-editor.js
@@ -1418,4 +1418,6 @@ class UnifiDeviceCardEditor extends HTMLElement {
   }
 }
 
-customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
+if (!customElements.get("unifi-device-card-editor")) {
+  customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor);
+}


### PR DESCRIPTION
### Motivation

- Improve accuracy of device type detection by combining model keys with capability signals and avoiding duplicate checks in `classifyDeviceType` in `src/classify.js`.
- Ensure the editor component can be hot-reloaded or included multiple times without throwing when registering the custom element in `src/unifi-device-card-editor.js`.
- Simplify and centralize gateway model logic to make future updates easier.

### Description

- Added a `gatewayModelKeys` array and a `hasPortSignals` check, and added an early-return branch that classifies a device as `gateway` when the `modelKey` appears in `gatewayModelKeys` and port-related capability signals exist in `src/classify.js`.
- Reordered capability checks so `ap_stats`/`uplink_mac` immediately classify as `access_point` and port signals classify as `switch` earlier, and removed duplicated capability checks later in the function.
- Reused `gatewayModelKeys` inside the existing `modelKey` branch to avoid duplicating the gateway model list.
- Wrapped the `customElements.define("unifi-device-card-editor", UnifiDeviceCardEditor)` call with a guard to only define the element if it is not already registered in `src/unifi-device-card-editor.js`.

### Testing

- Ran the project's automated test suite with `npm test`, and the tests completed successfully.
- Ran the linter with `npm run lint`, and no lint errors were reported.
- Verified no runtime errors occur when loading the editor component twice in a development reload scenario using the guarded `customElements.define` change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee09196ac48333805083f77b656f74)