### PR TITLE
Restore modelKey precedence in device classification

### DIFF
--- a/src/classify.js
+++ b/src/classify.js
@@ -29,6 +29,7 @@ export function classifyDeviceType(identity, capabilities, entities = [], device
   const manufacturer = String(identity?.manufacturer || "").toLowerCase();
   const name = String(identity?.name || "").toLowerCase();
   const translationKeys = new Set((entities || []).map((entity) => String(entity?.translation_key || "").toLowerCase()));
+  const modelKey = resolveModelKey(device || identity || {});
 
   const registryType = fromModel(model);
   if (registryType) return registryType;
@@ -42,10 +43,6 @@ export function classifyDeviceType(identity, capabilities, entities = [], device
     name.includes("router");
   if (gatewaySignals) return "gateway";
 
-  if (capabilities?.ap_stats || capabilities?.uplink_mac) return "access_point";
-  if (capabilities?.ports || capabilities?.port_control || capabilities?.poe_power) return "switch";
-
-  const modelKey = resolveModelKey(device || identity || {});
   if (modelKey) {
     if (["UDM", "UDR", "UDMPRO", "UDMPROSE", "UXGPRO", "UXGL", "UGW3", "UGW4", "UGWXG", "UCGULTRA", "UCGMAX", "UCGFIBER"].includes(modelKey)) {
       return "gateway";
@@ -54,6 +51,9 @@ export function classifyDeviceType(identity, capabilities, entities = [], device
       return "switch";
     }
   }
+
+  if (capabilities?.ap_stats || capabilities?.uplink_mac) return "access_point";
+  if (capabilities?.ports || capabilities?.port_control || capabilities?.poe_power) return "switch";
 
   if (manufacturer.includes("ubiquiti") || manufacturer.includes("unifi")) {
     if (name.includes("switch")) return "switch";

--- a/src/classify.js
+++ b/src/classify.js
@@ -24,6 +24,16 @@ function fromModel(model) {
   return null;
 }
 
+const GATEWAY_MODEL_KEYS = new Set(["UDM", "UDR", "UDMPRO", "UDMPROSE", "UXGPRO", "UXGL", "UGW3", "UGW4", "UGWXG", "UCGULTRA", "UCGMAX", "UCGFIBER"]);
+const SWITCH_MODEL_KEYS = new Set(["USMINI", "USWULTRA", "US8P60", "US8P150", "USL8LP", "USL16LP", "US24PRO", "US48PRO"]);
+
+function fromModelKey(modelKey) {
+  if (!modelKey) return null;
+  if (GATEWAY_MODEL_KEYS.has(modelKey)) return "gateway";
+  if (SWITCH_MODEL_KEYS.has(modelKey) || modelKey.startsWith("US")) return "switch";
+  return null;
+}
+
 export function classifyDeviceType(identity, capabilities, entities = [], device = null) {
   const model = normalizeModel(identity?.model || identity?.hw_version || "");
   const manufacturer = String(identity?.manufacturer || "").toLowerCase();
@@ -43,14 +53,8 @@ export function classifyDeviceType(identity, capabilities, entities = [], device
     name.includes("router");
   if (gatewaySignals) return "gateway";
 
-  if (modelKey) {
-    if (["UDM", "UDR", "UDMPRO", "UDMPROSE", "UXGPRO", "UXGL", "UGW3", "UGW4", "UGWXG", "UCGULTRA", "UCGMAX", "UCGFIBER"].includes(modelKey)) {
-      return "gateway";
-    }
-    if (["USMINI", "USWULTRA", "US8P60", "US8P150", "USL8LP", "USL16LP", "US24PRO", "US48PRO"].includes(modelKey) || modelKey.startsWith("US")) {
-      return "switch";
-    }
-  }
+  const modelKeyType = fromModelKey(modelKey);
+  if (modelKeyType) return modelKeyType;
 
   if (capabilities?.ap_stats || capabilities?.uplink_mac) return "access_point";
   if (capabilities?.ports || capabilities?.port_control || capabilities?.poe_power) return "switch";


### PR DESCRIPTION
### Motivation
- Restore explicit `modelKey`-based classification precedence in `classifyDeviceType` to avoid reclassifying known gateway/switch models as access points when capability heuristics like `ap_stats` are present but port signals are missing.

### Description
- In `src/classify.js` resolve `modelKey` earlier and run the known-model `gateway`/`switch` branch before capability-based checks (`ap_stats`, `uplink_mac`, ports) so model identity wins over heuristics, leaving the remaining manufacturer/name/entity fallbacks unchanged.

### Testing
- Ran `npm test` which failed because this repository has no `test` script; ran `npm run lint` which failed because there is no `lint` script; ran `npm run` which succeeded and confirmed only a `build` script is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee0cdfc9c88333ae016c71af867528)