### PR TITLE
fix: restore model-key precedence in device classification

### DIFF
--- a/src/classify.js
+++ b/src/classify.js
@@ -45,10 +45,6 @@ export function classifyDeviceType(identity, capabilities, entities = [], device
   const modelKey = resolveModelKey(device || identity || {});
   const gatewayModelKeys = ["UDM", "UDR", "UDMPRO", "UDMPROSE", "UXGPRO", "UXGL", "UGW3", "UGW4", "UGWXG", "UCGULTRA", "UCGMAX", "UCGFIBER"];
   const hasPortSignals = !!(capabilities?.ports || capabilities?.port_control || capabilities?.poe_power);
-  if (modelKey && gatewayModelKeys.includes(modelKey) && hasPortSignals) return "gateway";
-
-  if (capabilities?.ap_stats || capabilities?.uplink_mac) return "access_point";
-  if (hasPortSignals) return "switch";
 
   if (modelKey) {
     if (gatewayModelKeys.includes(modelKey)) {
@@ -58,6 +54,9 @@ export function classifyDeviceType(identity, capabilities, entities = [], device
       return "switch";
     }
   }
+
+  if (capabilities?.ap_stats || capabilities?.uplink_mac) return "access_point";
+  if (hasPortSignals) return "switch";
 
   if (manufacturer.includes("ubiquiti") || manufacturer.includes("unifi")) {
     if (name.includes("switch")) return "switch";


### PR DESCRIPTION
### Motivation
- Prevent known gateway/switch models from being misclassified as `access_point` when capability entities are incomplete by restoring model-key based classification precedence.

### Description
- Moved capability-based heuristics (`capabilities.ap_stats`, `capabilities.uplink_mac`, port signal checks) to run after `modelKey` checks in `src/classify.js`, so explicit `modelKey` identity wins for gateway/switch classification.
- Change is limited to `src/classify.js` and keeps behavior consistent with prior model-first logic; `dist` was not committed as this is a source-only fix.

### Testing
- Ran `npm ci` successfully and then `npm run build` successfully to validate the change and ensure the bundle builds.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee0f7da69083339f2c4e67066d78ca)