### PR TITLE
Map USWED37 to USW Flex 2.5G 8 PoE layout and update port labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [v0.7.1]
+
+### 🐛 Bug Fixes
+- Map `USWED37` to the USW Flex 2.5G 8 PoE layout so ports 1-8 render as RJ45 and ports 9-10 render as special ports.
+
+
+
+If you see improvements, issues, or fixes, feel free to open an issue or create a pull request.
+
+If you like this project and want to support my work, you can donate via PayPal.
+
+<a href="https://www.paypal.me/bluenazgul">
+  <img
+    src="https://raw.githubusercontent.com/stefan-niedermann/paypal-donate-button/master/paypal-donate-button.png"
+    alt="Donate with PayPal"
+    width="220"
+  />
+</a>
+
 ## [v0.7.0]
 
 ### ✨ Improvements

--- a/src/model-registry.js
+++ b/src/model-registry.js
@@ -234,14 +234,14 @@ export const MODEL_REGISTRY = {
     specialSlots: [{ key: "uplink", label: "Uplink", port: 5 }],
   },
 
-  // USW Flex 2.5G 8 PoE  — Port 9 Uplink/PoE-in, ports 1-8 LAN PoE-out, 1× SFP uplink
+  // USW Flex 2.5G 8 PoE  — Ports 1-8 2.5G RJ45 PoE-out, port 9 10G RJ45, port 10 SFP+
   USWFLEX25G8POE: {
     kind: "switch", frontStyle: "single-row", rows: [range(1, 8)],
     portCount: 10, displayModel: "USW Flex 2.5G 8 PoE", theme: "white",
     poePortRange: [1, 8],
     specialSlots: [
-      { key: "uplink", label: "Uplink", port: 9 },
-      { key: "sfp_1", label: "SFP 1", port: 10 },
+      { key: "uplink", label: "10G RJ45", port: 9 },
+      { key: "sfp_1", label: "SFP+ 1", port: 10 },
     ],
   },
   USWFLEX25G8: {
@@ -947,6 +947,7 @@ export function resolveModelKey(device) {
     if (candidate.includes("USWFLEXMINI"))        return "USMINI";
     if (candidate === "USWFLEX25G5")              return "USWFLEX25G5";
     if (candidate.includes("USWFLEX25G5"))        return "USWFLEX25G5";
+    if (candidate.includes("USWED37"))            return "USWFLEX25G8POE";
     if (candidate.includes("USWED35"))            return "USWFLEX25G5";
     if (candidate.includes("FLEX25G5"))           return "USWFLEX25G5";
     if (candidate.includes("SWITCHFLEXMINI25G"))  return "USWFLEX25G5";
@@ -1036,6 +1037,7 @@ export function inferPortCountFromModel(device) {
   if (text.includes("US8P150"))                                                       return 10;
   if (text.includes("S28150"))                                                        return 10;
   if (text.includes("USMINI")   || text.includes("FLEXMINI"))                        return 5;
+  if (text.includes("USWED37"))                                                       return 10;
   if (text.includes("USWFLEX25G5") || text.includes("USWED35") || text.includes("FLEX25G5") || text.includes("SWITCHFLEXMINI25G")) return 5;
   if (text.includes("USWFLEX25G8POE") || text.includes("FLEX25G8POE") || text.includes("USWFLEX25G8")) return 10;
   if (text.includes("USF5P")    || text.includes("USWFLEX"))                         return 5;


### PR DESCRIPTION
### Motivation
- Ensure the `USWED37` device is recognized as the USW Flex 2.5G 8 PoE so its ports render correctly with ports 1-8 as RJ45 PoE ports and ports 9-10 shown as special uplink/SFP ports.

### Description
- Update `USWFLEX25G8POE` model definition in `model-registry.js` to clarify port roles and change special slot labels to `10G RJ45` for port 9 and `SFP+ 1` for port 10.
- Add a device candidate mapping `if (candidate.includes("USWED37")) return "USWFLEX25G8POE";` to `resolveModelKey` in `model-registry.js` so `USWED37` maps to the correct model.
- Add `if (text.includes("USWED37")) return 10;` to `inferPortCountFromModel` so port count is inferred as 10 for `USWED37`.
- Add a `v0.7.1` entry to `CHANGELOG.md` describing the bug fix.

### Testing
- Ran the project's lint and automated test suite against the changes and observed no failures.
- Verified that localized model inference and port-count heuristics include `USWED37` and that the changelog entry was added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a185f97f8a08333905afa50b5fe48e4)