### PR TITLE
Fix media detection for USW Flex 2.5G (USWED36), propagate layout media to special ports, and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [v0.7.2]
+
+### 🐛 Bug Fixes
+- Fix non-PoE USW Flex 2.5G 8 (`USWED36`) detection so ports 1-8 render as RJ45 and ports 9-10 render as special ports.
+- Keep 10G RJ45 uplinks classified as RJ45 media while rendering SFP+ special ports as SFP media.
+
+Fixes issue: #172
+
+If you see improvements, issues, or fixes, feel free to open an issue or create a pull request.
+
+If you like this project and want to support my work, you can donate via PayPal.
+
+<a href="https://www.paypal.me/bluenazgul">
+  <img
+    src="https://raw.githubusercontent.com/stefan-niedermann/paypal-donate-button/master/paypal-donate-button.png"
+    alt="Donate with PayPal"
+    width="220"
+  />
+</a>
+
 ## [v0.7.1]
 
 ### 🐛 Bug Fixes

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1285,7 +1285,16 @@ export function mergeSpecialsWithLayout(layout, discoveredSpecials, discoveredPo
   const merged = layoutSpecials.map((slot) => {
     if (slot.port != null) {
       const portData = byPort.get(slot.port);
-      if (portData) return { ...portData, key: slot.key, physical_key: slot.key, label: slot.label, kind: "special" };
+      if (portData) {
+        return {
+          ...portData,
+          key: slot.key,
+          physical_key: slot.key,
+          label: slot.label,
+          media: slot.media ?? portData.media,
+          kind: "special",
+        };
+      }
     }
 
     const keyData = byKey.get(slot.key);
@@ -1295,6 +1304,7 @@ export function mergeSpecialsWithLayout(layout, discoveredSpecials, discoveredPo
         key: slot.key,
         physical_key: slot.key,
         label: slot.label,
+        media: slot.media ?? keyData.media,
         kind: "special",
         port: slot.port ?? keyData.port ?? null,
       };
@@ -1305,6 +1315,7 @@ export function mergeSpecialsWithLayout(layout, discoveredSpecials, discoveredPo
       physical_key: slot.key,
       port: slot.port ?? null,
       label: slot.label,
+      media: slot.media,
       kind: "special",
       link_entity: null,
       speed_entity: null,
@@ -1876,8 +1887,18 @@ function portObservedClientCount(hass, port) {
   return bestCount;
 }
 
+function explicitPortMedia(port) {
+  const media = lower(port?.media || port?.media_type || "");
+  if (["rj45", "sfp", "sfp_plus", "sfp28"].includes(media)) return media;
+  return null;
+}
+
 function isSfpSpecialPort(port) {
   if (port?.kind !== "special") return false;
+
+  const media = explicitPortMedia(port);
+  if (media === "rj45") return false;
+  if (media) return media !== "rj45";
 
   const key = lower(port?.physical_key || port?.key || "");
   return key.startsWith("sfp_") || key.startsWith("sfp28_");
@@ -1889,6 +1910,9 @@ function isSfpSpecialPort(port) {
  * "sfp_2" in their entity IDs rather than being declared as special slots.
  */
 export function isSfpLikePort(port) {
+  const media = explicitPortMedia(port);
+  if (media === "rj45") return false;
+  if (media) return media !== "rj45";
   if (isSfpSpecialPort(port)) return true;
   const text = [
     port?.key,

--- a/src/model-registry.js
+++ b/src/model-registry.js
@@ -240,16 +240,17 @@ export const MODEL_REGISTRY = {
     portCount: 10, displayModel: "USW Flex 2.5G 8 PoE", theme: "white",
     poePortRange: [1, 8],
     specialSlots: [
-      { key: "uplink", label: "10G RJ45", port: 9 },
-      { key: "sfp_1", label: "SFP+ 1", port: 10 },
+      { key: "uplink", label: "10G RJ45", port: 9, media: "rj45" },
+      { key: "sfp_1", label: "SFP+ 1", port: 10, media: "sfp_plus" },
     ],
   },
+  // USW Flex 2.5G 8  — Ports 1-8 2.5G RJ45, port 9 10G RJ45 PoE-in, port 10 10G SFP+
   USWFLEX25G8: {
     kind: "switch", frontStyle: "single-row", rows: [range(1, 8)],
     portCount: 10, displayModel: "USW Flex 2.5G 8", theme: "white",
     specialSlots: [
-      { key: "uplink", label: "Uplink", port: 9 },
-      { key: "sfp_1", label: "SFP 1", port: 10 },
+      { key: "uplink", label: "10G RJ45 PoE-In", port: 9, media: "rj45" },
+      { key: "sfp_1", label: "SFP+ 10G", port: 10, media: "sfp_plus" },
     ],
   },
 
@@ -948,6 +949,7 @@ export function resolveModelKey(device) {
     if (candidate === "USWFLEX25G5")              return "USWFLEX25G5";
     if (candidate.includes("USWFLEX25G5"))        return "USWFLEX25G5";
     if (candidate.includes("USWED37"))            return "USWFLEX25G8POE";
+    if (candidate.includes("USWED36"))            return "USWFLEX25G8";
     if (candidate.includes("USWED35"))            return "USWFLEX25G5";
     if (candidate.includes("FLEX25G5"))           return "USWFLEX25G5";
     if (candidate.includes("SWITCHFLEXMINI25G"))  return "USWFLEX25G5";
@@ -1037,7 +1039,7 @@ export function inferPortCountFromModel(device) {
   if (text.includes("US8P150"))                                                       return 10;
   if (text.includes("S28150"))                                                        return 10;
   if (text.includes("USMINI")   || text.includes("FLEXMINI"))                        return 5;
-  if (text.includes("USWED37"))                                                       return 10;
+  if (text.includes("USWED37") || text.includes("USWED36"))                           return 10;
   if (text.includes("USWFLEX25G5") || text.includes("USWED35") || text.includes("FLEX25G5") || text.includes("SWITCHFLEXMINI25G")) return 5;
   if (text.includes("USWFLEX25G8POE") || text.includes("FLEX25G8POE") || text.includes("USWFLEX25G8")) return 10;
   if (text.includes("USF5P")    || text.includes("USWFLEX"))                         return 5;

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -1209,6 +1209,9 @@ class UnifiDeviceCard extends HTMLElement {
   }
 
   _portMediaType(slot) {
+    const explicitMedia = String(slot?.media || slot?.media_type || "").toLowerCase();
+    if (["rj45", "sfp", "sfp_plus", "sfp28"].includes(explicitMedia)) return explicitMedia;
+
     const label = String(slot?.label || "").toLowerCase();
     const key = String(slot?.key || "").toLowerCase();
     const physicalKey = String(slot?.physical_key || "").toLowerCase();
@@ -1218,6 +1221,9 @@ class UnifiDeviceCard extends HTMLElement {
     const layoutSlot = Number.isInteger(slot?.port)
       ? (this._ctx?.layout?.specialSlots || []).find((s) => s.port === slot.port)
       : null;
+    const layoutMedia = String(layoutSlot?.media || layoutSlot?.media_type || "").toLowerCase();
+    if (["rj45", "sfp", "sfp_plus", "sfp28"].includes(layoutMedia)) return layoutMedia;
+
     const layoutKey = String(layoutSlot?.key || "").toLowerCase();
     const layoutLabel = String(layoutSlot?.label || "").toLowerCase();
     const allHints = [label, key, physicalKey, layoutKey, layoutLabel, ...rawEntities].join(" ");


### PR DESCRIPTION
### Motivation
- Ensure non-PoE USW Flex 2.5G 8 (model `USWED36`) is detected and rendered with ports 1–8 as RJ45 and ports 9–10 as the correct special media types.
- Preserve explicit media annotations for special slots so UI logic (`SFP` vs `RJ45`) follows layout metadata rather than heuristics alone.
- Document the bug fix in `CHANGELOG.md` for the `v0.7.2` release.

### Description
- Add a new model entry `USWFLEX25G8` and map `USWED36` to it, and annotate the model `USWFLEX25G8POE`/`USWFLEX25G8` special slots with `media` values for uplink and SFP ports.
- Update `mergeSpecialsWithLayout` to copy `media` from layout slots and key data into the merged special-port objects so merged data reflects explicit media.
- Add helper `explicitPortMedia` and update `isSfpSpecialPort` and `isSfpLikePort` to respect explicit `media` fields (treat `rj45` as non-SFP and other explicit media accordingly).
- Update UI logic in `_portMediaType` to consider explicit `media`/`media_type` on both the slot and the layout slot before falling back to name-based heuristics.
- Add `v0.7.2` changelog entries describing the fixes and donation blurb in `CHANGELOG.md`.

### Testing
- Ran the test suite with `npm test` and unit tests completed successfully.
- Ran the linter with `npm run lint` and there were no linting errors.
- Built the bundle with `npm run build` and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bdc34eb6483339e5b959591c4a82c)