### PR TITLE
Use Home Assistant entity-name formatting and add Lovelace entity suggestions for UniFi entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### ✨ Improvements
+- Add Home Assistant 2026.6 Lovelace entity suggestions for likely UniFi entities and use Home Assistant entity-name formatting when available for visible client/device-tracker names.
+
 ### 🐛 Bug Fixes
 - Improve UniFi model recognition and same-family fallbacks for current devices reported by UniFi Network / aiounifi:
   - **Access points / bridges:** `G7LR`, `U7UKU`, `U6ENT`, `U6ENTIW`, `UAL6`, `UALR6`, `UAM6`, `UAP6`, `UAP6MP`, `U7-Pro-XG-Wall`, `U7-Pro-Outdoor`, `U7ENT` / `E7`, `E7-Campus`, `E7-Audience`, `UK-Ultra`, `UBB`, `UBB-XG`, `U-AirWire`, `UDB`, `UDB-IoT`, `UDB-Switch`, `UDB-Pro`, `UDB-Pro-Sector`.

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -531,6 +531,23 @@ class UnifiDeviceCard extends HTMLElement {
     return /^[a-z0-9_-]+$/i.test(token) ? token : fallback;
   }
 
+  _formatEntityName(entityId, fallback = "") {
+    const fallbackName = String(fallback ?? "").trim();
+    const obj = entityId ? this._hass?.states?.[entityId] : null;
+    const formatter = this._hass?.formatEntityName;
+
+    if (obj && typeof formatter === "function") {
+      try {
+        const formatted = String(formatter(obj) ?? "").trim();
+        if (formatted) return formatted;
+      } catch (err) {
+        // Keep older Home Assistant versions and unexpected formatter failures silent.
+      }
+    }
+
+    return fallbackName;
+  }
+
   _apUplinkTooltip(uplink) {
     if (!uplink) return "";
     const lines = [];
@@ -628,12 +645,14 @@ class UnifiDeviceCard extends HTMLElement {
 
   _extractClientNameFromStateObj(obj, entityId) {
     const attrs = obj?.attributes || {};
-    const friendly = String(attrs.friendly_name || "").trim();
-    if (friendly) return friendly;
-    return String(entityId || "")
-      .replace(/^device_tracker\./i, "")
-      .replace(/_/g, " ")
-      .trim();
+    const fallback =
+      String(attrs.friendly_name || "").trim() ||
+      String(entityId || "")
+        .replace(/^device_tracker\./i, "")
+        .replace(/_/g, " ")
+        .trim();
+
+    return this._formatEntityName(entityId, fallback);
   }
 
   _extractPortFromAttributes(attrs, entityId = "") {
@@ -2438,6 +2457,30 @@ if (!customElements.get("unifi-device-card")) {
   customElements.define("unifi-device-card", UnifiDeviceCard);
 }
 
+function getUnifiDeviceCardEntitySuggestion(hass, entityId) {
+  const id = String(entityId || "").trim().toLowerCase();
+  if (!id || !id.includes(".")) return null;
+
+  const obj = hass?.states?.[entityId];
+  const attrs = obj?.attributes || {};
+  const friendly = String(attrs.friendly_name || "").toLowerCase();
+  const attribution = String(attrs.attribution || "").toLowerCase();
+  const hasUnifiHint =
+    id.includes("unifi") ||
+    id.includes("ubiquiti") ||
+    friendly.includes("unifi") ||
+    friendly.includes("ubiquiti") ||
+    attribution.includes("unifi") ||
+    attribution.includes("ubiquiti");
+
+  const hasUniFiPrefix = /^(sensor|switch|button|binary_sensor|number|select|update|device_tracker)\.unifi_/i.test(id);
+  const hasUnifiPortPattern = /(?:^|[_-])(port(?:[_-]\d+)?|link[_-]speed|poe[_-]power|power[_-]cycle)(?:[_-]|$)/i.test(id);
+
+  if (!hasUniFiPrefix && !(hasUnifiHint && hasUnifiPortPattern)) return null;
+
+  return { type: "custom:unifi-device-card" };
+}
+
 window.customCards = window.customCards || [];
 if (!window.customCards.some((card) => card?.type === "unifi-device-card")) {
   window.customCards.push({
@@ -2446,6 +2489,7 @@ if (!window.customCards.some((card) => card?.type === "unifi-device-card")) {
     description: `Lovelace card for UniFi devices (v${VERSION}).`,
     preview: true,
     documentationURL: "https://github.com/bluenazgul/unifi-device-card",
+    getEntitySuggestion: getUnifiDeviceCardEntitySuggestion,
   });
 }
 


### PR DESCRIPTION
### Motivation
- Respect Home Assistant's entity-name formatting when available to show better client/device-tracker labels. 
- Provide Lovelace entity suggestions for likely UniFi-related entities to improve card discoverability in Home Assistant 2026.6.

### Description
- Add `_formatEntityName` helper that uses `this._hass.formatEntityName` when present and falls back to a provided name. 
- Use the new helper in `_extractClientNameFromStateObj` so extracted client names use Home Assistant formatting when possible. 
- Add `getUnifiDeviceCardEntitySuggestion` and register it via `getEntitySuggestion` on the `customCards` entry to suggest `custom:unifi-device-card` for likely UniFi entities (based on id, `friendly_name`, `attribution`, and port-related patterns). 
- Update `CHANGELOG.md` with an Improvements entry describing the new behavior.

### Testing
- Ran `npm run build` to ensure the bundle compiles successfully. 
- Ran `npm run lint` to validate code style and linting rules, which passed. 
- No automated unit tests were added or modified in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21764b066883338aecc2afbacc1e6c)