### PR TITLE
Fix AP uptime rendering and extract uptime formatting helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Add Home Assistant 2026.6 Lovelace entity suggestions for likely UniFi entities and use Home Assistant entity-name formatting when available for visible client/device-tracker names.
 
 ### 🐛 Bug Fixes
-- Fix AP uptime rendering for Home Assistant `device_class: uptime` timestamp sensors so the card displays an elapsed duration instead of `2026.00`.
+- Fix AP uptime rendering for Home Assistant `device_class: uptime` timestamp sensors so the card displays and refreshes an elapsed duration instead of `2026.00`.
 - Improve UniFi model recognition and same-family fallbacks for current devices reported by UniFi Network / aiounifi:
   - **Access points / bridges:** `G7LR`, `U7UKU`, `U6ENT`, `U6ENTIW`, `UAL6`, `UALR6`, `UAM6`, `UAP6`, `UAP6MP`, `U7-Pro-XG-Wall`, `U7-Pro-Outdoor`, `U7ENT` / `E7`, `E7-Campus`, `E7-Audience`, `UK-Ultra`, `UBB`, `UBB-XG`, `U-AirWire`, `UDB`, `UDB-IoT`, `UDB-Switch`, `UDB-Pro`, `UDB-Pro-Sector`.
   - **Gateways / routers:** `UDMENT` / `EFG`, `UDM-Pro-Max`, `UDM-Beast`, `UCG-Industrial`, `UX`, `UEX`, `UX7`, `UXG`, `UXGB`, `UXG-Fiber`, `UTR`, `UDR7`, `UDR-5G-Max`, `UDW`, `UXG-Max`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,23 @@
 - Add Home Assistant 2026.6 Lovelace entity suggestions for likely UniFi entities and use Home Assistant entity-name formatting when available for visible client/device-tracker names.
 
 ### 🐛 Bug Fixes
+- Fix AP uptime rendering for Home Assistant `device_class: uptime` timestamp sensors so the card displays an elapsed duration instead of `2026.00`.
 - Improve UniFi model recognition and same-family fallbacks for current devices reported by UniFi Network / aiounifi:
   - **Access points / bridges:** `G7LR`, `U7UKU`, `U6ENT`, `U6ENTIW`, `UAL6`, `UALR6`, `UAM6`, `UAP6`, `UAP6MP`, `U7-Pro-XG-Wall`, `U7-Pro-Outdoor`, `U7ENT` / `E7`, `E7-Campus`, `E7-Audience`, `UK-Ultra`, `UBB`, `UBB-XG`, `U-AirWire`, `UDB`, `UDB-IoT`, `UDB-Switch`, `UDB-Pro`, `UDB-Pro-Sector`.
   - **Gateways / routers:** `UDMENT` / `EFG`, `UDM-Pro-Max`, `UDM-Beast`, `UCG-Industrial`, `UX`, `UEX`, `UX7`, `UXG`, `UXGB`, `UXG-Fiber`, `UTR`, `UDR7`, `UDR-5G-Max`, `UDW`, `UXG-Max`.
   - **Switches:** `USWED35`, `USWED36`, `USWED37`, `USW-Flex-XG`, `US6XG150` / `US-XG-6POE`, `USW-WAN`, `USW-WAN-RJ45`, `USW-Mission-Critical`, `USW-Pro-XG-*`, `USW-Pro-HD-24*`, `ECS-*`.
+
+If you see improvements, issues, or fixes, feel free to open an issue or create a pull request.
+
+If you like this project and want to support my work, you can donate via PayPal.
+
+<a href="https://www.paypal.me/bluenazgul">
+  <img
+    src="https://raw.githubusercontent.com/stefan-niedermann/paypal-donate-button/master/paypal-donate-button.png"
+    alt="Donate with PayPal"
+    width="220"
+  />
+</a>
 
 ## [v0.7.2]
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1823,6 +1823,66 @@ export function formatState(hass, entityId) {
   return val;
 }
 
+export function humanizeDurationSeconds(totalSeconds) {
+  const seconds = Math.max(0, Math.round(totalSeconds));
+  const days = Math.floor(seconds / 86400);
+  const hours = Math.floor((seconds % 86400) / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+
+  const parts = [];
+  if (days) parts.push(`${days}d`);
+  if (hours || days) parts.push(`${hours}h`);
+  parts.push(`${minutes}m`);
+  return parts.join(" ");
+}
+
+function looksLikeTimestamp(value) {
+  return /^\d{4}-\d{2}-\d{2}(?:[T\s]|$)/.test(String(value || "").trim());
+}
+
+export function formatUptimeState(hass, entityId, now = Date.now()) {
+  const obj = stateObj(hass, entityId);
+  if (!obj) return "—";
+
+  const rawState = String(obj.state ?? "").trim();
+  if (!rawState || rawState === "unavailable" || rawState === "unknown") return "—";
+
+  const deviceClass = String(obj.attributes?.device_class || "").toLowerCase().trim();
+  const originalDeviceClass = String(obj.attributes?.original_device_class || "").toLowerCase().trim();
+  const isUptimeTimestamp =
+    deviceClass === "uptime" ||
+    deviceClass === "timestamp" ||
+    originalDeviceClass === "uptime" ||
+    originalDeviceClass === "timestamp";
+
+  if (isUptimeTimestamp && looksLikeTimestamp(rawState)) {
+    const parsedMs = Date.parse(rawState);
+    const nowMs = Number(now);
+    if (Number.isFinite(parsedMs) && Number.isFinite(nowMs)) {
+      return humanizeDurationSeconds((nowMs - parsedMs) / 1000);
+    }
+  }
+
+  const raw = Number.parseFloat(rawState.replace(",", "."));
+  if (!Number.isFinite(raw)) return formatState(hass, entityId);
+
+  const unit = String(obj.attributes?.unit_of_measurement || "").toLowerCase().trim();
+  if (["s", "sec", "second", "seconds"].includes(unit)) {
+    return humanizeDurationSeconds(raw);
+  }
+  if (["min", "mins", "minute", "minutes"].includes(unit)) {
+    return humanizeDurationSeconds(raw * 60);
+  }
+  if (["h", "hr", "hour", "hours"].includes(unit)) {
+    return humanizeDurationSeconds(raw * 3600);
+  }
+  if (["d", "day", "days"].includes(unit)) {
+    return humanizeDurationSeconds(raw * 86400);
+  }
+
+  return formatState(hass, entityId);
+}
+
 export function getPoeStatus(hass, port) {
   const sw = stateValue(hass, port.poe_switch_entity);
   const pwr = stateValue(hass, port.poe_power_entity);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1840,12 +1840,8 @@ function looksLikeTimestamp(value) {
   return /^\d{4}-\d{2}-\d{2}(?:[T\s]|$)/.test(String(value || "").trim());
 }
 
-export function formatUptimeState(hass, entityId, now = Date.now()) {
-  const obj = stateObj(hass, entityId);
-  if (!obj) return "—";
-
-  const rawState = String(obj.state ?? "").trim();
-  if (!rawState || rawState === "unavailable" || rawState === "unknown") return "—";
+export function isUptimeTimestampState(obj) {
+  if (!obj) return false;
 
   const deviceClass = String(obj.attributes?.device_class || "").toLowerCase().trim();
   const originalDeviceClass = String(obj.attributes?.original_device_class || "").toLowerCase().trim();
@@ -1854,8 +1850,20 @@ export function formatUptimeState(hass, entityId, now = Date.now()) {
     deviceClass === "timestamp" ||
     originalDeviceClass === "uptime" ||
     originalDeviceClass === "timestamp";
+  if (!isUptimeTimestamp) return false;
 
-  if (isUptimeTimestamp && looksLikeTimestamp(rawState)) {
+  const rawState = String(obj.state ?? "").trim();
+  return looksLikeTimestamp(rawState) && Number.isFinite(Date.parse(rawState));
+}
+
+export function formatUptimeState(hass, entityId, now = Date.now()) {
+  const obj = stateObj(hass, entityId);
+  if (!obj) return "—";
+
+  const rawState = String(obj.state ?? "").trim();
+  if (!rawState || rawState === "unavailable" || rawState === "unknown") return "—";
+
+  if (isUptimeTimestampState(obj)) {
     const parsedMs = Date.parse(rawState);
     const nowMs = Number(now);
     if (Number.isFinite(parsedMs) && Number.isFinite(nowMs)) {

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -2,6 +2,7 @@ import {
   applyGatewayPortOverrides,
   discoverSpecialPorts,
   formatState,
+  formatUptimeState,
   getDeviceContext,
   getPoeStatus,
   getPortLinkText,
@@ -400,19 +401,6 @@ class UnifiDeviceCard extends HTMLElement {
     return unit ? `${intValue} ${unit}` : String(intValue);
   }
 
-  _humanizeDurationSeconds(totalSeconds) {
-    const seconds = Math.max(0, Math.round(totalSeconds));
-    const days = Math.floor(seconds / 86400);
-    const hours = Math.floor((seconds % 86400) / 3600);
-    const minutes = Math.floor((seconds % 3600) / 60);
-
-    const parts = [];
-    if (days) parts.push(`${days}d`);
-    if (hours || days) parts.push(`${hours}h`);
-    parts.push(`${minutes}m`);
-    return parts.join(" ");
-  }
-
   _apStatusRaw(entityId) {
     if (!entityId || !this._hass) return "—";
     const obj = stateObj(this._hass, entityId);
@@ -427,39 +415,7 @@ class UnifiDeviceCard extends HTMLElement {
 
   _apUptimeState(entityId) {
     if (!entityId || !this._hass) return "—";
-    const obj = stateObj(this._hass, entityId);
-    if (!obj) return "—";
-
-    const rawState = String(obj.state ?? "").trim();
-    const deviceClass = String(obj.attributes?.device_class || "").toLowerCase().trim();
-    if (deviceClass === "timestamp") {
-      const parsed = new Date(rawState);
-      if (!Number.isNaN(parsed.getTime())) {
-        return parsed.toLocaleString(this._hass?.locale?.language || undefined, {
-          year: "numeric",
-          month: "2-digit",
-          day: "2-digit",
-          hour: "2-digit",
-          minute: "2-digit",
-        });
-      }
-    }
-
-    const raw = Number.parseFloat(String(obj.state ?? "").replace(",", "."));
-    if (!Number.isFinite(raw)) return formatState(this._hass, entityId);
-
-    const unit = String(obj.attributes?.unit_of_measurement || "").toLowerCase().trim();
-    if (["s", "sec", "second", "seconds"].includes(unit)) {
-      return this._humanizeDurationSeconds(raw);
-    }
-    if (["min", "mins", "minute", "minutes"].includes(unit)) {
-      return this._humanizeDurationSeconds(raw * 60);
-    }
-    if (["h", "hr", "hour", "hours"].includes(unit)) {
-      return this._humanizeDurationSeconds(raw * 3600);
-    }
-
-    return formatState(this._hass, entityId);
+    return formatUptimeState(this._hass, entityId);
   }
 
   _apLedColorValue() {

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -8,6 +8,7 @@ import {
   getPortLinkText,
   getPortSpeedText,
   hasTraffic,
+  isUptimeTimestampState,
   isSfpLikePort,
   isOn,
   isPortConnected,
@@ -52,6 +53,7 @@ class UnifiDeviceCard extends HTMLElement {
     this._loadToken = 0;
     this._loadedDeviceId = null;
     this._resizeObserver = null;
+    this._uptimeRefreshTimer = null;
     this._lastMeasuredWidth = 0;
     this._lastMeasuredPanelWidth = 0;
     this._cardSize = 8;
@@ -174,11 +176,13 @@ class UnifiDeviceCard extends HTMLElement {
       this._render();
     });
     this._resizeObserver.observe(this);
+    this._syncUptimeRefreshTimer();
   }
 
   disconnectedCallback() {
     this._resizeObserver?.disconnect();
     this._resizeObserver = null;
+    this._clearUptimeRefreshTimer();
   }
 
   setConfig(config) {
@@ -192,6 +196,7 @@ class UnifiDeviceCard extends HTMLElement {
     });
 
     if (oldDeviceId !== newDeviceId) {
+      this._clearUptimeRefreshTimer();
       this._ctx = null;
       this._selectedKey = null;
       this._loadedDeviceId = null;
@@ -275,6 +280,38 @@ class UnifiDeviceCard extends HTMLElement {
     const key = `state_${String(raw).toLowerCase().replace(/\s+/g, "_")}`;
     const translated = this._t(key);
     return translated === key ? raw : translated;
+  }
+
+  _clearUptimeRefreshTimer() {
+    if (!this._uptimeRefreshTimer) return;
+    clearTimeout(this._uptimeRefreshTimer);
+    this._uptimeRefreshTimer = null;
+  }
+
+  _isTimestampUptimeEntity(entityId) {
+    if (!entityId || !this._hass) return false;
+    return isUptimeTimestampState(stateObj(this._hass, entityId));
+  }
+
+  _syncUptimeRefreshTimer() {
+    const needsRefresh =
+      this.isConnected &&
+      this._ctx?.type === "access_point" &&
+      this._isTimestampUptimeEntity(this._ctx?.uptime_entity);
+    if (!needsRefresh) {
+      this._clearUptimeRefreshTimer();
+      return;
+    }
+
+    if (this._uptimeRefreshTimer) return;
+
+    const now = Date.now();
+    const nextMinuteDelay = 60000 - (now % 60000);
+    this._uptimeRefreshTimer = setTimeout(() => {
+      this._uptimeRefreshTimer = null;
+      if (!this.isConnected) return;
+      this._render();
+    }, nextMinuteDelay || 60000);
   }
 
   _cardBgStyle() {
@@ -2096,6 +2133,7 @@ class UnifiDeviceCard extends HTMLElement {
 
   _renderPanelAndDetail() {
     if (this._ctx?.type === "access_point") {
+      this._syncUptimeRefreshTimer();
       const online = this._isDeviceOnline();
       const compactApView = this._apCompactViewEnabled();
       const apStatusRaw = this._apStatusRaw(this._ctx?.ap_status_entity);


### PR DESCRIPTION
### Motivation
- Ensure AP uptime sensors with `device_class: uptime` or timestamp-like states render as elapsed durations instead of calendar timestamps or numeric years. 
- Consolidate uptime/timestamp parsing and human-readable formatting into a reusable helper to remove duplicated logic.
- Keep device card code focused on UI behavior by moving parsing logic into `helpers.js`.

### Description
- Add `humanizeDurationSeconds`, `looksLikeTimestamp`, and `formatUptimeState` helpers to `src/helpers.js` to parse timestamps, interpret common uptime units, and return compact duration strings like `1d 2h 3m`.
- Replace the inline `_humanizeDurationSeconds` and `_apUptimeState` implementations in `src/unifi-device-card.js` with a call to the new `formatUptimeState` helper.
- Update `CHANGELOG.md` to mention the AP uptime rendering fix and add donation/issue guidance and a PayPal donate button.

### Testing
- Ran the project's linting via `npm run lint` and the automated test suite via `npm test`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2908c2bdcc833389724c265e347b55)