### PR TITLE
Add optional header telemetry toggle and improve telemetry detection/refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@
 
 ### ✨ Improvements
 - Add Home Assistant 2026.6 Lovelace entity suggestions for likely UniFi entities and use Home Assistant entity-name formatting when available for visible client/device-tracker names.
+- Add `show_telemetry` YAML/editor support to hide CPU, memory, and temperature telemetry rows from the card header.
 
 ### 🐛 Bug Fixes
+- Refresh the card when discovered telemetry or port-state entities update even if those entities are hidden from the normal visible device entity list.
+- Prefer Home Assistant Core UniFi telemetry identifiers (`device_cpu_utilization`, `device_memory_utilization`, `device_temperature`, CPU sub-temperature) so renamed/localized entities from the aiounifi-backed integration are matched more reliably.
 - Fix AP uptime rendering for Home Assistant `device_class: uptime` timestamp sensors so the card displays and refreshes an elapsed duration instead of `2026.00`.
 - Improve UniFi model recognition and same-family fallbacks for current devices reported by UniFi Network / aiounifi:
   - **Access points / bridges:** `G7LR`, `U7UKU`, `U6ENT`, `U6ENTIW`, `UAL6`, `UALR6`, `UAM6`, `UAP6`, `UAP6MP`, `U7-Pro-XG-Wall`, `U7-Pro-Outdoor`, `U7ENT` / `E7`, `E7-Campus`, `E7-Audience`, `UK-Ultra`, `UBB`, `UBB-XG`, `U-AirWire`, `UDB`, `UDB-IoT`, `UDB-Switch`, `UDB-Pro`, `UDB-Pro-Sector`.

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ special_port_label_color: "#60a5fa" # optional (special/WAN label + detail headl
 ap_led_color: "#2563eb"       # optional fallback (AP only; used if RGB LED color is not available)
 background_opacity: 85        # optional (0-100)
 show_name: true               # optional (default: true)
+show_telemetry: true          # optional (default: true; show CPU/memory/temperature in the header)
 show_panel: true              # optional (default: true)
 rotate180: false              # optional (default: false) | true flips the switch/gateway front panel by 180°
 ports_per_row: 8              # optional (switches only)
@@ -237,6 +238,7 @@ wan2_port: none               # optional (gateway only)
 | `device_id` | string | — | Home Assistant device registry ID of the UniFi device. |
 | `name` | string | device name | Custom display name shown in card header (if `show_name` is enabled). |
 | `show_name` | boolean | `true` | Show/hide the header title line. |
+| `show_telemetry` | boolean | `true` | Show/hide CPU, memory, and temperature telemetry rows in the card header. |
 | `background_color` | string | `var(--card-background-color)` | Any valid CSS color/token. |
 | `title_color` | string | theme default | Optional title text color. |
 | `telemetry_color` | string | theme default | Optional header telemetry color (CPU, memory, temperature values/labels). |
@@ -261,6 +263,8 @@ wan2_port: none               # optional (gateway only)
 | `special_ports` | array<number> | auto | Switch/Gateway only: explicit port numbers shown in the top special row; non-selected ports render in the normal grid. |
 | `wan_port` | string | auto | Gateway only: assign WAN role (`auto`, slot key like `wan`, or `port_<n>`). |
 | `wan2_port` | string | auto | Gateway only: assign WAN2 role (`auto`, `none`, slot key, or `port_<n>`). |
+
+Header telemetry is read from Home Assistant's UniFi Network sensor entities. The card prefers the stable Home Assistant Core UniFi identifiers behind those entities, so renamed or localized CPU, memory, and temperature sensors can still be matched when Home Assistant exposes them.
 
 > If `wan_port` or `wan2_port` is set in YAML, `edit_special_ports` is automatically treated as enabled in the editor and persisted.
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -29,15 +29,21 @@ function lower(value) {
 }
 
 function entityText(entity) {
+  const translationValues = entity?.translation_placeholders && typeof entity.translation_placeholders === "object"
+    ? Object.values(entity.translation_placeholders)
+    : [];
+
   return lower(
     [
-      entity.entity_id,
-      entity.original_name,
-      entity.name,
-      entity.platform,
-      entity.device_class,
-      entity.translation_key,
-      entity.original_device_class,
+      entity?.entity_id,
+      entity?.unique_id,
+      entity?.original_name,
+      entity?.name,
+      entity?.platform,
+      entity?.device_class,
+      entity?.translation_key,
+      entity?.original_device_class,
+      ...translationValues,
     ]
       .filter(Boolean)
       .join(" ")
@@ -361,53 +367,93 @@ function extractFirmware(device) {
 // Exported telemetry / reboot helpers
 // ─────────────────────────────────────────────────
 
+function isSensorEntity(entity) {
+  return lower(entity?.entity_id).startsWith("sensor.");
+}
+
 function findDeviceEntityByPatterns(entities, patterns = []) {
   for (const entity of entities || []) {
-    const id = lower(entity.entity_id);
-    if (!id.startsWith("sensor.")) continue;
-    if (patterns.some((pattern) => id.includes(pattern))) {
+    if (!isSensorEntity(entity)) continue;
+    if (isPortLevelTelemetrySensor(entity)) continue;
+    const text = entityText(entity);
+    if (patterns.some((pattern) => text.includes(pattern))) {
       return entity.entity_id;
     }
   }
   return null;
 }
 
-function isPortLevelTelemetrySensor(entityId) {
-  const id = lower(entityId);
+function isPortLevelTelemetrySensor(entity) {
+  const text = typeof entity === "string" ? lower(entity) : entityText(entity);
   return (
-    hasIndexedPortId(id) ||
-    id.includes("_wan_") ||
-    id.includes("link_speed") ||
-    id.includes("_rx") ||
-    id.includes("_tx") ||
-    id.includes("throughput")
+    hasIndexedPortId(text) ||
+    text.includes("_wan_") ||
+    text.includes("link_speed") ||
+    text.includes("port_link_speed") ||
+    text.includes("port_bandwidth") ||
+    text.includes("poe_power") ||
+    text.includes("_rx") ||
+    text.includes("_tx") ||
+    text.includes("throughput")
   );
+}
+
+function findCoreDeviceTelemetryEntity(entities, matchFn) {
+  for (const entity of entities || []) {
+    if (!isSensorEntity(entity)) continue;
+    if (isPortLevelTelemetrySensor(entity)) continue;
+    if (matchFn(entity, entityText(entity))) return entity.entity_id;
+  }
+  return null;
 }
 
 function findSystemStatEntity(entities, includePatterns = [], excludePatterns = []) {
   for (const entity of entities || []) {
-    const id = lower(entity.entity_id);
-    if (!id.startsWith("sensor.")) continue;
-    if (isPortLevelTelemetrySensor(id)) continue;
-    if (!includePatterns.some((pattern) => id.includes(pattern))) continue;
-    if (excludePatterns.some((pattern) => id.includes(pattern))) continue;
+    if (!isSensorEntity(entity)) continue;
+    if (isPortLevelTelemetrySensor(entity)) continue;
+    const text = entityText(entity);
+    if (!includePatterns.some((pattern) => text.includes(pattern))) continue;
+    if (excludePatterns.some((pattern) => text.includes(pattern))) continue;
     return entity.entity_id;
   }
   return null;
 }
 
 export function getDeviceTelemetry(entities) {
+  const coreCpuUtilization = findCoreDeviceTelemetryEntity(
+    entities,
+    (entity, text) => entity.translation_key === "device_cpu_utilization" || text.includes("cpu_utilization-")
+  );
+  const coreCpuTemperature = findCoreDeviceTelemetryEntity(
+    entities,
+    (entity, text) =>
+      text.includes("temperature-cpu-") ||
+      (entity.translation_key === "device_sub_temperature" && text.includes("cpu"))
+  );
+  const coreMemoryUtilization = findCoreDeviceTelemetryEntity(
+    entities,
+    (entity, text) => entity.translation_key === "device_memory_utilization" || text.includes("memory_utilization-")
+  );
+  const coreDeviceTemperature = findCoreDeviceTelemetryEntity(
+    entities,
+    (entity, text) => entity.translation_key === "device_temperature" || text.includes("device_temperature-")
+  );
+
   return {
     cpu_utilization_entity:
+      coreCpuUtilization ||
       findDeviceEntityByPatterns(entities, ["cpu_utilization", "cpu_usage", "processor_utilization"]) ||
       findSystemStatEntity(entities, ["cpu"], ["temperature", "temp", "clock", "frequency", "fan"]),
     cpu_temperature_entity:
-      findDeviceEntityByPatterns(entities, ["cpu_temperature", "processor_temperature", "temperature_cpu"]) ||
+      coreCpuTemperature ||
+      findDeviceEntityByPatterns(entities, ["cpu_temperature", "processor_temperature", "temperature_cpu", "temperature-cpu"]) ||
       findSystemStatEntity(entities, ["cpu_temp", "cpu_temperature", "processor_temperature", "temperature_cpu", "cpu"], ["utilization", "usage", "clock", "frequency"]),
     memory_utilization_entity:
+      coreMemoryUtilization ||
       findDeviceEntityByPatterns(entities, ["memory_utilization", "memory_usage", "ram_utilization"]) ||
       findSystemStatEntity(entities, ["memory", "ram"], ["temperature", "temp", "slot"]),
     temperature_entity:
+      coreDeviceTemperature ||
       findDeviceEntityByPatterns(entities, ["device_temperature", "system_temperature", "board_temperature", "chassis_temperature"]) ||
       findSystemStatEntity(
         entities,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -401,8 +401,8 @@ function isPortLevelTelemetrySensor(entity) {
 function findCoreDeviceTelemetryEntity(entities, matchFn) {
   for (const entity of entities || []) {
     if (!isSensorEntity(entity)) continue;
-    if (isPortLevelTelemetrySensor(entity)) continue;
-    if (matchFn(entity, entityText(entity))) return entity.entity_id;
+    const text = entityText(entity);
+    if (matchFn(entity, text)) return entity.entity_id;
   }
   return null;
 }

--- a/src/translations.js
+++ b/src/translations.js
@@ -63,6 +63,9 @@ const TRANSLATIONS = {
     editor_name_toggle_hint:  "Enabled by default. When disabled, only the model/firmware line is shown.",
     editor_name_label:        "Display name text",
     editor_name_hint:         "Optional — updates automatically when switching devices unless you changed it manually",
+    editor_telemetry_toggle_label: "Header telemetry",
+    editor_telemetry_toggle_text:  "Show telemetry data in the card header",
+    editor_telemetry_toggle_hint:  "Enabled by default. Disable to hide CPU, memory, and temperature rows in the header.",
     editor_panel_toggle_label: "Front panel",
     editor_panel_toggle_text:  "Show front panel hardware view",
     editor_panel_toggle_hint:  "Enabled by default. Disable to hide the visual front panel.",
@@ -231,6 +234,9 @@ const TRANSLATIONS = {
     editor_name_toggle_hint:  "Standardmäßig aktiviert. Wenn deaktiviert, wird nur die Modell-/Firmware-Zeile angezeigt.",
     editor_name_label:        "Text für den Anzeigenamen",
     editor_name_hint:         "Optional — wird beim Gerätewechsel automatisch aktualisiert, solange du ihn nicht manuell geändert hast",
+    editor_telemetry_toggle_label: "Header-Telemetrie",
+    editor_telemetry_toggle_text:  "Telemetriedaten im Karten-Header anzeigen",
+    editor_telemetry_toggle_hint:  "Standardmäßig aktiviert. Deaktivieren blendet CPU-, Speicher- und Temperaturzeilen im Header aus.",
     editor_panel_toggle_label: "Frontpanel",
     editor_panel_toggle_text:  "Hardware-Frontpanel anzeigen",
     editor_panel_toggle_hint:  "Standardmäßig aktiviert. Deaktivieren blendet die visuelle Port-Ansicht aus.",
@@ -399,6 +405,9 @@ const TRANSLATIONS = {
     editor_name_toggle_hint:  "Standaard ingeschakeld. Indien uitgeschakeld, wordt alleen de model-/firmwareregel getoond.",
     editor_name_label:        "Tekst voor de weergavenaam",
     editor_name_hint:         "Optioneel — wordt automatisch bijgewerkt bij het wisselen van apparaat zolang je hem niet handmatig hebt aangepast",
+    editor_telemetry_toggle_label: "Headertelemetrie",
+    editor_telemetry_toggle_text:  "Telemetriegegevens in de kaartkop tonen",
+    editor_telemetry_toggle_hint:  "Standaard ingeschakeld. Uitschakelen verbergt CPU-, geheugen- en temperatuurregels in de kop.",
     editor_panel_toggle_label: "Frontpaneel",
     editor_panel_toggle_text:  "Hardware-frontpaneel tonen",
     editor_panel_toggle_hint:  "Standaard ingeschakeld. Uitschakelen verbergt de visuele poortweergave.",
@@ -563,6 +572,9 @@ const TRANSLATIONS = {
     editor_name_toggle_hint:  "Activé par défaut. Si désactivé, seule la ligne modèle/firmware est affichée.",
     editor_name_label:     "Nom d'affichage",
     editor_name_hint:      "Optionnel — par défaut le nom de l'appareil",
+    editor_telemetry_toggle_label: "Télémétrie d’en-tête",
+    editor_telemetry_toggle_text:  "Afficher les données de télémétrie dans l’en-tête",
+    editor_telemetry_toggle_hint:  "Activé par défaut. Désactivez pour masquer les lignes CPU, mémoire et température dans l’en-tête.",
     editor_panel_toggle_label: "Panneau avant",
     editor_panel_toggle_text:  "Afficher la vue matérielle du panneau avant",
     editor_panel_toggle_hint:  "Activé par défaut. Désactivez pour masquer la vue visuelle des ports.",
@@ -727,6 +739,9 @@ const TRANSLATIONS = {
     editor_name_toggle_hint:  "Activado por defecto. Si se desactiva, solo se muestra la línea de modelo/firmware.",
     editor_name_label:     "Nombre para mostrar",
     editor_name_hint:      "Opcional — por defecto, el nombre del dispositivo",
+    editor_telemetry_toggle_label: "Telemetría del encabezado",
+    editor_telemetry_toggle_text:  "Mostrar datos de telemetría en el encabezado",
+    editor_telemetry_toggle_hint:  "Activado por defecto. Desactívalo para ocultar CPU, memoria y temperatura en el encabezado.",
     editor_panel_toggle_label: "Panel frontal",
     editor_panel_toggle_text:  "Mostrar vista de hardware del panel frontal",
     editor_panel_toggle_hint:  "Activado por defecto. Desactívalo para ocultar la vista visual del panel.",
@@ -891,6 +906,9 @@ const TRANSLATIONS = {
     editor_name_toggle_hint:  "Abilitato per default. Se disabilitato, viene mostrata solo la riga modello/firmware.",
     editor_name_label:     "Nome visualizzato",
     editor_name_hint:      "Opzionale — per impostazione predefinita il nome del dispositivo",
+    editor_telemetry_toggle_label: "Telemetria header",
+    editor_telemetry_toggle_text:  "Mostra i dati di telemetria nell’header",
+    editor_telemetry_toggle_hint:  "Abilitato per default. Disattiva per nascondere CPU, memoria e temperatura nell’header.",
     editor_panel_toggle_label: "Pannello frontale",
     editor_panel_toggle_text:  "Mostra la vista hardware del pannello frontale",
     editor_panel_toggle_hint:  "Abilitato per default. Disattivalo per nascondere la vista visiva dei porti.",
@@ -1005,6 +1023,9 @@ const TRANSLATIONS = {
 
 TRANSLATIONS.sv = {
   ...TRANSLATIONS.en,
+  editor_telemetry_toggle_label: "Headertelemetri",
+  editor_telemetry_toggle_text:  "Visa telemetridata i kortets header",
+  editor_telemetry_toggle_hint:  "Aktiverat som standard. Inaktivera för att dölja CPU-, minnes- och temperaturrader i headern.",
   editor_colors_open: "Ändra färger",
   editor_colors_back: "Tillbaka till editorn",
   editor_colors_apply: "Använd färger",
@@ -1014,6 +1035,9 @@ TRANSLATIONS.sv = {
 
 TRANSLATIONS.da = {
   ...TRANSLATIONS.en,
+  editor_telemetry_toggle_label: "Headertelemetri",
+  editor_telemetry_toggle_text:  "Vis telemetridata i kortets header",
+  editor_telemetry_toggle_hint:  "Aktiveret som standard. Slå fra for at skjule CPU-, hukommelses- og temperaturlinjer i headeren.",
   editor_colors_open: "Skift farver",
   editor_colors_back: "Tilbage til editor",
   editor_colors_apply: "Anvend farver",
@@ -1023,6 +1047,9 @@ TRANSLATIONS.da = {
 
 TRANSLATIONS.no = {
   ...TRANSLATIONS.en,
+  editor_telemetry_toggle_label: "Headertelemetri",
+  editor_telemetry_toggle_text:  "Vis telemetridata i kortoverskriften",
+  editor_telemetry_toggle_hint:  "Aktivert som standard. Slå av for å skjule CPU-, minne- og temperaturrader i overskriften.",
   editor_colors_open: "Endre farger",
   editor_colors_back: "Tilbake til editor",
   editor_colors_apply: "Bruk farger",
@@ -1032,6 +1059,9 @@ TRANSLATIONS.no = {
 
 TRANSLATIONS.fi = {
   ...TRANSLATIONS.en,
+  editor_telemetry_toggle_label: "Otsakkeen telemetria",
+  editor_telemetry_toggle_text:  "Näytä telemetriatiedot kortin otsakkeessa",
+  editor_telemetry_toggle_hint:  "Käytössä oletuksena. Poista käytöstä piilottaaksesi CPU-, muisti- ja lämpötilarivit otsakkeesta.",
   editor_colors_open: "Vaihda värejä",
   editor_colors_back: "Takaisin editoriin",
   editor_colors_apply: "Käytä värit",
@@ -1041,6 +1071,9 @@ TRANSLATIONS.fi = {
 
 TRANSLATIONS.pl = {
   ...TRANSLATIONS.en,
+  editor_telemetry_toggle_label: "Telemetria nagłówka",
+  editor_telemetry_toggle_text:  "Pokaż dane telemetryczne w nagłówku karty",
+  editor_telemetry_toggle_hint:  "Domyślnie włączone. Wyłącz, aby ukryć w nagłówku wiersze CPU, pamięci i temperatury.",
   editor_colors_open: "Zmień kolory",
   editor_colors_back: "Wróć do edytora",
   editor_colors_apply: "Zastosuj kolory",
@@ -1050,6 +1083,9 @@ TRANSLATIONS.pl = {
 
 TRANSLATIONS.cs = {
   ...TRANSLATIONS.en,
+  editor_telemetry_toggle_label: "Telemetrie záhlaví",
+  editor_telemetry_toggle_text:  "Zobrazit telemetrii v záhlaví karty",
+  editor_telemetry_toggle_hint:  "Ve výchozím stavu zapnuto. Vypnutím skryjete řádky CPU, paměti a teploty v záhlaví.",
   editor_colors_open: "Změnit barvy",
   editor_colors_back: "Zpět do editoru",
   editor_colors_apply: "Použít barvy",

--- a/src/unifi-device-card-editor.js
+++ b/src/unifi-device-card-editor.js
@@ -461,6 +461,7 @@ class UnifiDeviceCardEditor extends HTMLElement {
     }
     if (next.edit_special_ports !== true) delete next.edit_special_ports;
     if (next.show_name !== false) delete next.show_name;
+    if (next.show_telemetry !== false) delete next.show_telemetry;
     if (next.show_panel !== false) delete next.show_panel;
     if (next.force_sequential_ports !== true) delete next.force_sequential_ports;
     next.ports_per_row = normalizePortsPerRow(next.ports_per_row);
@@ -516,6 +517,11 @@ class UnifiDeviceCardEditor extends HTMLElement {
   _onShowNameChange(ev) {
     const checked = !!ev.target.checked;
     this._emitConfig({ show_name: checked ? undefined : false });
+  }
+
+  _onShowTelemetryChange(ev) {
+    const checked = !!ev.target.checked;
+    this._emitConfig({ show_telemetry: checked ? undefined : false });
   }
 
   _onBackgroundInput(ev) {
@@ -1119,6 +1125,7 @@ class UnifiDeviceCardEditor extends HTMLElement {
     const isSwitchOrGateway = isSwitchDevice || selectedType === "gateway";
     const nameValue = this._config?.name || "";
     const showName = this._config?.show_name !== false;
+    const showTelemetry = this._config?.show_telemetry !== false;
     const showPanel = this._config?.show_panel !== false;
     const forceSequentialPorts = this._config?.force_sequential_ports === true;
     const backgroundOpacity = clampOpacity(this._config?.background_opacity);
@@ -1133,7 +1140,7 @@ class UnifiDeviceCardEditor extends HTMLElement {
     const portSize = clampPortSize(this._config?.port_size);
     const apScale = clampApScale(this._config?.ap_scale);
     const apCompactView = this._config?.ap_compact_view === true;
-    const apCompactShowHeaderTelemetry = this._config?.ap_compact_show_header_telemetry === true;
+    const apCompactShowHeaderTelemetry = showTelemetry && this._config?.ap_compact_show_header_telemetry === true;
     const editSpecialPorts =
       this._config?.edit_special_ports === true ||
       !!this._config?.wan_port ||
@@ -1199,6 +1206,15 @@ class UnifiDeviceCardEditor extends HTMLElement {
           <div class="hint">${escapeHtml(this._t("editor_name_hint"))}</div>
         </div>
 
+        <div class="field">
+          <label>${escapeHtml(this._t("editor_telemetry_toggle_label"))}</label>
+          <label class="checkbox-row">
+            <input id="show_telemetry" type="checkbox" ${showTelemetry ? "checked" : ""}>
+            <span>${escapeHtml(this._t("editor_telemetry_toggle_text"))}</span>
+          </label>
+          <div class="hint">${escapeHtml(this._t("editor_telemetry_toggle_hint"))}</div>
+        </div>
+
         ${isSwitchOrGateway ? `
         <div class="field">
           <label>${escapeHtml(this._t("editor_panel_toggle_label"))}</label>
@@ -1237,7 +1253,7 @@ class UnifiDeviceCardEditor extends HTMLElement {
         <div class="field">
           <label>${escapeHtml(this._t("editor_ap_compact_header_telemetry_label"))}</label>
           <label class="checkbox-row">
-            <input id="ap_compact_show_header_telemetry" type="checkbox" ${apCompactShowHeaderTelemetry ? "checked" : ""}>
+            <input id="ap_compact_show_header_telemetry" type="checkbox" ${apCompactShowHeaderTelemetry ? "checked" : ""} ${showTelemetry ? "" : "disabled"}>
             <span>${escapeHtml(this._t("editor_ap_compact_header_telemetry_text"))}</span>
           </label>
           <div class="hint">${escapeHtml(this._t("editor_ap_compact_header_telemetry_hint"))}</div>
@@ -1350,6 +1366,8 @@ class UnifiDeviceCardEditor extends HTMLElement {
 
     this.shadowRoot.getElementById("show_name")
       ?.addEventListener("change", (ev) => this._onShowNameChange(ev));
+    this.shadowRoot.getElementById("show_telemetry")
+      ?.addEventListener("change", (ev) => this._onShowTelemetryChange(ev));
     this.shadowRoot.getElementById("show_panel")
       ?.addEventListener("change", (ev) => this._onShowPanelChange(ev));
 

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -367,8 +367,16 @@ class UnifiDeviceCard extends HTMLElement {
     return this._ctx?.type === "access_point" && this._config?.ap_compact_view === true;
   }
 
+  _telemetryEnabled() {
+    return this._config?.show_telemetry !== false;
+  }
+
   _apCompactHeaderTelemetryEnabled() {
-    return this._ctx?.type === "access_point" && this._config?.ap_compact_show_header_telemetry === true;
+    return (
+      this._ctx?.type === "access_point" &&
+      this._telemetryEnabled() &&
+      this._config?.ap_compact_show_header_telemetry === true
+    );
   }
 
   _maxPortColumns() {
@@ -794,13 +802,55 @@ class UnifiDeviceCard extends HTMLElement {
     return { specials: specialsRaw, numbered: numberedRaw };
   }
 
-  _hasRelevantStateChanges(previousHass, nextHass) {
-    const entities = this._ctx?.entities || [];
-    if (!Array.isArray(entities) || entities.length === 0) return true;
+  _relevantStateEntityIds() {
+    const ids = new Set();
+    for (const entity of this._ctx?.entities || []) {
+      if (entity?.entity_id) ids.add(entity.entity_id);
+    }
 
-    for (const entity of entities) {
-      const id = entity?.entity_id;
-      if (!id) continue;
+    const directEntityKeys = [
+      "cpu_utilization_entity",
+      "cpu_temperature_entity",
+      "memory_utilization_entity",
+      "temperature_entity",
+      "online_entity",
+      "uptime_entity",
+      "clients_entity",
+      "ap_status_entity",
+      "led_switch_entity",
+      "led_color_entity",
+      "reboot_entity",
+    ];
+    for (const key of directEntityKeys) {
+      const entityId = this._ctx?.[key];
+      if (entityId) ids.add(entityId);
+    }
+
+    const { specials, numbered } = this._buildSlotData(this._ctx);
+    const portEntityKeys = [
+      "link_entity",
+      "speed_entity",
+      "poe_switch_entity",
+      "poe_power_entity",
+      "port_switch_entity",
+      "power_cycle_entity",
+      "rx_entity",
+      "tx_entity",
+    ];
+    for (const slot of [...specials, ...numbered]) {
+      for (const key of portEntityKeys) {
+        if (slot?.[key]) ids.add(slot[key]);
+      }
+    }
+
+    return ids;
+  }
+
+  _hasRelevantStateChanges(previousHass, nextHass) {
+    const entityIds = this._relevantStateEntityIds();
+    if (!entityIds.size) return true;
+
+    for (const id of entityIds) {
       if (previousHass?.states?.[id] !== nextHass?.states?.[id]) return true;
     }
 
@@ -1132,7 +1182,7 @@ class UnifiDeviceCard extends HTMLElement {
   }
 
   _headerMetrics() {
-    if (!this._ctx || !this._hass) return [];
+    if (!this._telemetryEnabled() || !this._ctx || !this._hass) return [];
 
     const metrics = [
       { key: "cpu_utilization", entity: this._ctx.cpu_utilization_entity },


### PR DESCRIPTION
### Motivation
- Add an option to hide CPU/memory/temperature telemetry rows from the card header and surface that option in the editor and README. 
- Improve robustness of telemetry entity detection so Home Assistant Core UniFi identifiers and translated/renamed entities are matched more reliably. 
- Ensure the card refreshes when telemetry or port-state entities update even if those entities are hidden from the normal visible device entity list.

### Description
- Introduce a new YAML/editor config option `show_telemetry` (default: `true`) with editor checkbox, translations, README entry, and CHANGELOG note. 
- Editor: added `show_telemetry` control, its change handler, and logic to disable `ap_compact_show_header_telemetry` when header telemetry is turned off; ensure config normalization deletes default values. 
- Card logic: added `_telemetryEnabled()` and gated header metrics with it so telemetry rows are omitted when disabled. 
- State update logic: implemented `_relevantStateEntityIds()` and switched `_hasRelevantStateChanges()` to only watch a relevant set of entities (including telemetry and per-port entities) so hidden telemetry/port-state updates still trigger refresh. 
- Telemetry detection: enhanced `helpers.js` to inspect `translation_placeholders`, `unique_id`, and `translation_key`, added `isSensorEntity`, `findCoreDeviceTelemetryEntity`, and made port-level sensor detection more comprehensive (additional name patterns like `port_link_speed`, `port_bandwidth`, `poe_power`). 
- Added/updated translations for the new editor strings across locales and updated `README.md` and `CHANGELOG.md` to document the feature.

### Testing
- Ran the project's automated test suite via `npm test` and linting via `npm run lint`, both completed successfully. 
- Built the project with `npm run build` to validate bundling, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b004c1cfc83339344f07925921cbe)