### PR TITLE
Detect Home Assistant Core UniFi header telemetry and surface editor warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug Fixes
 - Refresh the card when discovered telemetry or port-state entities update even if those entities are hidden from the normal visible device entity list.
 - Prefer Home Assistant Core UniFi telemetry identifiers (`device_cpu_utilization`, `device_memory_utilization`, `device_temperature`, CPU sub-temperature) so renamed/localized entities from the aiounifi-backed integration are matched more reliably.
+- Detect disabled or hidden Home Assistant Core UniFi header telemetry sensors (`device_cpu_utilization`, `device_memory_utilization`, `device_temperature`, `device_sub_temperature`) in the editor warning.
 - Fix AP uptime rendering for Home Assistant `device_class: uptime` timestamp sensors so the card displays and refreshes an elapsed duration instead of `2026.00`.
 - Improve UniFi model recognition and same-family fallbacks for current devices reported by UniFi Network / aiounifi:
   - **Access points / bridges:** `G7LR`, `U7UKU`, `U6ENT`, `U6ENTIW`, `UAL6`, `UALR6`, `UAM6`, `UAP6`, `UAP6MP`, `U7-Pro-XG-Wall`, `U7-Pro-Outdoor`, `U7ENT` / `E7`, `E7-Campus`, `E7-Audience`, `UK-Ultra`, `UBB`, `UBB-XG`, `U-AirWire`, `UDB`, `UDB-IoT`, `UDB-Switch`, `UDB-Pro`, `UDB-Pro-Sector`.

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -431,33 +431,97 @@ function findSystemStatEntity(entities, includePatterns = [], excludePatterns = 
   return null;
 }
 
+const HEADER_TELEMETRY_MATCHERS = {
+  cpu_utilization: {
+    features: new Set(["cpu_utilization"]),
+    translationKeys: new Set(["device_cpu_utilization"]),
+    uniqueIdPrefixes: ["cpu_utilization-"],
+  },
+  cpu_temperature: {
+    features: new Set(["sub_temperature"]),
+    translationKeys: new Set(["device_sub_temperature"]),
+    uniqueIdPrefixes: ["temperature-cpu-"],
+    textPatterns: ["cpu", "processor", "temperature-cpu"],
+  },
+  memory_utilization: {
+    features: new Set(["memory_utilization"]),
+    translationKeys: new Set(["device_memory_utilization"]),
+    uniqueIdPrefixes: ["memory_utilization-"],
+  },
+  temperature: {
+    features: new Set(["temperature"]),
+    translationKeys: new Set(["device_temperature"]),
+    uniqueIdPrefixes: ["device_temperature-"],
+  },
+  sub_temperature: {
+    features: new Set(["sub_temperature"]),
+    translationKeys: new Set(["device_sub_temperature"]),
+  },
+};
+
+function matchesHeaderTelemetryTarget(entity, target) {
+  if (!isSensorEntity(entity)) return false;
+
+  const matcher = HEADER_TELEMETRY_MATCHERS[target];
+  if (!matcher) return false;
+
+  const parsed = parseUnifiDeviceUniqueId(entity?.unique_id);
+  if (parsed?.feature && matcher.features?.has(parsed.feature)) {
+    if (!matcher.textPatterns?.length) return true;
+    const text = entityText(entity);
+    return matcher.textPatterns.some((pattern) => text.includes(pattern));
+  }
+
+  const uid = lower(entity?.unique_id);
+  if (uid && matcher.uniqueIdPrefixes?.some((prefix) => uid.startsWith(prefix))) {
+    if (!matcher.textPatterns?.length) return true;
+    const text = entityText(entity);
+    return matcher.textPatterns.some((pattern) => text.includes(pattern));
+  }
+
+  const tk = lower(entity?.translation_key);
+  if (matcher.translationKeys?.has(tk)) {
+    if (!matcher.textPatterns?.length) return true;
+    const text = entityText(entity);
+    return matcher.textPatterns.some((pattern) => text.includes(pattern));
+  }
+
+  return false;
+}
+
+function findHeaderTelemetryEntity(entities, target) {
+  for (const entity of entities || []) {
+    if (matchesHeaderTelemetryTarget(entity, target)) return entity.entity_id;
+  }
+  return null;
+}
+
+function findFallbackSubTemperatureEntity(entities) {
+  for (const entity of entities || []) {
+    if (!matchesHeaderTelemetryTarget(entity, "sub_temperature")) continue;
+    const text = entityText(entity);
+    if (text.includes("cpu") || text.includes("processor")) continue;
+    return entity.entity_id;
+  }
+  return null;
+}
+
+function classifyHeaderTelemetryWarningType(entity) {
+  if (matchesHeaderTelemetryTarget(entity, "cpu_utilization")) return "header_cpu";
+  if (matchesHeaderTelemetryTarget(entity, "memory_utilization")) return "header_memory";
+  if (matchesHeaderTelemetryTarget(entity, "cpu_temperature")) return "header_cpu_temperature";
+  if (matchesHeaderTelemetryTarget(entity, "temperature")) return "header_temperature";
+  if (matchesHeaderTelemetryTarget(entity, "sub_temperature")) return "header_temperature";
+  return null;
+}
+
 export function getDeviceTelemetry(entities) {
-  const coreCpuUtilization =
-    findDeviceUniqueIdTelemetryEntity(entities, ["cpu_utilization"]) ||
-    findCoreDeviceTelemetryEntity(
-      entities,
-      (entity, text) => entity.translation_key === "device_cpu_utilization" || text.includes("device_cpu_utilization-")
-    );
-  const coreCpuTemperature =
-    findDeviceUniqueIdTelemetryEntity(entities, ["sub_temperature"]) ||
-    findCoreDeviceTelemetryEntity(
-      entities,
-      (entity, text) =>
-        text.includes("temperature-cpu-") ||
-        (entity.translation_key === "device_sub_temperature" && text.includes("cpu"))
-    );
-  const coreMemoryUtilization =
-    findDeviceUniqueIdTelemetryEntity(entities, ["memory_utilization"]) ||
-    findCoreDeviceTelemetryEntity(
-      entities,
-      (entity, text) => entity.translation_key === "device_memory_utilization" || text.includes("device_memory_utilization-")
-    );
+  const coreCpuUtilization = findHeaderTelemetryEntity(entities, "cpu_utilization");
+  const coreCpuTemperature = findHeaderTelemetryEntity(entities, "cpu_temperature");
+  const coreMemoryUtilization = findHeaderTelemetryEntity(entities, "memory_utilization");
   const coreDeviceTemperature =
-    findDeviceUniqueIdTelemetryEntity(entities, ["temperature"]) ||
-    findCoreDeviceTelemetryEntity(
-      entities,
-      (entity, text) => entity.translation_key === "device_temperature" || text.includes("device_temperature-")
-    );
+    findHeaderTelemetryEntity(entities, "temperature") ||
+    findFallbackSubTemperatureEntity(entities);
 
   return {
     cpu_utilization_entity:
@@ -819,6 +883,9 @@ export async function getUnifiDevices(hass) {
 // ─────────────────────────────────────────────────
 
 function classifyRelevantEntityType(entity) {
+  const headerTelemetryType = classifyHeaderTelemetryWarningType(entity);
+  if (headerTelemetryType) return headerTelemetryType;
+
   const id = lower(entity.entity_id);
   const eid = entity.entity_id || "";
   const tk = lower(entity.translation_key || "");
@@ -918,6 +985,10 @@ export async function getRelevantEntityWarningsForDevice(hass, deviceId) {
     rx_tx: [],
     power_cycle: [],
     link: [],
+    header_cpu: [],
+    header_memory: [],
+    header_cpu_temperature: [],
+    header_temperature: [],
   };
   const hidden = {
     port_switch: [],
@@ -927,6 +998,10 @@ export async function getRelevantEntityWarningsForDevice(hass, deviceId) {
     rx_tx: [],
     power_cycle: [],
     link: [],
+    header_cpu: [],
+    header_memory: [],
+    header_cpu_temperature: [],
+    header_temperature: [],
   };
 
   for (const entity of allForDevice) {

--- a/src/translations.js
+++ b/src/translations.js
@@ -174,6 +174,10 @@ const TRANSLATIONS = {
     warning_entity_rx_tx:       "RX/TX sensors",
     warning_entity_power_cycle: "power cycle buttons",
     warning_entity_link:        "link entities",
+    warning_entity_header_cpu:  "header CPU sensors",
+    warning_entity_header_memory: "header memory sensors",
+    warning_entity_header_cpu_temperature: "header CPU temperature sensors",
+    warning_entity_header_temperature: "header temperature sensors",
 
     // Device type labels (used in device selector)
     type_switch:  "Switch",
@@ -345,6 +349,10 @@ const TRANSLATIONS = {
     warning_entity_rx_tx:       "RX/TX-Sensoren",
     warning_entity_power_cycle: "Power-Cycle-Buttons",
     warning_entity_link:        "Link-Entities",
+    warning_entity_header_cpu:  "Header-CPU-Sensoren",
+    warning_entity_header_memory: "Header-Speichersensoren",
+    warning_entity_header_cpu_temperature: "Header-CPU-Temperatursensoren",
+    warning_entity_header_temperature: "Header-Temperatursensoren",
 
     // Device type labels
     type_switch:  "Switch",

--- a/src/unifi-device-card-editor.js
+++ b/src/unifi-device-card-editor.js
@@ -728,6 +728,10 @@ class UnifiDeviceCardEditor extends HTMLElement {
       "rx_tx",
       "power_cycle",
       "link",
+      "header_cpu",
+      "header_memory",
+      "header_cpu_temperature",
+      "header_temperature",
     ];
 
     return order


### PR DESCRIPTION
### Motivation
- Improve detection and matching of Home Assistant Core UniFi header telemetry sensors (CPU, memory, temperature and CPU sub-temperature) so the card uses canonical identifiers and localized/renamed entities are found reliably.
- Surface disabled or hidden Core UniFi header telemetry sensors in the editor warning UI to help users discover missing telemetry affecting the card.

### Description
- Added `HEADER_TELEMETRY_MATCHERS` and helper functions `matchesHeaderTelemetryTarget`, `findHeaderTelemetryEntity`, `findFallbackSubTemperatureEntity`, and `classifyHeaderTelemetryWarningType` to centralize header telemetry matching logic in `src/helpers.js`.
- Replaced older ad-hoc core telemetry matching in `getDeviceTelemetry` with the new matcher-based lookups and added a fallback for sub-temperature selection.
- Updated `classifyRelevantEntityType` and `getRelevantEntityWarningsForDevice` to detect and report header telemetry warning categories, and extended the editor (`src/unifi-device-card-editor.js`) to include these new warning types in the display order.
- Added translation strings for the new warning labels in `src/translations.js` and updated `CHANGELOG.md` to document the editor warning detection change.

### Testing
- Ran the project linter with `npm run lint` and the existing test suite with `npm test`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b15bb24e48333ade4056d9e1eefd1)