### PR TITLE
Improve device stat detection (translation keys) and entity suggestion compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🐛 Bug Fixes
 - Detect device uptime, client count, and status sensors by stable Home Assistant translation keys/name metadata so localized entity IDs continue to work.
+- Preserve device stat detection when device/entity names contain port-like tokens, while still avoiding port-level status sensors.
 - Return Home Assistant entity suggestions with a `config` object while keeping the legacy top-level card type for compatibility.
 
 ### ✨ Hints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### 🐛 Bug Fixes
 - Detect device uptime, client count, and status sensors by stable Home Assistant translation keys/name metadata so localized entity IDs continue to work.
 - Preserve device stat detection when device/entity names contain port-like tokens, while still avoiding port-level status sensors.
-- Return Home Assistant entity suggestions with a `config` object while keeping the legacy top-level card type for compatibility.
+- Return Home Assistant entity suggestions with a `config` object containing the selected `device_id` while keeping the legacy top-level card type for compatibility.
 
 ### ✨ Hints
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [v0.7.6]
+
+### 🐛 Bug Fixes
+- Detect device uptime, client count, and status sensors by stable Home Assistant translation keys/name metadata so localized entity IDs continue to work.
+- Return Home Assistant entity suggestions with a `config` object while keeping the legacy top-level card type for compatibility.
+
+### ✨ Hints
+
+I try to save money to get an Cloud Gateway Max in future to replace my Cloud Gateway Ultra, maybe then i could be able to add more feature to the card.
+
+If you see improvements, issues, or fixes, feel free to open an issue or create a pull request.
+
+If you like this project and want to support my work, you can donate via PayPal.
+
+<a href="https://www.paypal.me/bluenazgul">
+  <img
+    src="https://raw.githubusercontent.com/stefan-niedermann/paypal-donate-button/master/paypal-donate-button.png"
+    alt="Donate with PayPal"
+    width="220"
+  />
+</a>
+
 ## [v0.7.5]
 
 ### ✨ Improvements

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -621,26 +621,39 @@ function statTextIncludes(text, patterns) {
   });
 }
 
+function isUnambiguousDeviceStatTranslationKey(entity, stat, matcher) {
+  const tk = lower(entity?.translation_key);
+  if (!matcher.translationKeys.has(tk)) return false;
+  if (tk.startsWith("device_")) return true;
+  return stat !== "status";
+}
+
 function findDeviceStatEntity(entities, stat) {
   const matcher = DEVICE_STAT_MATCHERS[stat];
   if (!matcher) return null;
 
-  const sensors = (entities || []).filter((entity) => lower(entity?.entity_id).startsWith("sensor.") && !hasPortLevelStatSignal(entity));
+  const sensors = (entities || []).filter((entity) => lower(entity?.entity_id).startsWith("sensor."));
 
   for (const entity of sensors) {
+    if (isUnambiguousDeviceStatTranslationKey(entity, stat, matcher)) return entity.entity_id;
+  }
+
+  const deviceSensors = sensors.filter((entity) => !hasPortLevelStatSignal(entity));
+
+  for (const entity of deviceSensors) {
     if (matcher.translationKeys.has(lower(entity?.translation_key))) return entity.entity_id;
   }
 
-  for (const entity of sensors) {
+  for (const entity of deviceSensors) {
     const tk = canonicalStatText(entity?.translation_key);
     if (tk && statTextIncludes(tk, matcher.textPatterns)) return entity.entity_id;
   }
 
-  for (const entity of sensors) {
+  for (const entity of deviceSensors) {
     if (statTextIncludes(getDeviceStatDisplayText(entity), matcher.textPatterns)) return entity.entity_id;
   }
 
-  for (const entity of sensors) {
+  for (const entity of deviceSensors) {
     if (matcher.fallbackId(lower(entity?.entity_id)) || statTextIncludes(getDeviceStatFallbackText(entity), matcher.textPatterns)) {
       return entity.entity_id;
     }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -576,10 +576,80 @@ export function getDeviceOnlineEntity(entities) {
   return null;
 }
 
-export function getAccessPointStatEntities(entities) {
-  let uptimeEntity = null;
-  let clientsEntity = null;
-  let apStatusEntity = null;
+const DEVICE_STAT_MATCHERS = {
+  uptime: {
+    translationKeys: new Set(["uptime", "device_uptime"]),
+    textPatterns: ["uptime", "device_uptime"],
+    fallbackId: (id) => id.endsWith("_uptime") || id.includes(" uptime") || id.includes("_uptime_") || id.includes("uptime"),
+  },
+  clients: {
+    translationKeys: new Set(["clients", "connected_clients", "client_count", "num_clients", "active_clients", "station_count"]),
+    textPatterns: ["clients", "connected_clients", "client_count", "num_clients", "active_clients", "station_count"],
+    fallbackId: (id) => id.endsWith("_clients") || id.includes("_clients_") || id.includes(" clients"),
+  },
+  status: {
+    translationKeys: new Set(["state", "status", "device_state", "device_status"]),
+    textPatterns: ["state", "status", "device_state", "device_status"],
+    fallbackId: (id) => id.endsWith("_state") || id.includes("_state_") || id.endsWith("_status") || id.includes("_status_"),
+  },
+};
+
+function canonicalStatText(value) {
+  return lower(value).replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+}
+
+function hasPortLevelStatSignal(entity) {
+  if (parseUnifiPortUniqueId(entity?.unique_id)) return true;
+  if (hasIndexedPortId(entity?.entity_id)) return true;
+
+  const displayText = [entity?.original_name, entity?.name].filter(Boolean).join(" ");
+  return /\b(?:port|lan|eth|ethernet|sfp(?:28)?)\s*\d+\b/i.test(displayText);
+}
+
+function getDeviceStatDisplayText(entity) {
+  return canonicalStatText([entity?.original_name, entity?.name].filter(Boolean).join(" "));
+}
+
+function getDeviceStatFallbackText(entity) {
+  return canonicalStatText([entity?.entity_id, entity?.original_name, entity?.name].filter(Boolean).join(" "));
+}
+
+function statTextIncludes(text, patterns) {
+  return patterns.some((pattern) => {
+    const canonicalPattern = canonicalStatText(pattern);
+    return text === canonicalPattern || text.includes(canonicalPattern);
+  });
+}
+
+function findDeviceStatEntity(entities, stat) {
+  const matcher = DEVICE_STAT_MATCHERS[stat];
+  if (!matcher) return null;
+
+  const sensors = (entities || []).filter((entity) => lower(entity?.entity_id).startsWith("sensor.") && !hasPortLevelStatSignal(entity));
+
+  for (const entity of sensors) {
+    if (matcher.translationKeys.has(lower(entity?.translation_key))) return entity.entity_id;
+  }
+
+  for (const entity of sensors) {
+    const tk = canonicalStatText(entity?.translation_key);
+    if (tk && statTextIncludes(tk, matcher.textPatterns)) return entity.entity_id;
+  }
+
+  for (const entity of sensors) {
+    if (statTextIncludes(getDeviceStatDisplayText(entity), matcher.textPatterns)) return entity.entity_id;
+  }
+
+  for (const entity of sensors) {
+    if (matcher.fallbackId(lower(entity?.entity_id)) || statTextIncludes(getDeviceStatFallbackText(entity), matcher.textPatterns)) {
+      return entity.entity_id;
+    }
+  }
+
+  return null;
+}
+
+export function getDeviceStatEntities(entities) {
   let ledSwitchEntity = null;
   let ledColorEntity = null;
 
@@ -597,18 +667,6 @@ export function getAccessPointStatEntities(entities) {
 
     if (!id.startsWith("sensor.")) continue;
 
-    if (!uptimeEntity && (id.endsWith("_uptime") || id.includes(" uptime") || id.includes("_uptime_") || id.includes("uptime"))) {
-      uptimeEntity = entity.entity_id;
-    }
-
-    if (!clientsEntity && (id.endsWith("_clients") || id.includes("_clients_") || id.includes(" clients"))) {
-      clientsEntity = entity.entity_id;
-    }
-
-    if (!apStatusEntity && (id.endsWith("_state") || id.includes("_state_"))) {
-      apStatusEntity = entity.entity_id;
-    }
-
     if (
       !ledColorEntity &&
       (id.includes("led_color") ||
@@ -620,13 +678,20 @@ export function getAccessPointStatEntities(entities) {
     }
   }
 
+  const statusEntity = findDeviceStatEntity(entities, "status");
+
   return {
-    uptime_entity: uptimeEntity,
-    clients_entity: clientsEntity,
-    ap_status_entity: apStatusEntity,
+    uptime_entity: findDeviceStatEntity(entities, "uptime"),
+    clients_entity: findDeviceStatEntity(entities, "clients"),
+    status_entity: statusEntity,
+    ap_status_entity: statusEntity,
     led_switch_entity: ledSwitchEntity,
     led_color_entity: ledColorEntity,
   };
+}
+
+export function getAccessPointStatEntities(entities) {
+  return getDeviceStatEntities(entities);
 }
 
 function safeEntityState(hass, entityId) {
@@ -1861,7 +1926,7 @@ async function buildDeviceContext(hass, deviceId, cardConfig = null) {
   const specialPorts = discoverSpecialPorts(entities);
   const telemetryEntities = allEntities.filter((entity) => !entity?.disabled_by);
   const telemetry = getDeviceTelemetry(telemetryEntities.length > 0 ? telemetryEntities : entities);
-  const apStats = getAccessPointStatEntities(entities);
+  const deviceStats = getDeviceStatEntities(entities);
   const apUplink = type === "access_point"
     ? resolveAccessPointUplink(hass, entities, devices)
     : null;
@@ -1879,7 +1944,7 @@ async function buildDeviceContext(hass, deviceId, cardConfig = null) {
     manufacturer: normalize(device.manufacturer),
     firmware: extractFirmware(device),
     online_entity: getDeviceOnlineEntity(entities),
-    ...apStats,
+    ...deviceStats,
     ap_uplink: apUplink,
     reboot_entity: getDeviceRebootEntity(entities),
     ...telemetry,

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -816,6 +816,7 @@ class UnifiDeviceCard extends HTMLElement {
       "online_entity",
       "uptime_entity",
       "clients_entity",
+      "status_entity",
       "ap_status_entity",
       "led_switch_entity",
       "led_color_entity",
@@ -2522,7 +2523,10 @@ function getUnifiDeviceCardEntitySuggestion(hass, entityId) {
 
   if (!hasUniFiPrefix && !(hasUnifiHint && hasUnifiPortPattern)) return null;
 
-  return { type: "custom:unifi-device-card" };
+  return {
+    type: "custom:unifi-device-card",
+    config: { type: "custom:unifi-device-card" },
+  };
 }
 
 window.customCards = window.customCards || [];

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -2502,6 +2502,30 @@ if (!customElements.get("unifi-device-card")) {
   customElements.define("unifi-device-card", UnifiDeviceCard);
 }
 
+function getFrontendRegistryItem(collection, key) {
+  if (!collection || !key) return null;
+  if (typeof collection.get === "function") return collection.get(key) || null;
+  if (Array.isArray(collection)) {
+    return collection.find((item) => item?.entity_id === key || item?.id === key) || null;
+  }
+  return collection[key] || null;
+}
+
+function getEntitySuggestionDeviceId(hass, entityId) {
+  const registryEntity =
+    getFrontendRegistryItem(hass?.entities, entityId) ||
+    getFrontendRegistryItem(hass?.entityRegistry, entityId) ||
+    getFrontendRegistryItem(hass?.entity_registry, entityId);
+  const deviceId = registryEntity?.device_id || null;
+  if (!deviceId) return null;
+
+  const devices = hass?.devices || hass?.deviceRegistry || hass?.device_registry;
+  if (!devices) return deviceId;
+
+  const registryDevice = getFrontendRegistryItem(devices, deviceId);
+  return registryDevice ? deviceId : null;
+}
+
 function getUnifiDeviceCardEntitySuggestion(hass, entityId) {
   const id = String(entityId || "").trim().toLowerCase();
   if (!id || !id.includes(".")) return null;
@@ -2523,9 +2547,12 @@ function getUnifiDeviceCardEntitySuggestion(hass, entityId) {
 
   if (!hasUniFiPrefix && !(hasUnifiHint && hasUnifiPortPattern)) return null;
 
+  const deviceId = getEntitySuggestionDeviceId(hass, entityId);
+  if (!deviceId) return null;
+
   return {
     type: "custom:unifi-device-card",
-    config: { type: "custom:unifi-device-card" },
+    config: { type: "custom:unifi-device-card", device_id: deviceId },
   };
 }
 


### PR DESCRIPTION
### Motivation
- Improve reliability of detecting device uptime, client count, and status sensors across localized Home Assistant integrations by using translation keys and more robust name/id matching.
- Ensure Home Assistant Lovelace entity suggestions include a `config` object for compatibility with Core 2026.6+ while preserving legacy top-level card type.
- Clean up and centralize device-stat detection logic to reduce duplication and better exclude port-level sensors.

### Description
- Add a new canonicalization/matching subsystem (`DEVICE_STAT_MATCHERS`, `canonicalStatText`, `findDeviceStatEntity`, etc.) and replace ad-hoc `_uptime`, `_clients`, `_state` detection with `getDeviceStatEntities` that matches by `translation_key`, display text, and fallback id patterns. 
- Exclude port-level signals from device-stat detection via `hasPortLevelStatSignal` which checks `unique_id`, indexed port ids, and display name port patterns. 
- Preserve AP-specific naming by keeping `ap_status_entity` but also introduce/return a unified `status_entity` and wire callers to use the new device stats (`buildDeviceContext` now spreads `deviceStats`).
- Add `status_entity` to the card's `_relevantStateEntityIds` list so it is tracked for updates. 
- Update `getUnifiDeviceCardEntitySuggestion` to return a `config` object (`{ type: "custom:unifi-device-card" }`) alongside the top-level `type` for Home Assistant compatibility. 
- Bump `CHANGELOG.md` with a new `v0.7.6` entry describing the bug fixes and hints.

### Testing
- Ran the automated test suite with `npm test`, which passed successfully. 
- Ran linting with `npm run lint`, which reported no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b9d2879408333aaa7a6cdb894db2d)