### PR TITLE
Recognize device_* unique_id stats and add localized header-telemetry labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [v0.7.6]
 
 ### 🐛 Bug Fixes
+- Add missing localized labels for header telemetry entity warnings across all supported card languages.
+- Recognize Home Assistant Core UniFi device uptime/client/status sensors by their stable `device_*` unique IDs when localized entity IDs do not expose usable English names.
 - Detect device uptime, client count, and status sensors by stable Home Assistant translation keys/name metadata so localized entity IDs continue to work.
 - Preserve device stat detection when device/entity names contain port-like tokens, while still avoiding port-level status sensors.
 - Return Home Assistant entity suggestions with a `config` object containing the selected `device_id` while keeping the legacy top-level card type for compatibility.

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -134,6 +134,7 @@ function hasInfrastructureEntitySignals(entities = []) {
   return entities.some((e) => {
     const id = lower(e?.entity_id);
     if (!id.startsWith("sensor.") && !id.startsWith("binary_sensor.")) return false;
+    const parsed = parseUnifiDeviceUniqueId(e?.unique_id);
     return (
       id.includes("cpu") ||
       id.includes("memory") ||
@@ -141,7 +142,8 @@ function hasInfrastructureEntitySignals(entities = []) {
       id.endsWith("_uptime") ||
       id.includes("_uptime_") ||
       id.endsWith("_clients") ||
-      id.includes("_clients_")
+      id.includes("_clients_") ||
+      ["uptime", "clients", "status"].includes(parsed?.feature)
     );
   });
 }
@@ -578,16 +580,19 @@ export function getDeviceOnlineEntity(entities) {
 
 const DEVICE_STAT_MATCHERS = {
   uptime: {
+    features: new Set(["uptime"]),
     translationKeys: new Set(["uptime", "device_uptime"]),
     textPatterns: ["uptime", "device_uptime"],
     fallbackId: (id) => id.endsWith("_uptime") || id.includes(" uptime") || id.includes("_uptime_") || id.includes("uptime"),
   },
   clients: {
-    translationKeys: new Set(["clients", "connected_clients", "client_count", "num_clients", "active_clients", "station_count"]),
-    textPatterns: ["clients", "connected_clients", "client_count", "num_clients", "active_clients", "station_count"],
+    features: new Set(["clients"]),
+    translationKeys: new Set(["clients", "device_clients", "connected_clients", "client_count", "num_clients", "active_clients", "station_count"]),
+    textPatterns: ["clients", "device_clients", "connected_clients", "client_count", "num_clients", "active_clients", "station_count"],
     fallbackId: (id) => id.endsWith("_clients") || id.includes("_clients_") || id.includes(" clients"),
   },
   status: {
+    features: new Set(["status"]),
     translationKeys: new Set(["state", "status", "device_state", "device_status"]),
     textPatterns: ["state", "status", "device_state", "device_status"],
     fallbackId: (id) => id.endsWith("_state") || id.includes("_state_") || id.endsWith("_status") || id.includes("_status_"),
@@ -633,6 +638,11 @@ function findDeviceStatEntity(entities, stat) {
   if (!matcher) return null;
 
   const sensors = (entities || []).filter((entity) => lower(entity?.entity_id).startsWith("sensor."));
+
+  for (const entity of sensors) {
+    const parsed = parseUnifiDeviceUniqueId(entity?.unique_id);
+    if (parsed?.feature && matcher.features?.has(parsed.feature)) return entity.entity_id;
+  }
 
   for (const entity of sensors) {
     if (isUnambiguousDeviceStatTranslationKey(entity, stat, matcher)) return entity.entity_id;

--- a/src/translations.js
+++ b/src/translations.js
@@ -521,6 +521,10 @@ const TRANSLATIONS = {
     warning_entity_rx_tx:       "RX/TX-sensoren",
     warning_entity_power_cycle: "power cycle-knoppen",
     warning_entity_link:        "link-entiteiten",
+    warning_entity_header_cpu:  "CPU-sensoren in de header",
+    warning_entity_header_memory: "geheugensensoren in de header",
+    warning_entity_header_cpu_temperature: "CPU-temperatuursensoren in de header",
+    warning_entity_header_temperature: "temperatuursensoren in de header",
 
     type_switch:  "Switch",
     type_gateway: "Gateway",
@@ -688,6 +692,10 @@ const TRANSLATIONS = {
     warning_entity_rx_tx:       "capteurs RX/TX",
     warning_entity_power_cycle: "boutons de redémarrage PoE",
     warning_entity_link:        "entités de lien",
+    warning_entity_header_cpu:  "capteurs CPU d’en-tête",
+    warning_entity_header_memory: "capteurs mémoire d’en-tête",
+    warning_entity_header_cpu_temperature: "capteurs de température CPU d’en-tête",
+    warning_entity_header_temperature: "capteurs de température d’en-tête",
 
     type_switch:  "Switch",
     type_gateway: "Passerelle",
@@ -855,6 +863,10 @@ const TRANSLATIONS = {
     warning_entity_rx_tx:       "sensores RX/TX",
     warning_entity_power_cycle: "botones de reinicio PoE",
     warning_entity_link:        "entidades de enlace",
+    warning_entity_header_cpu:  "sensores de CPU del encabezado",
+    warning_entity_header_memory: "sensores de memoria del encabezado",
+    warning_entity_header_cpu_temperature: "sensores de temperatura de CPU del encabezado",
+    warning_entity_header_temperature: "sensores de temperatura del encabezado",
 
     type_switch:  "Switch",
     type_gateway: "Gateway",
@@ -1022,6 +1034,10 @@ const TRANSLATIONS = {
     warning_entity_rx_tx:       "sensori RX/TX",
     warning_entity_power_cycle: "pulsanti riavvio PoE",
     warning_entity_link:        "entità link",
+    warning_entity_header_cpu:  "sensori CPU dell’header",
+    warning_entity_header_memory: "sensori memoria dell’header",
+    warning_entity_header_cpu_temperature: "sensori temperatura CPU dell’header",
+    warning_entity_header_temperature: "sensori temperatura dell’header",
 
     type_switch:  "Switch",
     type_gateway: "Gateway",
@@ -1039,6 +1055,10 @@ TRANSLATIONS.sv = {
   editor_colors_apply: "Använd färger",
   editor_colors_reset_all: "Återställ alla färger",
   editor_bg_opacity_label: "Kortets transparens",
+  warning_entity_header_cpu:  "CPU-sensorer i headern",
+  warning_entity_header_memory: "minnessensorer i headern",
+  warning_entity_header_cpu_temperature: "CPU-temperatursensorer i headern",
+  warning_entity_header_temperature: "temperatursensorer i headern",
 };
 
 TRANSLATIONS.da = {
@@ -1051,6 +1071,10 @@ TRANSLATIONS.da = {
   editor_colors_apply: "Anvend farver",
   editor_colors_reset_all: "Nulstil alle farver",
   editor_bg_opacity_label: "Korttransparens",
+  warning_entity_header_cpu:  "CPU-sensorer i headeren",
+  warning_entity_header_memory: "hukommelsessensorer i headeren",
+  warning_entity_header_cpu_temperature: "CPU-temperatursensorer i headeren",
+  warning_entity_header_temperature: "temperatursensorer i headeren",
 };
 
 TRANSLATIONS.no = {
@@ -1063,6 +1087,10 @@ TRANSLATIONS.no = {
   editor_colors_apply: "Bruk farger",
   editor_colors_reset_all: "Tilbakestill alle farger",
   editor_bg_opacity_label: "Kortgjennomsiktighet",
+  warning_entity_header_cpu:  "CPU-sensorer i overskriften",
+  warning_entity_header_memory: "minnesensorer i overskriften",
+  warning_entity_header_cpu_temperature: "CPU-temperatursensorer i overskriften",
+  warning_entity_header_temperature: "temperatursensorer i overskriften",
 };
 
 TRANSLATIONS.fi = {
@@ -1075,6 +1103,10 @@ TRANSLATIONS.fi = {
   editor_colors_apply: "Käytä värit",
   editor_colors_reset_all: "Nollaa kaikki värit",
   editor_bg_opacity_label: "Kortin läpinäkyvyys",
+  warning_entity_header_cpu:  "otsakkeen CPU-anturit",
+  warning_entity_header_memory: "otsakkeen muistianturit",
+  warning_entity_header_cpu_temperature: "otsakkeen CPU-lämpötila-anturit",
+  warning_entity_header_temperature: "otsakkeen lämpötila-anturit",
 };
 
 TRANSLATIONS.pl = {
@@ -1087,6 +1119,10 @@ TRANSLATIONS.pl = {
   editor_colors_apply: "Zastosuj kolory",
   editor_colors_reset_all: "Resetuj wszystkie kolory",
   editor_bg_opacity_label: "Przezroczystość karty",
+  warning_entity_header_cpu:  "czujniki CPU w nagłówku",
+  warning_entity_header_memory: "czujniki pamięci w nagłówku",
+  warning_entity_header_cpu_temperature: "czujniki temperatury CPU w nagłówku",
+  warning_entity_header_temperature: "czujniki temperatury w nagłówku",
 };
 
 TRANSLATIONS.cs = {
@@ -1099,6 +1135,10 @@ TRANSLATIONS.cs = {
   editor_colors_apply: "Použít barvy",
   editor_colors_reset_all: "Resetovat všechny barvy",
   editor_bg_opacity_label: "Průhlednost karty",
+  warning_entity_header_cpu:  "senzory CPU v záhlaví",
+  warning_entity_header_memory: "senzory paměti v záhlaví",
+  warning_entity_header_cpu_temperature: "senzory teploty CPU v záhlaví",
+  warning_entity_header_temperature: "senzory teploty v záhlaví",
 };
 
 /**

--- a/src/unique-id.js
+++ b/src/unique-id.js
@@ -18,6 +18,9 @@ const PORT_FEATURE_PREFIXES = {
 
 const DEVICE_FEATURE_PREFIXES = {
   device_restart: "restart",
+  device_uptime: "uptime",
+  device_clients: "clients",
+  device_state: "status",
   cpu_utilization: "cpu_utilization",
   memory_utilization: "memory_utilization",
   temperature: "temperature",


### PR DESCRIPTION
### Motivation
- Ensure device-level uptime/clients/status sensors are recognized even when localized entity names don't expose usable English text by leveraging stable `device_*` `unique_id` prefixes.
- Surface proper localized labels for header telemetry-related entity warnings across supported languages so users see clear guidance in their locale.

### Description
- Map `device_uptime`, `device_clients`, and `device_state` to features in `DEVICE_FEATURE_PREFIXES` in `src/unique-id.js` so these `unique_id` prefixes resolve to `uptime`, `clients`, and `status` features.
- Use `parseUnifiDeviceUniqueId` in `src/helpers.js` inside `hasInfrastructureEntitySignals` and add an early `unique_id`-feature check in `findDeviceStatEntity` so device-level stat sensors are detected by `unique_id` before falling back to translation/text heuristics, and add `features` sets to `DEVICE_STAT_MATCHERS` for `uptime`, `clients`, and `status`.
- Add missing localized translation keys for header telemetry entity warnings (`warning_entity_header_cpu`, `warning_entity_header_memory`, `warning_entity_header_cpu_temperature`, `warning_entity_header_temperature`) in `src/translations.js` for multiple languages and include Swedish/other locale overrides where applicable.
- Update `CHANGELOG.md` to document the localization labels addition and the recognition of Home Assistant Core UniFi device uptime/clients/status sensors by stable `device_*` unique IDs.

### Testing
- No automated tests were added or modified for this change and no automated test runs are included in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bbd3fa4248333b3245f5e449c5d26)