### PR TITLE
docs: clarify HACS installation and add manual custom repository instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,13 +176,28 @@ Unknown models are auto-detected by port count and fall back to a generic dark t
 
 ## Installation via HACS
 
-1. Open **HACS** → **Frontend**
-2. Click **⋮** → **Custom repositories**
-3. Add:
+1. Open **HACS**
+2. Go to **Frontend**
+3. Search for **UniFi Device Card**
+4. Install the card
+5. Reload the browser/frontend
+
+> [!NOTE]
+> Manual installation as a custom repository is only relevant for development, forks, or fallback cases.
+
+### Manual HACS custom repository installation
+
+Use this path only if the card is not available through the normal HACS search, or if you want to install a development version, fork, or fallback source.
+
+1. Open **HACS**
+2. Go to **Frontend**
+3. Click **⋮** → **Custom repositories**
+4. Add:
    - **Repository:** `https://github.com/bluenazgul/unifi-device-card`
    - **Category:** `Dashboard`
-4. Click **Add**, search for **UniFi Device Card** and install
-5. Reload the browser (`Ctrl+Shift+R`)
+5. Click **Add**
+6. Search for **UniFi Device Card** and install the card
+7. Reload the browser/frontend
 
 ---
 


### PR DESCRIPTION
### Motivation
- Improve clarity and guidance for installing the card via HACS and provide an explicit fallback path for manual HACS custom repository installation.  

### Description
- Rewrote the HACS installation steps for clarity, added a prominent note about when manual installation is relevant, and introduced a `Manual HACS custom repository installation` section with the repository URL `https://github.com/bluenazgul/unifi-device-card` and explicit step order, plus updated wording for reload instructions such as `Ctrl+Shift+R` and "reload the browser/frontend".  

### Testing
- No automated tests were run because this is a documentation-only change to `README.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a474e9db48333b969163f67bbb142)