### PR TITLE
Panel layout and sections view sizing refinements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Size a switch or gateway card by the width its front panel actually needs, instead of always requesting the full section width. Set `grid_options` on the card to override.
 - A special slot may name the port row it sits beside, so SFP cages and WAN ports render next to the RJ45 block rather than above it. Applied to the US-24-250W, the UDM Pro, the US-16-XG and the USW Ultra 60W. The UDM Pro and the USW Ultra 60W panels change through this. Models without a `row` on their slots render as before.
 - Draw the US-24-250W as two rows of twelve and the UDM Pro as two rows of four, matching their front panels.
+- Draw the USW Pro Max 48 and USW Pro Max 48 PoE as three rows of sixteen. Ubiquiti's own front panel data groups them by sixteen, not twelve.
 
 ## [0.7.94-dev]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### 🐛 Bug Fixes
+- Re-render the front panel when the number of ports that fit in a row changes. A card widened after its first paint kept the packing of the narrower one.
+
+### ✨ Improvements
+- Size a switch or gateway card by the width its front panel actually needs, instead of always requesting the full section width. Set `grid_options` on the card to override.
+- A special slot may name the port row it sits beside, so SFP cages and WAN ports render next to the RJ45 block rather than above it. Applied to the US-24-250W, the UDM Pro, the US-16-XG and the USW Ultra 60W. The UDM Pro and the USW Ultra 60W panels change through this. Models without a `row` on their slots render as before.
+- Draw the US-24-250W as two rows of twelve and the UDM Pro as two rows of four, matching their front panels.
+
 ## [0.7.94-dev]
 
 ### 🐛 Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🐛 Bug Fixes
 - Re-render the front panel when the number of ports that fit in a row changes. A card widened after its first paint kept the packing of the narrower one.
+- Fill the grid cell a sections view assigns, so cards in one row share the row height. The host element was inline and kept its content height, which left a row of cards with ragged bottom edges.
 
 ### ✨ Improvements
 - Size a switch or gateway card by the width its front panel actually needs, instead of always requesting the full section width. Set `grid_options` on the card to override.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🐛 Bug Fixes
 - Re-render the front panel when the number of ports that fit in a row changes. A card widened after its first paint kept the packing of the narrower one.
-- Fill the grid cell a sections view assigns, so cards in one row share the row height. The host element was inline and kept its content height, which left a row of cards with ragged bottom edges.
+- Fill the grid cell a sections view assigns, so cards in one row share the row height. The host element was inline and kept its content height, which left a row of cards with ragged bottom edges. The slack collects between the header and the front panel, so the panels, port details and buttons of one row line up even when a device reports fewer telemetry lines.
 
 ### ✨ Improvements
 - Size a switch or gateway card by the width its front panel actually needs, instead of always requesting the full section width. Set `grid_options` on the card to override.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ If you like this project and want to support my work, you can donate via PayPal.
 
 ## Features
 
-- **Realistic front-panel view** — ports laid out close to the physical device, including dual-row, six-grid, quad-row, compact gateway, and special WAN/SFP slot layouts
+- **Realistic front-panel view** — ports laid out close to the physical device, including dual-row, six-grid, quad-row, compact gateway, and special WAN/SFP slot layouts, with SFP cages and WAN ports drawn beside their port row where the hardware places them
+- **Sections view sizing** — the card asks Home Assistant for the width its front panel needs, so a 24 port switch gets a wider card than an access point without any configuration; set `grid_options` on the card to override
 - **Device-accurate styling** — white panels for Lite / Flex / Ultra / Cloud Gateway style devices and silver/dark panels for rack devices and unknown switch fallbacks
 - **Per-port link and PoE indication** — visual port LEDs reflect link state, speed class, and active PoE
 - **Port detail panel** — click any port to see link status, speed, PoE state, PoE power draw, RX/TX values, and available actions; disabling a port requires confirmation
@@ -313,7 +314,7 @@ wan2_port: none               # optional (gateway only)
 | `background_opacity` | number | `100` | Background transparency in percent (`0` = transparent, `100` = opaque). |
 | `show_panel` | boolean | `true` | Show/hide the visual front panel area. |
 | `rotate180` | boolean | `false` | Switch/Gateway only: rotates the front-panel layout by 180° (`false`/`true`). |
-| `ports_per_row` | number | auto | Optional row width override for switch layouts and compatible In-Wall AP integrated-port sections. |
+| `ports_per_row` | number | auto | Optional row width override for switch layouts and compatible In-Wall AP integrated-port sections. Without it, a model with declared rows keeps them, and only single-row fallbacks use 8 per row. |
 | `force_sequential_ports` | boolean | `false` | Switch/Gateway only: disables odd/even row rendering and keeps ports in natural numeric order. |
 | `port_size` | number | `36` | Port size in pixels for switch/gateway front panel rendering and compatible In-Wall AP port sections (special and numbered ports are unified). |
 | `ap_scale` | number | `100` | AP device scale in percent (`25`-`140`) for AP card mode. |

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If you like this project and want to support my work, you can donate via PayPal.
 ## Features
 
 - **Realistic front-panel view** — ports laid out close to the physical device, including dual-row, six-grid, quad-row, compact gateway, and special WAN/SFP slot layouts, with SFP cages and WAN ports drawn beside their port row where the hardware places them
-- **Sections view sizing** — the card asks Home Assistant for the width its front panel needs, so a 24 port switch gets a wider card than an access point without any configuration; set `grid_options` on the card to override
+- **Sections view sizing** — the card asks Home Assistant for the width its front panel needs, so a 24 port switch gets a wider card than an access point without any configuration; set `grid_options` on the card to override. Cards in one row fill the row height, so their bottom edges line up.
 - **Device-accurate styling** — white panels for Lite / Flex / Ultra / Cloud Gateway style devices and silver/dark panels for rack devices and unknown switch fallbacks
 - **Per-port link and PoE indication** — visual port LEDs reflect link state, speed class, and active PoE
 - **Port detail panel** — click any port to see link status, speed, PoE state, PoE power draw, RX/TX values, and available actions; disabling a port requires confirmation

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1631,6 +1631,7 @@ export function mergeSpecialsWithLayout(layout, discoveredSpecials, discoveredPo
           physical_key: slot.key,
           label: slot.label,
           media: slot.media ?? portData.media,
+          row: slot.row,
           kind: "special",
           port: slot.port ?? portData.port,
         };
@@ -1645,6 +1646,7 @@ export function mergeSpecialsWithLayout(layout, discoveredSpecials, discoveredPo
         physical_key: slot.key,
         label: slot.label,
         media: slot.media ?? keyData.media,
+        row: slot.row,
         kind: "special",
         port: slot.port ?? keyData.port ?? null,
       };
@@ -1656,6 +1658,7 @@ export function mergeSpecialsWithLayout(layout, discoveredSpecials, discoveredPo
       port: slot.port ?? null,
       label: slot.label,
       media: slot.media,
+      row: slot.row,
       kind: "special",
       link_entity: null,
       speed_entity: null,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -2054,6 +2054,10 @@ async function buildDeviceContext(hass, deviceId, cardConfig = null) {
   if (hasConfiguredPortsPerRow) {
     layout = applyPortsPerRowOverride(layout, configuredPortsPerRow);
   } else if (type === "switch" && !(layout?.rows?.length > 1)) {
+    // A model that declares more than one row has described its own front panel;
+    // keep that grouping. Single-row layouts are the generic fallback and still
+    // get the 8-per-row default. Rows too wide for the card are repacked later
+    // by _buildEffectiveRows().
     layout = applyPortsPerRowOverride(layout, 8);
   }
 

--- a/src/model-registry.js
+++ b/src/model-registry.js
@@ -680,7 +680,7 @@ export const MODEL_REGISTRY = {
     kind: "switch", frontStyle: "single-row", rows: [range(1, 7)],
     portCount: 8, displayModel: "USW Ultra 60W", theme: "white",
     poePortRange: [1, 7],
-    specialSlots: [{ key: "uplink", label: "Uplink", port: 8 }],
+    specialSlots: [{ key: "uplink", label: "Uplink", port: 8, media: "rj45", row: 0 }],
   },
   USWULTRA210W: {
     kind: "switch", frontStyle: "single-row", rows: [range(1, 7)],

--- a/src/model-registry.js
+++ b/src/model-registry.js
@@ -75,7 +75,13 @@ function applyRj45LayoutHints(layout) {
 
   return {
     ...layout,
-    rj45_odd_even: isSwitchOrGateway && !isExcluded && numberedRj45Count > 8,
+    // A model may state the odd/even panel explicitly. Devices with eight or
+    // fewer ports fall below the automatic threshold but can still be built
+    // that way, the UDM Pro being the obvious one.
+    rj45_odd_even:
+      typeof layout?.rj45_odd_even === "boolean"
+        ? layout.rj45_odd_even
+        : isSwitchOrGateway && !isExcluded && numberedRj45Count > 8,
   };
 }
 
@@ -234,8 +240,8 @@ export const MODEL_REGISTRY = {
     portCount: 26, displayModel: "US-24-250W", theme: "silver",
     poePortRange: [1, 24],
     specialSlots: [
-      { key: "sfp_1", label: "SFP 1", port: 25 },
-      { key: "sfp_2", label: "SFP 2", port: 26 },
+      { key: "sfp_1", label: "SFP 1", port: 25, row: 0 },
+      { key: "sfp_2", label: "SFP 2", port: 26, row: 1 },
     ],
   },
 
@@ -566,9 +572,14 @@ export const MODEL_REGISTRY = {
 
   // US 16 XG  — 12× SFP+, 4× 10G RJ45
   USXG: {
-    kind: "switch", frontStyle: "single-row", rows: [range(13, 16)],
+    kind: "switch", frontStyle: "six-grid", rows: [range(1, 12)],
     portCount: 16, displayModel: "US-16-XG", theme: "silver",
-    specialSlots: range(1, 12).map((p) => ({ key: `sfp_${p}`, label: `SFP+ ${p}`, port: p })),
+    specialSlots: [
+      { key: "rj45_13", label: "13", port: 13, media: "rj45", row: 0 },
+      { key: "rj45_14", label: "14", port: 14, media: "rj45", row: 0 },
+      { key: "rj45_15", label: "15", port: 15, media: "rj45", row: 1 },
+      { key: "rj45_16", label: "16", port: 16, media: "rj45", row: 1 },
+    ],
   },
 
   // USW Flex XG  — 4× 10G RJ45, 1× 1G RJ45 PoE-in/uplink
@@ -894,10 +905,11 @@ export const MODEL_REGISTRY = {
   UDMPRO: {
     kind: "gateway", frontStyle: "gateway-rack", rows: [range(1, 8)],
     portCount: 11, displayModel: "UDM Pro", theme: "silver",
+    rj45_odd_even: true,
     specialSlots: [
-      { key: "wan",   label: "WAN",    port: 9  },
-      { key: "sfp_1", label: "SFP+ 1", port: 10 },
-      { key: "sfp_2", label: "SFP+ 2", port: 11 },
+      { key: "sfp_1", label: "SFP+ 1", port: 10, row: 0 },
+      { key: "wan",   label: "WAN",    port: 9,  media: "rj45", row: 1 },
+      { key: "sfp_2", label: "SFP+ 2", port: 11, row: 1 },
     ],
   },
   UDMPROSE: {

--- a/src/model-registry.js
+++ b/src/model-registry.js
@@ -499,7 +499,7 @@ export const MODEL_REGISTRY = {
   // USW Pro Max 48 (PoE / non-PoE)  — 48× RJ45, 4× SFP+
   USPM48: {
     kind: "switch", frontStyle: "quad-row",
-    rows: [range(1, 12), range(13, 24), range(25, 36), range(37, 48)],
+    rows: [range(1, 16), range(17, 32), range(33, 48)],
     portCount: 52, displayModel: "USW Pro Max 48", theme: "silver",
     specialSlots: [
       { key: "sfp_1", label: "SFP+ 1", port: 49 },
@@ -510,7 +510,7 @@ export const MODEL_REGISTRY = {
   },
   USPM48P: {
     kind: "switch", frontStyle: "quad-row",
-    rows: [range(1, 12), range(13, 24), range(25, 36), range(37, 48)],
+    rows: [range(1, 16), range(17, 32), range(33, 48)],
     portCount: 52, displayModel: "USW Pro Max 48 PoE", theme: "silver",
     poePortRange: [1, 48],
     specialSlots: [

--- a/src/model-registry.js
+++ b/src/model-registry.js
@@ -229,8 +229,8 @@ export const MODEL_REGISTRY = {
 
   // US 24 250W  — 24× 1G RJ45 PoE (all), 2× 1G SFP
   US24P250: {
-    kind: "switch", frontStyle: "eight-grid",
-    rows: [range(1, 8), range(9, 16), range(17, 24)],
+    kind: "switch", frontStyle: "quad-row",
+    rows: [range(1, 12), range(13, 24)],
     portCount: 26, displayModel: "US-24-250W", theme: "silver",
     poePortRange: [1, 24],
     specialSlots: [

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -236,11 +236,22 @@ class UnifiDeviceCard extends HTMLElement {
     const rendersNetworkPanel = layoutMode !== "ap" && (
       this._ctx?.type === "switch" || this._ctx?.type === "gateway"
     );
+    if (!rendersNetworkPanel) {
+      return { columns: 12, rows: "auto" };
+    }
 
-    return {
-      columns: rendersNetworkPanel ? "full" : 12,
-      rows: "auto",
-    };
+    // Ask for width in proportion to the widest line the front panel has to
+    // draw. A section column is 12 grid columns wide, so 12 is one standard
+    // card and 24 is two. The section clamps the span to its own width
+    // (grid-column: span min(--column-size, --grid-column-count)), so asking
+    // for more than a narrow section holds is safe.
+    const layout = this._ctx?.layout;
+    const widestRow = (layout?.rows || []).reduce((max, row) => Math.max(max, row.length), 0);
+    const slots = Math.max(widestRow, (layout?.specialSlots || []).length);
+
+    if (slots <= 8) return { columns: 12, rows: "auto" };
+    if (slots <= 12) return { columns: 24, rows: "auto" };
+    return { columns: "full", rows: "auto" };
   }
 
   _estimateCardSize() {
@@ -282,7 +293,15 @@ class UnifiDeviceCard extends HTMLElement {
 
       const panelWidth = this._measuredFrontPanelContentWidth();
       if (panelWidth <= 0) return;
-      if (Math.abs(panelWidth - this._lastMeasuredPanelWidth) < 1) return;
+
+      // The panel width alone is not enough. The card can be widened after its
+      // first paint - a sections view applies the column span in its own render
+      // pass - and the width then matches on the next measurement while the
+      // ports are still packed for the old one. Compare the column count the
+      // DOM was actually built with as well.
+      const widthChanged = Math.abs(panelWidth - this._lastMeasuredPanelWidth) >= 1;
+      const columnsChanged = this._maxFittableColumns() !== this._renderedFittableColumns;
+      if (!widthChanged && !columnsChanged) return;
 
       this._lastMeasuredPanelWidth = panelWidth;
       this._render();
@@ -1081,9 +1100,14 @@ class UnifiDeviceCard extends HTMLElement {
       .filter((port) => Number.isInteger(port) && !knownPorts.has(port))
       .sort((a, b) => a - b);
 
-    if (!extraPorts.length && !baseRows.length && !orderedPorts.length) return [];
-
     const fitCols = this._maxFittableColumns();
+    // Remember the column count this layout was built with, so _finalizeRender
+    // can tell a stale panel from a settled one. Record it before the empty
+    // early return: a panel with no ports must settle too, or _finalizeRender
+    // re-renders it on every frame.
+    this._renderedFittableColumns = fitCols;
+
+    if (!extraPorts.length && !baseRows.length && !orderedPorts.length) return [];
 
     if (!baseRows.length) {
       if (!Number.isFinite(fitCols) || extraPorts.length <= fitCols) return [extraPorts];
@@ -2611,6 +2635,12 @@ class UnifiDeviceCard extends HTMLElement {
       this._ctx?.type === "access_point" || this._ctx?.layout?.supportsHybridLayouts
     );
     if (renderApLayout) {
+      // The AP disc renders a .frontpanel too, so _finalizeRender measures it
+      // and compares _maxFittableColumns() against _renderedFittableColumns.
+      // Record the value here as well, or an AP card re-renders every frame.
+      // In-Wall APs with an integrated port grid overwrite it in
+      // _buildEffectiveRows.
+      this._renderedFittableColumns = this._maxFittableColumns();
       this._syncUptimeRefreshTimer();
       const online = this._isDeviceOnline();
       const compactApView = this._apCompactViewEnabled();

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -1692,6 +1692,12 @@ class UnifiDeviceCard extends HTMLElement {
         align-items: flex-start;
       }
 
+      .port-row-side {
+        display: flex;
+        gap: 6px;
+        margin-left: 12px;
+      }
+
       .frontpanel.rotate180-enabled .panel-label {
         text-align: right;
       }
@@ -2807,8 +2813,31 @@ class UnifiDeviceCard extends HTMLElement {
       : baseRows;
     const renderedSpecials = reverseFrontpanel ? [...allSpecials].reverse() : allSpecials;
 
-    const specialRow = renderedSpecials.length
-      ? `<div class="special-row">${renderedSpecials.map((s) => this._renderPortButton(s, selected?.key, portClientIndex)).join("")}</div>`
+    // A slot may name the port row it belongs beside, which is how the real
+    // front panels put their SFP cages and WAN port next to the RJ45 block
+    // instead of above it. Slots without a row keep the leading row.
+    const sideSpecials = new Map();
+    const topSpecials = [];
+    for (const slot of renderedSpecials) {
+      const row = slot?.row;
+      if (!Number.isInteger(row)) {
+        topSpecials.push(slot);
+        continue;
+      }
+      const index = reverseFrontpanel ? effectiveRows.length - 1 - row : row;
+      // Repacking (force_sequential_ports, narrow cards) can leave fewer rows
+      // than the model declares. A slot that names a missing row joins the
+      // leading row instead of disappearing with it.
+      if (index < 0 || index >= effectiveRows.length) {
+        topSpecials.push(slot);
+        continue;
+      }
+      if (!sideSpecials.has(index)) sideSpecials.set(index, []);
+      sideSpecials.get(index).push(slot);
+    }
+
+    const specialRow = topSpecials.length
+      ? `<div class="special-row">${topSpecials.map((s) => this._renderPortButton(s, selected?.key, portClientIndex)).join("")}</div>`
       : "";
 
     const layoutRows = effectiveRows
@@ -2820,9 +2849,14 @@ class UnifiDeviceCard extends HTMLElement {
           .map((slot) => this._renderPortButton(slot, selected?.key, portClientIndex, oddEvenTopRow))
           .join("");
 
+        const sideItems = (sideSpecials.get(rowIndex) || [])
+          .map((slot) => this._renderPortButton(slot, selected?.key, portClientIndex, oddEvenTopRow))
+          .join("");
+        const side = sideItems ? `<div class="port-row-side">${sideItems}</div>` : "";
+
         const cols = Math.max(1, rowPorts.length);
-        return items
-          ? `<div class="port-row" style="--udc-cols: ${cols};">${items}</div>`
+        return items || side
+          ? `<div class="port-row" style="--udc-cols: ${cols};">${items}${side}</div>`
           : "";
       })
       .filter(Boolean);

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -184,6 +184,9 @@ class UnifiDeviceCard extends HTMLElement {
   disconnectedCallback() {
     this._resizeObserver?.disconnect();
     this._resizeObserver = null;
+    this._panelObserver?.disconnect();
+    this._panelObserver = null;
+    this._observedFrontPanel = null;
     this._clearUptimeRefreshTimer();
   }
 
@@ -287,6 +290,25 @@ class UnifiDeviceCard extends HTMLElement {
     this._cardSize = nextSize;
   }
 
+  // Watch the panel itself, not only the host. The host can keep its size
+  // while the panel gains room, and a sections view resizes the card after the
+  // first paint, so a host-only observer misses the change that decides how
+  // many ports fit in a row.
+  _observeFrontPanel() {
+    const panel = this.shadowRoot?.querySelector(".frontpanel");
+    if (!panel || panel === this._observedFrontPanel) return;
+
+    if (!this._panelObserver) {
+      this._panelObserver = new ResizeObserver(() => {
+        if (this._maxFittableColumns() === this._renderedFittableColumns) return;
+        this._render();
+      });
+    }
+    if (this._observedFrontPanel) this._panelObserver.unobserve(this._observedFrontPanel);
+    this._observedFrontPanel = panel;
+    this._panelObserver.observe(panel);
+  }
+
   _finalizeRender() {
     requestAnimationFrame(() => {
       this._updateCardSize();
@@ -299,6 +321,8 @@ class UnifiDeviceCard extends HTMLElement {
       // pass - and the width then matches on the next measurement while the
       // ports are still packed for the old one. Compare the column count the
       // DOM was actually built with as well.
+      this._observeFrontPanel();
+
       const widthChanged = Math.abs(panelWidth - this._lastMeasuredPanelWidth) >= 1;
       const columnsChanged = this._maxFittableColumns() !== this._renderedFittableColumns;
       if (!widthChanged && !columnsChanged) return;

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -227,6 +227,10 @@ class UnifiDeviceCard extends HTMLElement {
     return this._cardSize || this._estimateCardSize();
   }
 
+  // Sections view sizing. Derived from the device type only, never from a
+  // measurement: getGridOptions() decides the width that a measurement would
+  // read back, so feeding one in would oscillate. Whatever width the card
+  // actually receives is handled by the row repacking in _buildEffectiveRows().
   getGridOptions() {
     const layoutMode = this._deviceLayoutMode(this._ctx);
     const rendersNetworkPanel = layoutMode !== "ap" && (

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -1563,6 +1563,8 @@ class UnifiDeviceCard extends HTMLElement {
         isolation: isolate;
         height: 100%;
         box-sizing: border-box;
+        display: flex;
+        flex-direction: column;
       }
 
       .header {
@@ -1692,6 +1694,11 @@ class UnifiDeviceCard extends HTMLElement {
         position: relative;
         z-index: 0;
         overflow: hidden;
+        /* In a stretched card the slack collects here, between the header
+           and the panel. Panels, details and buttons of one sections view
+           row then line up even when a device shows fewer telemetry lines.
+           As a nested block in the AP layout this resolves to 0. */
+        margin-top: auto;
       }
 
       .frontpanel.theme-white { background: #d6d6d9; }

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -243,18 +243,41 @@ class UnifiDeviceCard extends HTMLElement {
       return { columns: 12, rows: "auto" };
     }
 
-    // Ask for width in proportion to the widest line the front panel has to
-    // draw. A section column is 12 grid columns wide, so 12 is one standard
-    // card and 24 is two. The section clamps the span to its own width
-    // (grid-column: span min(--column-size, --grid-column-count)), so asking
-    // for more than a narrow section holds is safe.
+    // Ask for the width the front panel actually needs, counted in slots on
+    // its widest line. Odd/even panels draw one pair of declared rows as two
+    // lines, so a pair of twelve is twelve wide, not twenty-four.
     const layout = this._ctx?.layout;
-    const widestRow = (layout?.rows || []).reduce((max, row) => Math.max(max, row.length), 0);
-    const slots = Math.max(widestRow, (layout?.specialSlots || []).length);
+    const rows = layout?.rows || [];
+    let widest = 0;
+    if (layout?.rj45_odd_even === true) {
+      for (let i = 0; i < rows.length; i += 2) {
+        const pair = (rows[i]?.length || 0) + (rows[i + 1]?.length || 0);
+        widest = Math.max(widest, Math.ceil(pair / 2));
+      }
+    } else {
+      widest = rows.reduce((max, row) => Math.max(max, row.length), 0);
+    }
 
-    if (slots <= 8) return { columns: 12, rows: "auto" };
-    if (slots <= 12) return { columns: 24, rows: "auto" };
-    return { columns: "full", rows: "auto" };
+    // Slots parked beside a row add to that line. Slots without a row form
+    // their own leading line, but that line wraps (.special-row is flex-wrap),
+    // so it adapts to the width the port rows need and does not add to the
+    // request. All-special panels (aggregation switches) fall back to the
+    // 12 column minimum below.
+    const perRow = new Map();
+    for (const slot of layout?.specialSlots || []) {
+      if (Number.isInteger(slot?.row)) perRow.set(slot.row, (perRow.get(slot.row) || 0) + 1);
+    }
+    const slots = widest + Math.max(0, ...perRow.values());
+
+    // A slot occupies port_size + 4px of pitch (40 at the default 36, the same
+    // pitch _maxFittableColumns measures with) and the panel adds 28px of
+    // padding. A grid column is a twelfth of a view column, which Home
+    // Assistant keeps between 320 and 500px, so ~36px per column sits in that
+    // range. Narrower viewports fall short of the request; the row repacking
+    // absorbs that.
+    const needed = slots * (this._portSize() + 4) + 28;
+    const columns = Math.min(48, Math.max(12, Math.ceil(needed / 36)));
+    return { columns, rows: "auto" };
   }
 
   _estimateCardSize() {

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -1533,6 +1533,12 @@ class UnifiDeviceCard extends HTMLElement {
   _styles() {
     return `<style>
       :host {
+        /* Fill the grid cell a sections view assigns. The section stretches
+           its items to the row height, but the stretch ends at an inline
+           host. In a masonry view the wrapper has no fixed height, so 100%
+           resolves to auto and nothing changes. */
+        display: block;
+        height: 100%;
         --udc-bg: #141820;
         --udc-surface: #1e2433;
         --udc-surf2: #252d3d;
@@ -1555,6 +1561,8 @@ class UnifiDeviceCard extends HTMLElement {
         overflow: hidden;
         position: relative;
         isolation: isolate;
+        height: 100%;
+        box-sizing: border-box;
       }
 
       .header {


### PR DESCRIPTION
Refs #213 — the "separate topic" list, minus what v0.7.94-dev already covers (declared model rows and the layout-mode aware `getGridOptions()`; this branch keeps both and builds on them).

Rebased onto v0.7.94-dev.

- **Width by panel:** v0.7.94-dev requests the full section width for every switch and gateway, so an 8 port switch takes the same room as a 48 port one. `getGridOptions()` now asks for the width the front panel actually needs — widest declared line, odd/even pairs counted as one, `port_size` aware. The layout-mode guard stays: AP views keep their 12 columns.
- **Special slots beside their port row:** a registry slot may name the row it sits next to (`row`), so SFP cages and WAN ports render beside the RJ45 block like on the hardware. When repacking removes the target row (`force_sequential_ports`, narrow cards), the slot falls back to the leading row instead of disappearing. Applied to the US-24-250W (two rows of twelve), the UDM Pro (two rows of four beside WAN and SFP+), the US-16-XG and the USW Ultra 60W.
- **Cards fill their sections-view grid cell:** the host element renders inline and keeps its content height, so a row of cards shows ragged bottom edges — point 4 in #213. The host becomes a block that fills the cell, and the stretch slack collects above the front panel, so the panels, port details and buttons of one row line up even when a device reports fewer telemetry lines.
- **Re-render when the fitting column count changes:** a card widened after its first paint kept the packing of the narrower one.

Tested on my fleet (UDM Pro, US-24-250W, 2× US-16-XG, USW Ultra 60W, USC8, 6 APs) — I am running this branch right now. `dist/` and `screenshots/` are untouched.
