### PR TITLE
Fix missing editor translations and locale handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [v0.8.0]
 
 ### 🐛 Bug Fixes
+- Complete the integrated-port editor translations, localize port labels throughout the editor, and recognize Home Assistant locale codes that use underscores or the locale object.
 - Localize the uptime label on the UniFi 5G Backup display instead of always showing the English label.
 - Keep switch panels to the white and silver/dark UniFi hardware colors while preserving configured label colors.
 - Re-render the front panel when the number of ports that fit in a row changes. A card widened after its first paint kept the packing of the narrower one.

--- a/src/translations.js
+++ b/src/translations.js
@@ -488,6 +488,9 @@ const TRANSLATIONS = {
     editor_device_layout_network: "Alleen Switch/Gateway",
     editor_device_layout_ap: "Alleen AP",
     editor_device_layout_hint: "Voor geïntegreerde In-Wall-apparaten. De gecombineerde indeling is standaard.",
+    editor_integrated_ports_toggle_label: "Geïntegreerde poorten",
+    editor_integrated_ports_toggle_text:  "Geïntegreerde switchpoorten weergeven",
+    editor_integrated_ports_toggle_hint:  "Voor compatibele In-Wall-accesspoints. Schakel dit uit voor de klassieke AP-weergave.",
     editor_ap_compact_toggle_label: "AP-indeling",
     editor_ap_compact_toggle_text:  "Compacte AP-weergave gebruiken",
     editor_ap_compact_toggle_hint:  "Alleen voor access points. Toont AP-afbeelding en statusdetails naast elkaar.",
@@ -679,6 +682,9 @@ const TRANSLATIONS = {
     editor_device_layout_network: "Switch/Gateway uniquement",
     editor_device_layout_ap: "AP uniquement",
     editor_device_layout_hint: "Pour les appareils In-Wall intégrés. La disposition combinée est utilisée par défaut.",
+    editor_integrated_ports_toggle_label: "Ports intégrés",
+    editor_integrated_ports_toggle_text:  "Afficher les ports du commutateur intégré",
+    editor_integrated_ports_toggle_hint:  "Pour les points d’accès In-Wall compatibles. Désactivez cette option pour l’affichage AP classique.",
     editor_ap_compact_toggle_label: "Disposition AP",
     editor_ap_compact_toggle_text:  "Utiliser la vue AP compacte",
     editor_ap_compact_toggle_hint:  "Uniquement pour les points d’accès. Affiche l’image AP et les détails d’état côte à côte.",
@@ -870,6 +876,9 @@ const TRANSLATIONS = {
     editor_device_layout_network: "Solo Switch/Gateway",
     editor_device_layout_ap: "Solo AP",
     editor_device_layout_hint: "Para dispositivos In-Wall integrados. El diseño combinado es el predeterminado.",
+    editor_integrated_ports_toggle_label: "Puertos integrados",
+    editor_integrated_ports_toggle_text:  "Mostrar los puertos del switch integrado",
+    editor_integrated_ports_toggle_hint:  "Para puntos de acceso In-Wall compatibles. Desactívalo para usar la vista clásica solo de AP.",
     editor_ap_compact_toggle_label: "Diseño AP",
     editor_ap_compact_toggle_text:  "Usar vista AP compacta",
     editor_ap_compact_toggle_hint:  "Solo para puntos de acceso. Muestra la imagen del AP y los detalles de estado lado a lado.",
@@ -1061,6 +1070,9 @@ const TRANSLATIONS = {
     editor_device_layout_network: "Solo Switch/Gateway",
     editor_device_layout_ap: "Solo AP",
     editor_device_layout_hint: "Per dispositivi In-Wall integrati. Il layout combinato è quello predefinito.",
+    editor_integrated_ports_toggle_label: "Porte integrate",
+    editor_integrated_ports_toggle_text:  "Mostra le porte dello switch integrato",
+    editor_integrated_ports_toggle_hint:  "Per access point In-Wall compatibili. Disattiva questa opzione per la visualizzazione AP classica.",
     editor_ap_compact_toggle_label: "Layout AP",
     editor_ap_compact_toggle_text:  "Usa vista AP compatta",
     editor_ap_compact_toggle_hint:  "Solo per access point. Mostra immagine AP e dettagli di stato affiancati.",
@@ -1286,7 +1298,7 @@ TRANSLATIONS.cs = {
  */
 export function getTranslations(lang) {
   if (!lang) return TRANSLATIONS.en;
-  const short = String(lang).split("-")[0].toLowerCase();
+  const short = String(lang).trim().split(/[-_]/)[0].toLowerCase();
   return TRANSLATIONS[short] || TRANSLATIONS.en;
 }
 
@@ -1295,7 +1307,7 @@ export function getTranslations(lang) {
  * Usage: t(hass, "loading")
  */
 export function t(hass, key) {
-  const lang = hass?.language || "en";
+  const lang = hass?.language || hass?.locale?.language || "en";
   const strings = getTranslations(lang);
   return strings[key] ?? TRANSLATIONS.en[key] ?? key;
 }

--- a/src/unifi-device-card-editor.js
+++ b/src/unifi-device-card-editor.js
@@ -17,7 +17,7 @@ function slotPortType(slot) {
 
 function slotDropdownLabel(slot, tFn) {
   const type = slotPortType(slot);
-  const portNum = slot.port != null ? ` (Port ${slot.port})` : "";
+  const portNum = slot.port != null ? ` (${tFn("port_label")} ${slot.port})` : "";
 
   switch (type) {
     case "wan":
@@ -53,7 +53,7 @@ function buildGatewayRoleOptions(layout, tFn, { includeNone = false } = {}) {
   for (const portNum of allPortNums) {
     options.push({
       value: `port_${portNum}`,
-      label: `Port ${portNum} — ${tFn("editor_wan_port_lan")}`,
+      label: `${tFn("port_label")} ${portNum} — ${tFn("editor_wan_port_lan")}`,
       type: "lan",
       port: portNum,
     });
@@ -1397,7 +1397,7 @@ class UnifiDeviceCardEditor extends HTMLElement {
           <label>${escapeHtml(this._t("editor_custom_special_ports_label"))}</label>
           <div id="special_ports_list" class="port-toggle-list">
             ${selectableSpecialPorts
-              .map((port) => `<button type="button" class="port-toggle ${selectedSpecialPorts.includes(port) ? "selected" : ""}" data-port="${escapeAttr(port)}">Port ${escapeHtml(port)}</button>`)
+              .map((port) => `<button type="button" class="port-toggle ${selectedSpecialPorts.includes(port) ? "selected" : ""}" data-port="${escapeAttr(port)}">${escapeHtml(this._t("port_label"))} ${escapeHtml(port)}</button>`)
               .join("")}
           </div>
           <div class="hint">${escapeHtml(this._t("editor_custom_special_ports_hint"))}</div>


### PR DESCRIPTION
### Motivation
- Complete missing localized labels used in the editor so non-English users see the integrated-port toggle and port labels. 
- Replace hard-coded English "Port" labels in editor UI with the translation key to ensure consistent localization. 
- Make locale detection more robust to Home Assistant variants (underscore locales and nested `hass.locale.language`) so the card picks the right language.

### Description
- Added `editor_integrated_ports_toggle_label`, `editor_integrated_ports_toggle_text`, and `editor_integrated_ports_toggle_hint` to the Dutch, French, Spanish, and Italian translation blocks in `src/translations.js`. 
- Replaced hard-coded "Port" strings in `src/unifi-device-card-editor.js` (gateway selector options and special-port buttons) with the localized `port_label` via `t()` calls. 
- Improved locale resolution in `src/translations.js` by normalizing locale strings with `trim().split(/[-_]/)[0].toLowerCase()` and by using `hass?.language || hass?.locale?.language` when selecting the language. 
- Added a short changelog entry in `CHANGELOG.md` describing the editor localization fixes; left `/dist` unchanged per repository rules.

### Testing
- Ran `node --check src/translations.js` and `node --check src/unifi-device-card-editor.js`, both succeeded. 
- Executed inline JS checks that verify underscore and hyphen locale handling, nested `hass.locale.language` fallback, and presence of the four added translations, which all passed. 
- Ran a parity check script to ensure translation key sets match English for the main language blocks, which passed. 
- Ran `npm run build` successfully and verified `git diff --check` produced no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7e220202a8833395ea704da0725e61)