### PR TITLE
Fix compact AP panels layout in stretched and narrow cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Fix compact AP panels being pushed down in stretched cards while preserving their configured size, and keep the AP portion of combined In-Wall cards compact on narrow cards.
+
 ## [v0.8.0]
 
 ### 🐛 Bug Fixes

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -1810,6 +1810,10 @@ class UnifiDeviceCard extends HTMLElement {
         padding: 4px 14px;
       }
 
+      .ap-layout > .frontpanel {
+        margin-top: 0;
+      }
+
       .ap-layout.compact {
         display: grid;
         grid-template-columns: 1fr 1fr;
@@ -2550,15 +2554,10 @@ class UnifiDeviceCard extends HTMLElement {
           border-bottom: 1px solid var(--udc-border);
         }
 
-        .ap-layout.has-integrated-ports,
-        .ap-layout.compact.has-integrated-ports {
+        .ap-layout.has-integrated-ports:not(.compact) {
           grid-template-columns: 1fr;
         }
 
-        .ap-layout.compact.has-integrated-ports .frontpanel.ap-disc {
-          border-right: none;
-          border-bottom: 1px solid var(--udc-border);
-        }
       }
 
     </style>`;


### PR DESCRIPTION
### Motivation

- Prevent compact AP front panels from being visually pushed down when the card is stretched while preserving their configured compact sizing.
- Ensure the AP portion of combined In-Wall cards remains compact on narrow screens instead of being forced into the stacked layout.

### Description

- Add a rule to reset the front panel top margin with `.ap-layout > .frontpanel { margin-top: 0; }` to stop panels from shifting downward.
- Adjust the responsive selector to ` .ap-layout.has-integrated-ports:not(.compact) { grid-template-columns: 1fr; }` so compact combined layouts are not forced to a single column on narrow screens.
- Remove the previous compact-with-integrated-ports border/bottom override that caused inconsistent rendering on small viewports.
- Update `CHANGELOG.md` with an entry describing the layout fix.

### Testing

- Ran `npm run lint` and the lint step completed successfully.
- Ran `npm run build` and the project build completed successfully.
- `npm test` is not configured for this repository, so no automated unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7e2ced658c8333abe0f7a2caaff715)