### PR TITLE
Add per-port `trust_link_speed_ports` option to allow genuine 10 Mbit/s RJ45 links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [v0.8.01-dev]
 
 ### 🐛 Bug Fixes
-- Allow genuine 10 Mbit/s RJ45 connections to opt out of ghost-link protection on selected ports through `trust_link_speed_ports` and the card editor.
+- Allow genuine 10 Mbit/s RJ45 connections to opt out of ghost-link protection on selected ports through `trust_link_speed_ports` and the card editor, with consistent link status text throughout the card.
 
 ## [v0.8.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v0.8.01-dev]
+
+### 🐛 Bug Fixes
+- Allow genuine 10 Mbit/s RJ45 connections to opt out of ghost-link protection on selected ports through `trust_link_speed_ports` and the card editor.
+
 ## [v0.8.0]
 
 ### 🐛 Bug Fixes

--- a/README.md
+++ b/README.md
@@ -280,6 +280,9 @@ log_level: warn               # optional (error|warn|info|debug|trace)
 debug: false                  # optional shorthand (true => debug log level)
 edit_special_ports: false     # optional (switch/gateway only)
 special_ports: [1, 2, 9]      # optional (switch/gateway only)
+trust_link_speed_ports:        # optional (switch/gateway and compatible integrated ports)
+  - 3
+  - 7
 wan_port: auto                # optional (gateway only)
 wan2_port: none               # optional (gateway only)
 ```
@@ -326,6 +329,7 @@ wan2_port: none               # optional (gateway only)
 | `debug` | boolean | `false` | Shorthand for enabling debug logging (`true` behaves like `log_level: debug` if `log_level` is not set). |
 | `edit_special_ports` | boolean | `false` | Switch/Gateway only: enables WAN/WAN2 selectors and manual special-port editing in the UI/editor. |
 | `special_ports` | array<number> | auto | Switch/Gateway only: explicit port numbers shown in the top special row; non-selected ports render in the normal grid. |
+| `trust_link_speed_ports` | array<number> | `[]` | Ports whose positive link-speed value is trusted even at 10 Mbit/s. By default, the RJ45 ghost-link guard treats speeds up to and including 10 Mbit/s as disconnected when no link, traffic, client, or PoE signal confirms the connection. Select only ports with a genuine 10 Mbit/s link; `0`, `unknown`, and `unavailable` remain disconnected. |
 | `wan_port` | string | auto | Gateway only: assign WAN role (`auto`, slot key like `wan`, or `port_<n>`). |
 | `wan2_port` | string | auto | Gateway only: assign WAN2 role (`auto`, `none`, slot key, or `port_<n>`). |
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -28,6 +28,14 @@ function lower(value) {
   return normalize(value).toLowerCase();
 }
 
+export function normalizePositivePortNumbers(value) {
+  if (!Array.isArray(value)) return [];
+  return Array.from(new Set(value
+    .map((entry) => Number(entry))
+    .filter((port) => Number.isInteger(port) && port > 0)))
+    .sort((a, b) => a - b);
+}
+
 function entityText(entity) {
   const translationValues = entity?.translation_placeholders && typeof entity.translation_placeholders === "object"
     ? Object.values(entity.translation_placeholders)
@@ -2368,7 +2376,7 @@ export function isSfpLikePort(port) {
   return text.includes("sfp") || text.includes("10g");
 }
 
-export function isPortConnected(hass, port) {
+export function isPortConnected(hass, port, { trustLowSpeedLink = false } = {}) {
   if (port.link_entity) {
     const s = lower(stateValue(hass, port.link_entity));
     if (["on", "true", "connected", "up", "active"].includes(s)) return true;
@@ -2404,7 +2412,7 @@ export function isPortConnected(hass, port) {
       // Some setups report persistent 10 Mbit on idle/disconnected copper ports.
       // If no explicit link sensor exists and we have neither traffic, clients, nor PoE activity,
       // treat 10 Mbit as not connected to avoid false "up" LEDs.
-      if (!isSfpLikePort(port) && !port?.link_entity && speedMbit <= 10) {
+      if (!trustLowSpeedLink && !isSfpLikePort(port) && !port?.link_entity && speedMbit <= 10) {
         const hasActiveTraffic = hasTraffic(hass, port);
         const clientCount = portObservedClientCount(hass, port);
         const poeActive = getPoeStatus(hass, port).active;

--- a/src/translations.js
+++ b/src/translations.js
@@ -83,6 +83,8 @@ const TRANSLATIONS = {
     editor_edit_special_ports_toggle_hint: "Enable to show WAN/WAN2 selectors and customize which ports appear in the top special row.",
     editor_custom_special_ports_label: "Special ports (top row)",
     editor_custom_special_ports_hint:  "Click to toggle ports in the upper special row. Unselected ports move to the normal grid.",
+    editor_trust_link_speed_ports_label: "Trust 10 Mbit/s link speed on ports",
+    editor_trust_link_speed_ports_hint: "Only select ports with a real 10 Mbit/s connection. This disables the false-link protection for the selected port.",
     editor_port_size_label: "Port size",
     editor_port_size_hint:  "Adjusts front-panel port size for switches and gateways.",
     editor_ap_scale_label:  "AP size",
@@ -281,6 +283,8 @@ const TRANSLATIONS = {
     editor_edit_special_ports_toggle_hint: "Aktivieren, um WAN/WAN2-Auswahl anzuzeigen und festzulegen, welche Ports in der oberen Spezial-Reihe erscheinen.",
     editor_custom_special_ports_label: "Spezial-Ports (obere Reihe)",
     editor_custom_special_ports_hint:  "Per Klick Ports in der oberen Spezial-Reihe umschalten. Nicht gewählte Ports erscheinen im normalen Grid.",
+    editor_trust_link_speed_ports_label: "10-Mbit/s-Link-Speed an Ports vertrauen",
+    editor_trust_link_speed_ports_hint: "Nur für Ports mit einer echten 10-Mbit/s-Verbindung auswählen. Dadurch wird der Schutz vor fälschlich gemeldeten Links für den ausgewählten Port deaktiviert.",
     editor_port_size_label: "Portgröße",
     editor_port_size_hint:  "Skaliert die Frontpanel-Portgröße für Switches und Gateways.",
     editor_ap_scale_label:  "AP-Größe",
@@ -479,6 +483,8 @@ const TRANSLATIONS = {
     editor_edit_special_ports_toggle_hint: "Inschakelen om WAN/WAN2-selectie te tonen en te bepalen welke poorten in de bovenste speciale rij staan.",
     editor_custom_special_ports_label: "Speciale poorten (bovenste rij)",
     editor_custom_special_ports_hint:  "Klik om poorten in de bovenste speciale rij te wisselen. Niet-geselecteerde poorten gaan naar het normale raster.",
+    editor_trust_link_speed_ports_label: "Vertrouw 10 Mbit/s-linksnelheid op poorten",
+    editor_trust_link_speed_ports_hint: "Selecteer alleen poorten met een echte 10 Mbit/s-verbinding. Dit schakelt de beveiliging tegen foutief gemelde links voor de geselecteerde poort uit.",
     editor_port_size_label: "Poortgrootte",
     editor_port_size_hint:  "Schaalt de poortgrootte op het frontpaneel voor switches en gateways.",
     editor_ap_scale_label:  "AP-grootte",
@@ -673,6 +679,8 @@ const TRANSLATIONS = {
     editor_edit_special_ports_toggle_hint: "Activez pour afficher les sélecteurs WAN/WAN2 et choisir quels ports apparaissent dans la ligne spéciale supérieure.",
     editor_custom_special_ports_label: "Ports spéciaux (ligne du haut)",
     editor_custom_special_ports_hint:  "Cliquez pour basculer les ports de la ligne spéciale supérieure. Les ports non sélectionnés passent dans la grille normale.",
+    editor_trust_link_speed_ports_label: "Faire confiance au débit de liaison 10 Mbit/s",
+    editor_trust_link_speed_ports_hint: "Sélectionnez uniquement les ports avec une véritable connexion à 10 Mbit/s. Cela désactive la protection contre les liaisons signalées à tort pour le port sélectionné.",
     editor_port_size_label: "Taille des ports",
     editor_port_size_hint:  "Ajuste la taille des ports du panneau avant pour switches/passerelles.",
     editor_ap_scale_label:  "Taille AP",
@@ -867,6 +875,8 @@ const TRANSLATIONS = {
     editor_edit_special_ports_toggle_hint: "Activa para mostrar selectores WAN/WAN2 y elegir qué puertos aparecen en la fila especial superior.",
     editor_custom_special_ports_label: "Puertos especiales (fila superior)",
     editor_custom_special_ports_hint:  "Haz clic para alternar puertos en la fila especial superior. Los no seleccionados pasan a la cuadrícula normal.",
+    editor_trust_link_speed_ports_label: "Confiar en enlaces de 10 Mbit/s por puerto",
+    editor_trust_link_speed_ports_hint: "Selecciona solo puertos con una conexión real de 10 Mbit/s. Esto desactiva la protección contra enlaces notificados erróneamente para el puerto seleccionado.",
     editor_port_size_label: "Tamaño de puerto",
     editor_port_size_hint:  "Ajusta el tamaño de puertos del panel frontal para switches y gateways.",
     editor_ap_scale_label:  "Tamaño AP",
@@ -1061,6 +1071,8 @@ const TRANSLATIONS = {
     editor_edit_special_ports_toggle_hint: "Abilita per mostrare i selettori WAN/WAN2 e scegliere quali porte appaiono nella riga speciale superiore.",
     editor_custom_special_ports_label: "Porte speciali (riga superiore)",
     editor_custom_special_ports_hint:  "Clicca per attivare/disattivare le porte nella riga speciale superiore. Le porte non selezionate passano alla griglia normale.",
+    editor_trust_link_speed_ports_label: "Considera attendibile il link a 10 Mbit/s",
+    editor_trust_link_speed_ports_hint: "Seleziona solo porte con una connessione reale a 10 Mbit/s. Questa opzione disattiva la protezione dai link segnalati erroneamente per la porta selezionata.",
     editor_port_size_label: "Dimensione porta",
     editor_port_size_hint:  "Regola la dimensione delle porte del pannello frontale per switch e gateway.",
     editor_ap_scale_label:  "Dimensione AP",
@@ -1185,6 +1197,8 @@ const TRANSLATIONS = {
 
 TRANSLATIONS.sv = {
   ...TRANSLATIONS.en,
+  editor_trust_link_speed_ports_label: "Lita på 10 Mbit/s länkhastighet för portar",
+  editor_trust_link_speed_ports_hint: "Välj endast portar med en verklig 10 Mbit/s-anslutning. Detta inaktiverar skyddet mot felaktigt rapporterade länkar för den valda porten.",
   editor_telemetry_toggle_label: "Headertelemetri",
   editor_telemetry_toggle_text:  "Visa telemetridata i kortets header",
   editor_telemetry_toggle_hint:  "Aktiverat som standard. Inaktivera för att dölja CPU-, minnes- och temperaturrader i headern.",
@@ -1203,6 +1217,8 @@ TRANSLATIONS.sv = {
 
 TRANSLATIONS.da = {
   ...TRANSLATIONS.en,
+  editor_trust_link_speed_ports_label: "Stol på 10 Mbit/s-linkhastighed for porte",
+  editor_trust_link_speed_ports_hint: "Vælg kun porte med en ægte 10 Mbit/s-forbindelse. Dette deaktiverer beskyttelsen mod fejlagtigt rapporterede links for den valgte port.",
   editor_telemetry_toggle_label: "Headertelemetri",
   editor_telemetry_toggle_text:  "Vis telemetridata i kortets header",
   editor_telemetry_toggle_hint:  "Aktiveret som standard. Slå fra for at skjule CPU-, hukommelses- og temperaturlinjer i headeren.",
@@ -1221,6 +1237,8 @@ TRANSLATIONS.da = {
 
 TRANSLATIONS.no = {
   ...TRANSLATIONS.en,
+  editor_trust_link_speed_ports_label: "Stol på 10 Mbit/s-linkhastighet for porter",
+  editor_trust_link_speed_ports_hint: "Velg bare porter med en reell 10 Mbit/s-forbindelse. Dette deaktiverer beskyttelsen mot feilrapporterte linker for den valgte porten.",
   editor_telemetry_toggle_label: "Headertelemetri",
   editor_telemetry_toggle_text:  "Vis telemetridata i kortoverskriften",
   editor_telemetry_toggle_hint:  "Aktivert som standard. Slå av for å skjule CPU-, minne- og temperaturrader i overskriften.",
@@ -1239,6 +1257,8 @@ TRANSLATIONS.no = {
 
 TRANSLATIONS.fi = {
   ...TRANSLATIONS.en,
+  editor_trust_link_speed_ports_label: "Luota porttien 10 Mbit/s linkkinopeuteen",
+  editor_trust_link_speed_ports_hint: "Valitse vain portit, joissa on todellinen 10 Mbit/s yhteys. Tämä poistaa virheellisesti ilmoitettujen linkkien suojauksen käytöstä valitussa portissa.",
   editor_telemetry_toggle_label: "Otsakkeen telemetria",
   editor_telemetry_toggle_text:  "Näytä telemetriatiedot kortin otsakkeessa",
   editor_telemetry_toggle_hint:  "Käytössä oletuksena. Poista käytöstä piilottaaksesi CPU-, muisti- ja lämpötilarivit otsakkeesta.",
@@ -1257,6 +1277,8 @@ TRANSLATIONS.fi = {
 
 TRANSLATIONS.pl = {
   ...TRANSLATIONS.en,
+  editor_trust_link_speed_ports_label: "Ufaj prędkości łącza 10 Mbit/s na portach",
+  editor_trust_link_speed_ports_hint: "Wybieraj tylko porty z rzeczywistym połączeniem 10 Mbit/s. Wyłącza to ochronę przed błędnie zgłaszanymi łączami dla wybranego portu.",
   editor_telemetry_toggle_label: "Telemetria nagłówka",
   editor_telemetry_toggle_text:  "Pokaż dane telemetryczne w nagłówku karty",
   editor_telemetry_toggle_hint:  "Domyślnie włączone. Wyłącz, aby ukryć w nagłówku wiersze CPU, pamięci i temperatury.",
@@ -1275,6 +1297,8 @@ TRANSLATIONS.pl = {
 
 TRANSLATIONS.cs = {
   ...TRANSLATIONS.en,
+  editor_trust_link_speed_ports_label: "Důvěřovat rychlosti linky 10 Mbit/s na portech",
+  editor_trust_link_speed_ports_hint: "Vyberte pouze porty se skutečným připojením 10 Mbit/s. Tím se pro vybraný port vypne ochrana proti chybně hlášeným linkám.",
   editor_telemetry_toggle_label: "Telemetrie záhlaví",
   editor_telemetry_toggle_text:  "Zobrazit telemetrii v záhlaví karty",
   editor_telemetry_toggle_hint:  "Ve výchozím stavu zapnuto. Vypnutím skryjete řádky CPU, paměti a teploty v záhlaví.",

--- a/src/unifi-device-card-editor.js
+++ b/src/unifi-device-card-editor.js
@@ -195,7 +195,7 @@ function normalizeSpecialPortNumbers(value) {
   if (!Array.isArray(value)) return [];
 
   const normalized = value
-    .map((entry) => Number.parseInt(entry, 10))
+    .map((entry) => Number(entry))
     .filter((num) => Number.isInteger(num) && num > 0);
 
   return Array.from(new Set(normalized)).sort((a, b) => a - b);
@@ -470,6 +470,8 @@ class UnifiDeviceCardEditor extends HTMLElement {
     if (hasManualWanSelection) next.edit_special_ports = true;
     next.custom_special_ports = normalizeSpecialPortNumbers(next.custom_special_ports);
     if (!next.custom_special_ports.length) delete next.custom_special_ports;
+    next.trust_link_speed_ports = normalizeSpecialPortNumbers(next.trust_link_speed_ports);
+    if (!next.trust_link_speed_ports.length) delete next.trust_link_speed_ports;
     next.special_ports = normalizeSpecialPortNumbers(next.special_ports);
     if (
       !next.special_ports.length &&
@@ -531,6 +533,7 @@ class UnifiDeviceCardEditor extends HTMLElement {
       custom_special_ports: undefined,
       special_ports: undefined,
       edit_special_ports: undefined,
+      trust_link_speed_ports: undefined,
       ports_per_row: nextDevice?.type === "gateway" ? undefined : this._config?.ports_per_row,
       device_layout: undefined,
       integrated_ports: undefined,
@@ -773,6 +776,20 @@ class UnifiDeviceCardEditor extends HTMLElement {
     this._emitConfig({
       special_ports: normalizeSpecialPortNumbers(next),
     });
+  }
+
+  _onTrustLinkSpeedPortToggle(ev) {
+    const button = ev.target?.closest?.("[data-port]");
+    if (!button) return;
+
+    const port = Number(button.dataset.port);
+    if (!Number.isInteger(port) || port < 1) return;
+
+    const current = normalizeSpecialPortNumbers(this._config?.trust_link_speed_ports);
+    const next = current.includes(port)
+      ? current.filter((entry) => entry !== port)
+      : [...current, port];
+    this._emitConfig({ trust_link_speed_ports: next });
   }
 
   _warningItems() {
@@ -1254,6 +1271,7 @@ class UnifiDeviceCardEditor extends HTMLElement {
       new Set([...collectLayoutPorts(this._deviceCtx?.layout), ...discoveredPorts])
     ).sort((a, b) => a - b);
     const customSpecialPortOptions = selectableSpecialPorts;
+    const selectedTrustedLinkSpeedPorts = normalizeSpecialPortNumbers(this._config?.trust_link_speed_ports);
     const selectedSpecialPorts = editSpecialPorts
       ? resolveSelectedSpecialPorts(this._config, this._deviceCtx?.layout)
       : [];
@@ -1341,6 +1359,17 @@ class UnifiDeviceCardEditor extends HTMLElement {
           <label>${escapeHtml(this._t("editor_port_size_label"))}: ${escapeHtml(portSize)}px</label>
           <input id="port_size" type="range" min="24" max="52" step="1" value="${escapeAttr(portSize)}">
           <div class="hint">${escapeHtml(this._t("editor_port_size_hint"))}</div>
+        </div>` : ""}
+
+        ${(isSwitchOrGateway || supportsIntegratedPorts) ? `
+        <div class="field">
+          <label>${escapeHtml(this._t("editor_trust_link_speed_ports_label"))}</label>
+          <div id="trust_link_speed_ports_list" class="port-toggle-list">
+            ${selectableSpecialPorts
+              .map((port) => `<button type="button" class="port-toggle ${selectedTrustedLinkSpeedPorts.includes(port) ? "selected" : ""}" data-port="${escapeAttr(port)}">${escapeHtml(this._t("port_label"))} ${escapeHtml(port)}</button>`)
+              .join("")}
+          </div>
+          <div class="hint">${escapeHtml(this._t("editor_trust_link_speed_ports_hint"))}</div>
         </div>` : ""}
 
         ${supportsLayoutSelection ? `
@@ -1536,6 +1565,8 @@ class UnifiDeviceCardEditor extends HTMLElement {
       ?.addEventListener("change", (ev) => this._onEditSpecialPortsChange(ev));
     this.shadowRoot.getElementById("special_ports_list")
       ?.addEventListener("click", (ev) => this._onSpecialPortToggle(ev));
+    this.shadowRoot.getElementById("trust_link_speed_ports_list")
+      ?.addEventListener("click", (ev) => this._onTrustLinkSpeedPortToggle(ev));
 
     this.shadowRoot.getElementById("open_color_editor")
       ?.addEventListener("click", () => this._onOpenColorStep());

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -14,6 +14,7 @@ import {
   isPortConnected,
   mergePortsWithLayout,
   mergeSpecialsWithLayout,
+  normalizePositivePortNumbers,
   parseLinkSpeedMbit,
   stateObj,
 } from "./helpers.js";
@@ -192,7 +193,13 @@ class UnifiDeviceCard extends HTMLElement {
 
   setConfig(config) {
     const oldDeviceId = this._config?.device_id || null;
-    const newConfig = config || {};
+    const newConfig = { ...(config || {}) };
+    const trustLinkSpeedPorts = normalizePositivePortNumbers(newConfig.trust_link_speed_ports);
+    if (trustLinkSpeedPorts.length) {
+      newConfig.trust_link_speed_ports = trustLinkSpeedPorts;
+    } else {
+      delete newConfig.trust_link_speed_ports;
+    }
     const newDeviceId = newConfig?.device_id || null;
     this._config = newConfig;
     this._log("info", "setConfig", {
@@ -1350,11 +1357,12 @@ class UnifiDeviceCard extends HTMLElement {
    * link speed itself drops to 0 (cable genuinely removed).
    */
   _isPortConnected(port) {
+    const trustLowSpeedLink = this._config?.trust_link_speed_ports?.includes(port?.port) === true;
     if (isSfpLikePort(port)) {
       const key = port?.key || port?.physical_key;
       if (key) {
         if (hasTraffic(this._hass, port)) this._sfpConnectedSeen.add(key);
-        const result = isPortConnected(this._hass, port);
+        const result = isPortConnected(this._hass, port, { trustLowSpeedLink });
         if (!result && this._sfpConnectedSeen.has(key)) {
           // Port was live before — only keep sticky when speed entity confirms
           // the link is still up (> 0). A null means no speed entity exists so
@@ -1368,7 +1376,7 @@ class UnifiDeviceCard extends HTMLElement {
         return result;
       }
     }
-    return isPortConnected(this._hass, port);
+    return isPortConnected(this._hass, port, { trustLowSpeedLink });
   }
 
   _connectedCount(allSlots) {

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -5,7 +5,6 @@ import {
   formatUptimeState,
   getDeviceContext,
   getPoeStatus,
-  getPortLinkText,
   getPortSpeedText,
   hasTraffic,
   isUptimeTimestampState,
@@ -1482,7 +1481,7 @@ class UnifiDeviceCard extends HTMLElement {
     const mergedCount = Math.max(clientInfo?.count || 0, indexedCount);
     const tooltip = [
       slot.port_label || (isSpecial ? slot.label : `${this._t("port_label")} ${slot.label}`),
-      this._translateState(getPortLinkText(this._hass, slot)),
+      this._translateState(linkUp ? "connected" : "no_link"),
       linkUp ? getPortSpeedText(this._hass, slot) : null,
       poeOn ? `${this._t("poe")}${poeStatus.power ? ` ${poeStatus.power}` : " ON"}` : null,
       mergedCount > 0 ? `${this._t("clients")}: ${mergedCount}` : null,
@@ -2590,7 +2589,7 @@ class UnifiDeviceCard extends HTMLElement {
     if (!selected) return `<div class="muted">${this._escapeHtml(this._t("no_ports"))}</div>`;
 
     const linkUp = this._isPortConnected(selected);
-    const linkText = getPortLinkText(this._hass, selected);
+    const linkText = linkUp ? "connected" : "no_link";
     const speedText = getPortSpeedText(this._hass, selected);
     const poeStatus = getPoeStatus(this._hass, selected);
     const hasPoe = !!(selected.poe_switch_entity || selected.poe_power_entity || selected.power_cycle_entity);
@@ -2916,7 +2915,7 @@ class UnifiDeviceCard extends HTMLElement {
 
     if (selected) {
       const linkUp = this._isPortConnected(selected);
-      const linkText = getPortLinkText(this._hass, selected);
+      const linkText = linkUp ? "connected" : "no_link";
       const speedText = getPortSpeedText(this._hass, selected);
       const poeStatus = getPoeStatus(this._hass, selected);
       const hasPoe = !!(selected.poe_switch_entity || selected.poe_power_entity || selected.power_cycle_entity);


### PR DESCRIPTION
### Motivation
- Prevent false "ghost" link detection for genuine 10 Mbit/s RJ45 connections by allowing selected ports to opt out of the existing ghost-link protection.
- Expose the option in the card editor and document it so users can selectively trust low-speed links for known 10 Mbit/s ports.

### Description
- Add a new config key `trust_link_speed_ports` and document it in `README.md` and `CHANGELOG.md`.
- Add `normalizePositivePortNumbers` helper in `src/helpers.js` and extend `isPortConnected` to accept an options object (`{ trustLowSpeedLink }`) so the RJ45 ghost-link guard can be bypassed for trusted ports.
- Wire `trust_link_speed_ports` normalization into card config handling in `src/unifi-device-card.js` and use the flag when evaluating port connectivity in `_isPortConnected`.
- Add UI controls and editor plumbing in `src/unifi-device-card-editor.js` to select trusted ports, including storage/normalization of the list and event handlers, and add translations for the new editor labels in `src/translations.js`.

### Testing
- Ran the project build and existing automated test suite (lint/build/tests); all checks completed successfully and no regressions were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8042b39fe883338966ca4e7240eb00)