### PR TITLE
Recognize and render U7 Outdoor / U7 Pro Outdoor; map additional AP identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🐛 Bug Fixes
 - Allow genuine 10 Mbit/s RJ45 connections to opt out of ghost-link protection on selected ports through `trust_link_speed_ports` and the card editor, with consistent link status text throughout the card.
+- Recognize the U7 Outdoor (`UKPW`) and U7 Pro Outdoor (`UAPA6B0`) controller identifiers and render both devices with a dedicated outdoor enclosure and lower status LED.
+- Map additional raw UniFi AP identifiers for the UAP XG, nanoHD, AC Mesh Pro, U6 Mesh, U7 In-Wall, U7 Pro XGS, E7 Campus, and BaseStation XG to their existing device layouts.
 
 ## [v0.8.0]
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ If you like this project and want to support my work, you can donate via PayPal.
 - **Live port counter** — connected / total shown in the header chip
 - **Automatic device detection** — finds UniFi switches and gateways registered in Home Assistant
 - **Access Point card mode** — AP devices render a dedicated AP panel with online status, uptime, clients, and reboot action (if available)
-- **Dedicated AP designs** — standard APs stay round, Wall/In-Wall APs and the U6 Extender use a scalable rectangular HTML design, and UniFi 5G Backup uses its own HTML device display
+- **Dedicated AP designs** — standard APs stay round, Wall/In-Wall APs and the U6 Extender use a scalable rectangular HTML design, U7 Outdoor models use their matching rounded-rectangle design with a lower status LED, and UniFi 5G Backup uses its own HTML device display
 - **Combined In-Wall AP view** — compatible In-Wall models can show their integrated switch ports below the normal AP details, with an editor toggle to return to AP-only mode
 - **Built-in UI editor** — full card configuration without YAML
 - **Multi-language support** — translations available for English, German, Dutch, French, Spanish, Italian, Swedish, Danish, Norwegian, Finnish, Polish, and Czech

--- a/src/model-registry.js
+++ b/src/model-registry.js
@@ -165,11 +165,12 @@ export const MODEL_REGISTRY = {
   U7LR: apModel("U7 LR"),
   U7MSH: apModel("U7 Mesh"),
   U7LITE: apModel("U7 Lite"),
-  U7OUTDOOR: apModel("U7 Outdoor"),
+  U7OUTDOOR: apModel("U7 Outdoor", { frontStyle: "ap-u7-outdoor" }),
+  UKPW: apModel("U7 Outdoor", { frontStyle: "ap-u7-outdoor" }),
   U7PROXG: apModel("U7 Pro XG"),
   U7PROXGS: apModel("U7 Pro XGS"),
   U7PROXGWALL: apModel("U7 Pro XG Wall", { frontStyle: "ap-in-wall" }),
-  U7PROOUTDOOR: apModel("U7 Pro Outdoor"),
+  U7PROOUTDOOR: apModel("U7 Pro Outdoor", { frontStyle: "ap-u7-outdoor" }),
   U6MESHPRO: apModel("U6 Mesh Pro"),
   E7: apModel("E7"),
   U7ENTERPRISE: apModel("U7 Enterprise"),
@@ -1103,12 +1104,16 @@ export function resolveModelKey(device) {
     if (candidate.includes("UAPFLEXHD"))          return "UAPFLEXHD";
     if (candidate.includes("UAPBEACONHD"))        return "UAPBEACONHD";
     if (candidate.includes("UAPSHD"))             return "UAPSHD";
+    if (candidate.includes("UXSDM"))              return "UWBXG";
+    if (candidate.includes("UCXG"))               return "UAPXG";
     if (candidate.includes("UAPXG"))              return "UAPXG";
+    if (candidate.includes("U7NHD"))              return "UAPNANOHD";
     if (candidate.includes("UAPHD"))              return "UAPHD";
     if (candidate.includes("U6ENTERPRISEIW") || candidate.includes("U6ENTERPRISEINWALL")) return "U6ENTERPRISEIW";
     if (candidate.includes("U6ENTIW"))            return "U6ENTERPRISEIW";
     if (candidate.includes("U6ENTERPRISE"))       return "U6ENTERPRISE";
     if (candidate.includes("U6ENT"))              return "U6ENTERPRISE";
+    if (candidate === "U6M")                      return "U6MESH";
     if (candidate.includes("U6MESH"))             return "U6MESH";
     if (candidate.includes("U6PLUS"))             return "U6PLUS";
     if (candidate.includes("U6PRO"))              return "U6PRO";
@@ -1123,8 +1128,10 @@ export function resolveModelKey(device) {
     if (candidate.includes("UAL6"))               return "U6LITE";
     if (candidate.includes("UAM6"))               return "U6MESH";
     if (candidate.includes("U6MESHPRO"))          return "U6MESHPRO";
+    if (candidate.includes("U7MP"))               return "UAPACMPRO";
     if (candidate.includes("U7IW"))               return "U7IW";
     if (candidate.includes("U7INWALL"))           return "U7IW";
+    if (candidate.includes("UAPA6A5"))            return "U7IW";
     if (candidate.includes("G7LR"))               return "U7LR";
     if (candidate.includes("U7LR"))               return "U7LR";
     if (candidate.includes("U7MSH"))              return "U7MSH";
@@ -1135,13 +1142,17 @@ export function resolveModelKey(device) {
     if (candidate.includes("U7ENT"))              return "U7ENTERPRISE";
     if (candidate.includes("U7PROXGWALL"))        return "U7PROXGWALL";
     if (candidate.includes("U7PROWALL"))          return "U7PROWALL";
+    if (candidate.includes("UAPA6A4"))            return "U7PROXGS";
     if (candidate.includes("U7PROXGS"))           return "U7PROXGS";
     if (candidate.includes("U7PROXG"))            return "U7PROXG";
     if (candidate.includes("U7PROMAX"))           return "U7PROMAX";
+    if (candidate.includes("UAPA6B0"))            return "U7PROOUTDOOR";
     if (candidate.includes("U7PROOUTDOOR"))       return "U7PROOUTDOOR";
     if (candidate.includes("U7PRO"))              return "U7PRO";
     if (candidate.includes("U7OUTDOOR"))          return "U7OUTDOOR";
+    if (candidate.includes("UKPW"))               return "UKPW";
     if (candidate.includes("UWBXG"))              return "UWBXG";
+    if (candidate.includes("UAPA6B1"))            return "E7CAMPUS";
     if (candidate.includes("E7CAMPUS"))           return "E7CAMPUS";
     if (candidate.includes("E7AUDIENCE"))         return "E7AUDIENCE";
     if (candidate === "E7" || candidate.startsWith("E7")) return "E7";

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -1806,6 +1806,7 @@ class UnifiDeviceCard extends HTMLElement {
 
       .frontpanel.ap-disc,
       .frontpanel.ap-in-wall,
+      .frontpanel.ap-u7-outdoor,
       .frontpanel.ap-5g-backup {
         background: var(--udc-chrome-bg, linear-gradient(160deg, var(--udc-surface) 0%, var(--udc-bg) 100%));
         display: grid;

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -1829,6 +1829,7 @@ class UnifiDeviceCard extends HTMLElement {
 
       .ap-layout.compact .frontpanel.ap-disc,
       .ap-layout.compact .frontpanel.ap-in-wall,
+      .ap-layout.compact .frontpanel.ap-u7-outdoor,
       .ap-layout.compact .frontpanel.ap-5g-backup {
         min-height: 0;
         border-bottom: none;
@@ -1845,6 +1846,10 @@ class UnifiDeviceCard extends HTMLElement {
 
       .ap-layout.compact .ap-device.ap-in-wall-device {
         width: min(100%, calc(112px * var(--udc-ap-scale)));
+      }
+
+      .ap-layout.compact .ap-device.ap-u7-outdoor-device {
+        width: min(100%, calc(150px * var(--udc-ap-scale)));
       }
 
       .ap-layout.compact .section {
@@ -2062,6 +2067,45 @@ class UnifiDeviceCard extends HTMLElement {
         font: 700 calc(34px * var(--udc-ap-scale))/1 ui-sans-serif, system-ui, -apple-system, sans-serif;
         transform: translateY(calc(5px * var(--udc-ap-scale)));
         user-select: none;
+      }
+
+      .ap-u7-outdoor-device {
+        width: calc(184px * var(--udc-ap-scale));
+        aspect-ratio: .82 / 1;
+        border-radius: calc(35px * var(--udc-ap-scale));
+        background: linear-gradient(145deg, #ffffff 0%, #f5f6f7 58%, #e5e8ea 100%);
+        border: 1px solid rgba(150, 158, 166, .18);
+        box-shadow:
+          inset 9px 11px 17px rgba(255,255,255,.85),
+          inset -9px -11px 18px rgba(120,128,136,.09),
+          0 14px 24px rgba(0,0,0,.18);
+        display: grid;
+        place-items: center;
+        position: relative;
+      }
+
+      .ap-u7-outdoor-logo {
+        color: rgba(180, 188, 195, .42);
+        font: 700 calc(37px * var(--udc-ap-scale))/1 ui-sans-serif, system-ui, -apple-system, sans-serif;
+        transform: translateY(calc(-10px * var(--udc-ap-scale)));
+        user-select: none;
+      }
+
+      .ap-u7-outdoor-led {
+        position: absolute;
+        left: 50%;
+        bottom: 17%;
+        width: calc(4px * var(--udc-ap-scale));
+        height: calc(4px * var(--udc-ap-scale));
+        transform: translateX(-50%);
+        border-radius: 50%;
+        background: var(--ap-ring-color, #62c8fa);
+        box-shadow: 0 0 6px color-mix(in srgb, var(--ap-ring-color, #62c8fa) 65%, transparent);
+      }
+
+      .ap-u7-outdoor-led.off {
+        background: #aeb4ba;
+        box-shadow: none;
       }
 
       .ap-ring {
@@ -2729,6 +2773,7 @@ class UnifiDeviceCard extends HTMLElement {
       const isFiveGBackup = this._ctx?.layout?.frontStyle === "ap-5g-backup";
       const apFrontStyle = this._ctx?.layout?.apFrontStyle || this._ctx?.layout?.frontStyle;
       const isInWallAp = apFrontStyle === "ap-in-wall";
+      const isU7Outdoor = apFrontStyle === "ap-u7-outdoor";
       const fiveGDisplay = isFiveGBackup ? this._fiveGBackupDisplayData(uptime) : null;
 
       const headerTitle = this._title();
@@ -2757,7 +2802,7 @@ class UnifiDeviceCard extends HTMLElement {
           </div>
 
           <div class="ap-layout ${compactApView ? "compact" : ""}${this._integratedPortsEnabled(this._ctx) && this._ctx?.numberedPorts?.length ? " has-integrated-ports" : ""}">
-            <div class="frontpanel ${isFiveGBackup ? "ap-5g-backup" : (isInWallAp ? "ap-in-wall" : "ap-disc")}">
+            <div class="frontpanel ${isFiveGBackup ? "ap-5g-backup" : (isInWallAp ? "ap-in-wall" : (isU7Outdoor ? "ap-u7-outdoor" : "ap-disc"))}">
               ${isFiveGBackup ? `
               <div class="ap-device ap-5g-device">
                 <div class="ap-5g-face"></div>
@@ -2775,6 +2820,10 @@ class UnifiDeviceCard extends HTMLElement {
               <div class="ap-device ap-in-wall-device">
                 <div class="ap-in-wall-led ${ledEnabled ? "" : "off"}"></div>
                 <div class="ap-in-wall-logo">U</div>
+              </div>` : isU7Outdoor ? `
+              <div class="ap-device ap-u7-outdoor-device">
+                <div class="ap-u7-outdoor-logo">U</div>
+                <div class="ap-u7-outdoor-led ${ledEnabled ? "" : "off"}"></div>
               </div>` : `
               <div class="ap-device">
                 <div class="ap-ring ${ledEnabled ? "online" : "off"}">


### PR DESCRIPTION
### Motivation
- Recognize the U7 Outdoor and U7 Pro Outdoor controller identifiers and render them with a dedicated outdoor enclosure and a lower status LED.
- Map additional raw UniFi AP identifiers to existing device layouts to improve automatic device detection and correct fallbacks.
- Provide matching CSS and markup so the new outdoor AP presentation integrates into compact AP views and the AP card UI.

### Description
- Add a new `ap-u7-outdoor` frontStyle and CSS rules including `.ap-u7-outdoor-device`, `.ap-u7-outdoor-logo`, and a lower-positioned `.ap-u7-outdoor-led` with compact sizing adjustments.
- Update `MODEL_REGISTRY` to expose `UKPW` as a `U7 Outdoor` entry and set `U7 Pro Outdoor` to use the new `ap-u7-outdoor` frontStyle, and add several raw identifier mappings in `resolveModelKey` (examples: `UXSDM`, `UCXG`, `U7NHD`, `U6M`, `U7MP`, `UAPA6A5`, `UAPA6A4`, `UAPA6B0`, `UKPW`, `UAPA6B1`) so devices map to the intended layouts.
- Update `unifi-device-card.js` to detect the `ap-u7-outdoor` front style (`isU7Outdoor`) and render the appropriate AP device markup conditionally alongside existing 5G backup and in-wall layouts.
- Update `README.md` and `CHANGELOG.md` to document the new outdoor AP design and the added identifier mappings.

### Testing
- Ran the project build and lint checks with `npm run build` and `npm run lint`, and the build completed without errors.
- Ran the test suite with `npm test`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8049db97dc833395092f28d9fbe712)