### PR TITLE
feat: add YAML-only `fake_device` preview mode with synthetic devices

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -2,7 +2,9 @@ import {
   AP_MODEL_PREFIXES,
   applyPortsPerRowOverride,
   GATEWAY_MODEL_PREFIXES,
+  getFakeDevices,
   getDeviceLayout,
+  MODEL_REGISTRY,
   resolveModelKey,
   SWITCH_MODEL_PREFIXES,
 } from "./model-registry.js";
@@ -217,7 +219,8 @@ function normalizePortsPerRowForCache(cardConfig) {
 }
 
 function getDeviceContextCacheKey(deviceId, cardConfig) {
-  return `${deviceId}::${normalizePortsPerRowForCache(cardConfig) || "auto"}`;
+  const source = cardConfig?.fake_device === true ? "fake" : "real";
+  return `${source}::${deviceId}::${normalizePortsPerRowForCache(cardConfig) || "auto"}`;
 }
 
 function getContextCacheStore(map, hass) {
@@ -1036,7 +1039,9 @@ export function getDeviceRebootEntity(entities) {
 // Public: device list for editor
 // ─────────────────────────────────────────────────
 
-export async function getUnifiDevices(hass) {
+export async function getUnifiDevices(hass, cardConfig = null) {
+  if (cardConfig?.fake_device === true) return getFakeDevices();
+
   const { devices, entitiesByDevice, allEntitiesByDevice, configEntries } = await getAllData(hass);
   const unifiEntryIds = extractUnifiEntryIds(configEntries);
 
@@ -2008,6 +2013,54 @@ function filterPortsByLayout(discoveredPorts, layout) {
 }
 
 async function buildDeviceContext(hass, deviceId, cardConfig = null) {
+  if (String(deviceId).startsWith("fake:")) {
+    if (cardConfig?.fake_device !== true) return null;
+    const modelKey = String(deviceId).slice(5);
+    const model = MODEL_REGISTRY[modelKey];
+    if (!model) return null;
+
+    let layout = getDeviceLayout({ model: modelKey });
+    const configuredPortsPerRow = Number.parseInt(cardConfig?.ports_per_row, 10);
+    if (Number.isFinite(configuredPortsPerRow) && configuredPortsPerRow > 0) {
+      layout = applyPortsPerRowOverride(layout, configuredPortsPerRow);
+    }
+
+    const device = {
+      id: deviceId,
+      name: model.displayModel,
+      model: model.displayModel,
+      manufacturer: "Ubiquiti",
+    };
+
+    return {
+      device,
+      identity: buildNormalizedDeviceIdentity(device),
+      capabilities: {},
+      entities: [],
+      type: model.kind,
+      layout,
+      specialPorts: mergeSpecialsWithLayout(layout, [], []),
+      numberedPorts: mergePortsWithLayout(layout, []),
+      name: model.displayModel,
+      model: model.displayModel,
+      manufacturer: "Ubiquiti",
+      firmware: "",
+      online_entity: null,
+      led_switch_entity: null,
+      led_color_entity: null,
+      uptime_entity: null,
+      clients_entity: null,
+      ap_status_entity: null,
+      ap_uplink: null,
+      reboot_entity: null,
+      cpu_utilization_entity: null,
+      cpu_temperature_entity: null,
+      memory_utilization_entity: null,
+      temperature_entity: null,
+      fake_device: true,
+    };
+  }
+
   const { devices, entitiesByDevice, allEntitiesByDevice, configEntries } = await getAllData(hass);
   const unifiEntryIds = extractUnifiEntryIds(configEntries);
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -2013,7 +2013,10 @@ function filterPortsByLayout(discoveredPorts, layout) {
 }
 
 async function buildDeviceContext(hass, deviceId, cardConfig = null) {
-  if (String(deviceId).startsWith("fake:")) {
+  const isFakeDevice = String(deviceId).startsWith("fake:");
+  if (cardConfig?.fake_device === true && !isFakeDevice) return null;
+
+  if (isFakeDevice) {
     if (cardConfig?.fake_device !== true) return null;
     const modelKey = String(deviceId).slice(5);
     const model = MODEL_REGISTRY[modelKey];

--- a/src/model-registry.js
+++ b/src/model-registry.js
@@ -1004,6 +1004,15 @@ export const MODEL_REGISTRY = {
   },
 };
 
+export function getFakeDevices() {
+  return Object.entries(MODEL_REGISTRY).map(([modelKey, model]) => ({
+    id: `fake:${modelKey}`,
+    label: model.displayModel,
+    model: model.displayModel,
+    type: model.kind,
+  }));
+}
+
 export function validateModelLayoutEntry(key, entry) {
   const issues = [];
   const rows = Array.isArray(entry?.rows) ? entry.rows : [];

--- a/src/unifi-device-card-editor.js
+++ b/src/unifi-device-card-editor.js
@@ -261,13 +261,38 @@ class UnifiDeviceCardEditor extends HTMLElement {
 
   setConfig(config) {
     const prevDeviceId = this._config?.device_id || "";
+    const prevFakeMode = this._config?.fake_device === true;
     this._config = config || {};
+    const nextFakeMode = this._config?.fake_device === true;
     this._syncDraftColors();
 
     const nextDeviceId = this._config?.device_id || "";
-    if (this._hass && nextDeviceId) {
+    if (prevFakeMode !== nextFakeMode) {
+      ++this._loadToken;
+      ++this._entityHintToken;
+      ++this._deviceCtxToken;
+      this._devices = [];
+      this._loaded = false;
+      this._loading = false;
+      this._entityHint = null;
+      this._deviceCtx = null;
+      this._lastHintDeviceId = null;
+      this._lastCtxDeviceId = null;
+      if (this._hass) this._loadDevices();
+    }
+
+    const selectionMatchesMode = nextFakeMode
+      ? nextDeviceId.startsWith("fake:")
+      : !nextDeviceId.startsWith("fake:");
+    if (this._hass && nextDeviceId && selectionMatchesMode) {
       if (nextDeviceId !== prevDeviceId) {
-        this._loadEntityHint(nextDeviceId);
+        ++this._entityHintToken;
+        ++this._deviceCtxToken;
+        this._entityHint = null;
+        this._deviceCtx = null;
+        this._lastHintDeviceId = null;
+        this._lastCtxDeviceId = null;
+        if (!nextFakeMode) this._loadEntityHint(nextDeviceId);
       }
       if (nextDeviceId !== prevDeviceId || !this._deviceCtx) {
         this._loadDeviceCtx(nextDeviceId);
@@ -295,7 +320,7 @@ class UnifiDeviceCardEditor extends HTMLElement {
 
     const deviceId = this._config?.device_id || "";
     if (deviceId) {
-      if (deviceId !== this._lastHintDeviceId) {
+      if (this._config?.fake_device !== true && deviceId !== this._lastHintDeviceId) {
         this._loadEntityHint(deviceId);
       }
       if (deviceId !== this._lastCtxDeviceId || !this._deviceCtx) {
@@ -365,7 +390,7 @@ class UnifiDeviceCardEditor extends HTMLElement {
 
     const token = ++this._loadToken;
     try {
-      const devices = await getUnifiDevices(this._hass);
+      const devices = await getUnifiDevices(this._hass, this._config);
       if (token !== this._loadToken) return;
       this._devices = devices;
       this._loaded = true;
@@ -413,9 +438,7 @@ class UnifiDeviceCardEditor extends HTMLElement {
       const result = await getDeviceContext(this._hass, deviceId, this._config);
       if (token !== this._deviceCtxToken) return;
 
-      if (result) {
-        this._deviceCtx = result;
-      }
+      this._deviceCtx = result;
     } catch (err) {
       console.error("[unifi-device-card] failed to load device context for editor", err);
       if (token !== this._deviceCtxToken) return;

--- a/src/unifi-device-card-editor.js
+++ b/src/unifi-device-card-editor.js
@@ -275,7 +275,9 @@ class UnifiDeviceCardEditor extends HTMLElement {
       this._loaded = false;
       this._loading = false;
       this._entityHint = null;
+      this._entityHintLoading = false;
       this._deviceCtx = null;
+      this._deviceCtxLoading = false;
       this._lastHintDeviceId = null;
       this._lastCtxDeviceId = null;
       if (this._hass) this._loadDevices();

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -192,6 +192,7 @@ class UnifiDeviceCard extends HTMLElement {
 
   setConfig(config) {
     const oldDeviceId = this._config?.device_id || null;
+    const oldFakeMode = this._config?.fake_device === true;
     const newConfig = { ...(config || {}) };
     const trustLinkSpeedPorts = normalizePositivePortNumbers(newConfig.trust_link_speed_ports);
     if (trustLinkSpeedPorts.length) {
@@ -200,13 +201,15 @@ class UnifiDeviceCard extends HTMLElement {
       delete newConfig.trust_link_speed_ports;
     }
     const newDeviceId = newConfig?.device_id || null;
+    const newFakeMode = newConfig?.fake_device === true;
     this._config = newConfig;
     this._log("info", "setConfig", {
       device_id: newDeviceId || null,
       log_level: this._configuredLogLevel(),
     });
 
-    if (oldDeviceId !== newDeviceId) {
+    if (oldDeviceId !== newDeviceId || oldFakeMode !== newFakeMode) {
+      ++this._loadToken;
       this._clearUptimeRefreshTimer();
       this._ctx = null;
       this._selectedKey = null;


### PR DESCRIPTION
### Motivation

- Provide a hidden, YAML-only preview mode to let users pick synthetic devices from the canonical `MODEL_REGISTRY` without requiring Home Assistant devices. 
- Keep all existing behavior unchanged when `fake_device` is absent or not strictly `true`. 
- Ensure editor/context caches and async loads do not mix real and fake data and avoid showing invalid selections across mode switches.

### Description

- Exported `getFakeDevices()` from `src/model-registry.js` which returns options with IDs in the form `fake:<modelKey>`, readable `label`/`model` from `displayModel`, and `type` from `kind`. 
- Extended `getUnifiDevices` in `src/helpers.js` to accept an optional `cardConfig` parameter and return only `getFakeDevices()` when `cardConfig?.fake_device === true`, otherwise unchanged behavior. 
- Added fake-ID handling to `buildDeviceContext` in `src/helpers.js` so `deviceId` starting with `fake:` yields a synthetic, tolerant device context validated against `MODEL_REGISTRY` and producing modeled numbered ports and special slots with offline/inactive state and no actionable services. 
- Separated context cache keys by source (real vs fake) via `getDeviceContextCacheKey` to avoid cross-mode reuse. 
- Updated `UnifiDeviceCardEditor` (`src/unifi-device-card-editor.js`) to pass current config to `getUnifiDevices`, to invalidate inflight/old async loads and caches when `fake_device` toggles, and to ensure the dropdown shows readable labels but stores `device_id` as the internal `fake:<modelKey>` via existing `config-changed` behavior. 
- Updated `UnifiDeviceCard.setConfig` (`src/unifi-device-card.js`) to invalidate and reload context when `fake_device` changes even if `device_id` remains the same. 
- Preserved the single-source-of-truth rule by implementing changes only in `/src` and rebuilding to verify `dist` rather than editing `dist/` manually.

### Testing

- Ran unit-style assertions (`node --input-type=module` snippets) verifying `getFakeDevices()` length and an example entry (`fake:U7MSH`), `getUnifiDevices` real vs fake behavior, and synthetic `getDeviceContext` properties (type, `layout.modelKey`, no entities, no reboot/PoE/LED actions); all assertions passed. 
- Simulated the editor selection path by instantiating the editor class and invoking `_onDeviceChange` to confirm the dropdown shows labels and emits `config-changed` with `device_id: 'fake:U7MSH'`; the check passed. 
- Performed static checks `node --check` on modified `src` files and executed `npm run build`, both succeeded and produced an updated `dist/unifi-device-card.js` as a build artifact. 
- Ran `git diff --check` and verified no whitespace or diff-check errors; no test files were added per request.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a817fb3f23c833391aa031dd2d942ea)