### PR TITLE
Prioritize usable Home Assistant telemetry entities for device headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [v0.8.02-dev]
 
 ### 🐛 Bug Fixes
+- Prefer the UniFi telemetry entity with a currently usable Home Assistant state when duplicate registry candidates exist.
 - Allow genuine 10 Mbit/s RJ45 connections to opt out of ghost-link protection on selected ports through `trust_link_speed_ports` and the card editor, with consistent link status text throughout the card.
 - Recognize the U7 Outdoor (`UKPW`) and U7 Pro Outdoor (`UAPA6B0`) controller identifiers and render both devices with a dedicated outdoor enclosure and lower status LED.
 - Map additional raw UniFi AP identifiers for the UAP XG, nanoHD, AC Mesh Pro, U6 Mesh, U7 In-Wall, U7 Pro XGS, E7 Campus, and BaseStation XG to their existing device layouts.

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -619,41 +619,53 @@ function prioritizeAvailableTelemetryEntities(entities, hass) {
     .map(({ entity }) => entity);
 }
 
+function preferUsableTelemetryMatch(entityIds, hass) {
+  const matches = entityIds.filter(Boolean);
+  if (!hass?.states) return matches[0] || null;
+
+  return matches.find((entityId) => {
+    const state = hass.states[entityId];
+    return state && state.state !== "unknown" && state.state !== "unavailable";
+  }) || matches[0] || null;
+}
+
 export function getDeviceTelemetry(entities, hass = null) {
   const candidates = prioritizeAvailableTelemetryEntities(entities, hass);
   const coreCpuUtilization = findHeaderTelemetryEntity(candidates, "cpu_utilization");
   const coreCpuTemperature = findHeaderTelemetryEntity(candidates, "cpu_temperature");
   const coreMemoryUtilization = findHeaderTelemetryEntity(candidates, "memory_utilization");
-  const coreDeviceTemperature =
-    findHeaderTelemetryEntity(candidates, "temperature") ||
-    findFallbackSubTemperatureEntity(candidates);
 
   return {
-    cpu_utilization_entity:
-      coreCpuUtilization ||
-      findDeviceEntityByPatterns(candidates, ["cpu_utilization", "cpu_usage", "processor_utilization"]) ||
+    cpu_utilization_entity: preferUsableTelemetryMatch([
+      coreCpuUtilization,
+      findDeviceEntityByPatterns(candidates, ["cpu_utilization", "cpu_usage", "processor_utilization"]),
       findSystemStatEntity(candidates, ["cpu"], ["temperature", "temp", "clock", "frequency", "fan"]),
-    cpu_temperature_entity:
-      coreCpuTemperature ||
-      findDeviceEntityByPatterns(candidates, ["cpu_temperature", "processor_temperature", "temperature_cpu", "temperature-cpu"]) ||
+    ], hass),
+    cpu_temperature_entity: preferUsableTelemetryMatch([
+      coreCpuTemperature,
+      findDeviceEntityByPatterns(candidates, ["cpu_temperature", "processor_temperature", "temperature_cpu", "temperature-cpu"]),
       findSystemStatEntity(candidates, ["cpu_temp", "cpu_temperature", "processor_temperature", "temperature_cpu", "cpu"], ["utilization", "usage", "clock", "frequency"]),
-    memory_utilization_entity:
-      coreMemoryUtilization ||
-      findDeviceEntityByPatterns(candidates, ["memory_utilization", "memory_usage", "ram_utilization"]) ||
+    ], hass),
+    memory_utilization_entity: preferUsableTelemetryMatch([
+      coreMemoryUtilization,
+      findDeviceEntityByPatterns(candidates, ["memory_utilization", "memory_usage", "ram_utilization"]),
       findSystemStatEntity(candidates, ["memory", "ram"], ["temperature", "temp", "slot"]),
-    temperature_entity:
-      coreDeviceTemperature ||
+    ], hass),
+    temperature_entity: preferUsableTelemetryMatch([
+      findHeaderTelemetryEntity(candidates, "temperature"),
+      findFallbackSubTemperatureEntity(candidates),
       findDeviceEntityByPatterns(
         candidates,
         ["device_temperature", "system_temperature", "board_temperature", "chassis_temperature"],
         (entity) => isValidTemperatureTelemetryEntity(entity, { allowSubTemperature: false })
-      ) ||
+      ),
       findSystemStatEntity(
         candidates,
         ["temperature", "temp"],
         ["cpu", "processor", "memory", "ram", "wan", "sfp", "uplink", "link_speed", "link", "rx", "tx", "throughput", "poe", "fan"],
         (entity) => isValidTemperatureTelemetryEntity(entity, { allowSubTemperature: false })
       ),
+    ], hass),
   };
 }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -604,36 +604,52 @@ function classifyHeaderTelemetryWarningType(entity) {
   return null;
 }
 
-export function getDeviceTelemetry(entities) {
-  const coreCpuUtilization = findHeaderTelemetryEntity(entities, "cpu_utilization");
-  const coreCpuTemperature = findHeaderTelemetryEntity(entities, "cpu_temperature");
-  const coreMemoryUtilization = findHeaderTelemetryEntity(entities, "memory_utilization");
+function prioritizeAvailableTelemetryEntities(entities, hass) {
+  if (!hass?.states) return entities || [];
+
+  return (entities || [])
+    .map((entity, index) => {
+      const state = hass.states[entity?.entity_id];
+      const hasUsableState = !!state && state.state !== "unknown" && state.state !== "unavailable";
+      return { entity, index, hasUsableState };
+    })
+    .sort((left, right) =>
+      Number(right.hasUsableState) - Number(left.hasUsableState) || left.index - right.index
+    )
+    .map(({ entity }) => entity);
+}
+
+export function getDeviceTelemetry(entities, hass = null) {
+  const candidates = prioritizeAvailableTelemetryEntities(entities, hass);
+  const coreCpuUtilization = findHeaderTelemetryEntity(candidates, "cpu_utilization");
+  const coreCpuTemperature = findHeaderTelemetryEntity(candidates, "cpu_temperature");
+  const coreMemoryUtilization = findHeaderTelemetryEntity(candidates, "memory_utilization");
   const coreDeviceTemperature =
-    findHeaderTelemetryEntity(entities, "temperature") ||
-    findFallbackSubTemperatureEntity(entities);
+    findHeaderTelemetryEntity(candidates, "temperature") ||
+    findFallbackSubTemperatureEntity(candidates);
 
   return {
     cpu_utilization_entity:
       coreCpuUtilization ||
-      findDeviceEntityByPatterns(entities, ["cpu_utilization", "cpu_usage", "processor_utilization"]) ||
-      findSystemStatEntity(entities, ["cpu"], ["temperature", "temp", "clock", "frequency", "fan"]),
+      findDeviceEntityByPatterns(candidates, ["cpu_utilization", "cpu_usage", "processor_utilization"]) ||
+      findSystemStatEntity(candidates, ["cpu"], ["temperature", "temp", "clock", "frequency", "fan"]),
     cpu_temperature_entity:
       coreCpuTemperature ||
-      findDeviceEntityByPatterns(entities, ["cpu_temperature", "processor_temperature", "temperature_cpu", "temperature-cpu"]) ||
-      findSystemStatEntity(entities, ["cpu_temp", "cpu_temperature", "processor_temperature", "temperature_cpu", "cpu"], ["utilization", "usage", "clock", "frequency"]),
+      findDeviceEntityByPatterns(candidates, ["cpu_temperature", "processor_temperature", "temperature_cpu", "temperature-cpu"]) ||
+      findSystemStatEntity(candidates, ["cpu_temp", "cpu_temperature", "processor_temperature", "temperature_cpu", "cpu"], ["utilization", "usage", "clock", "frequency"]),
     memory_utilization_entity:
       coreMemoryUtilization ||
-      findDeviceEntityByPatterns(entities, ["memory_utilization", "memory_usage", "ram_utilization"]) ||
-      findSystemStatEntity(entities, ["memory", "ram"], ["temperature", "temp", "slot"]),
+      findDeviceEntityByPatterns(candidates, ["memory_utilization", "memory_usage", "ram_utilization"]) ||
+      findSystemStatEntity(candidates, ["memory", "ram"], ["temperature", "temp", "slot"]),
     temperature_entity:
       coreDeviceTemperature ||
       findDeviceEntityByPatterns(
-        entities,
+        candidates,
         ["device_temperature", "system_temperature", "board_temperature", "chassis_temperature"],
         (entity) => isValidTemperatureTelemetryEntity(entity, { allowSubTemperature: false })
       ) ||
       findSystemStatEntity(
-        entities,
+        candidates,
         ["temperature", "temp"],
         ["cpu", "processor", "memory", "ram", "wan", "sfp", "uplink", "link_speed", "link", "rx", "tx", "throughput", "poe", "fan"],
         (entity) => isValidTemperatureTelemetryEntity(entity, { allowSubTemperature: false })
@@ -2154,7 +2170,7 @@ async function buildDeviceContext(hass, deviceId, cardConfig = null) {
   const numberedPorts = filterPortsByLayout(discoveredPortsRaw, layout);
   const specialPorts = discoverSpecialPorts(entities);
   const telemetryEntities = allEntities.filter((entity) => !entity?.disabled_by);
-  const telemetry = getDeviceTelemetry(telemetryEntities.length > 0 ? telemetryEntities : entities);
+  const telemetry = getDeviceTelemetry(telemetryEntities.length > 0 ? telemetryEntities : entities, hass);
   const deviceStats = getDeviceStatEntities(entities);
   const apUplink = type === "access_point"
     ? resolveAccessPointUplink(hass, entities, devices)


### PR DESCRIPTION
### Motivation
- Avoid selecting telemetry entities that are present in the registry but have unusable Home Assistant states when multiple candidates exist for header telemetry.
- Ensure header CPU/memory/temperature telemetry shows the most relevant entity with an actual HA state instead of a duplicate with `unknown`/`unavailable`.

### Description
- Add `prioritizeAvailableTelemetryEntities(entities, hass)` to sort telemetry candidates by whether they have a usable HA state and preserve original order among equals. 
- Change `getDeviceTelemetry` to accept an optional `hass` parameter and to use the prioritized candidate list when resolving telemetry entities. 
- Update `buildDeviceContext` to pass `hass` into `getDeviceTelemetry`. 
- Update `CHANGELOG.md` with a note about preferring telemetry entities that have currently usable Home Assistant states.

### Testing
- Ran the repository linting with `npm run lint` and it completed successfully. 
- Ran the test suite with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a81879019b48333a51bbcb0b8dc1e06)