### PR TITLE
Re-evaluate duplicate telemetry entities when Home Assistant states change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [v0.8.02-dev]
 
 ### 🐛 Bug Fixes
+- Re-evaluate duplicate telemetry sensors as Home Assistant states change instead of keeping an unavailable sensor selected from the initial card load.
 - Prefer the UniFi telemetry entity with a currently usable Home Assistant state when duplicate registry candidates exist.
 - Allow genuine 10 Mbit/s RJ45 connections to opt out of ghost-link protection on selected ports through `trust_link_speed_ports` and the card editor, with consistent link status text throughout the card.
 - Recognize the U7 Outdoor (`UKPW`) and U7 Pro Outdoor (`UAPA6B0`) controller identifiers and render both devices with a dedicated outdoor enclosure and lower status LED.

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -2193,6 +2193,7 @@ async function buildDeviceContext(hass, deviceId, cardConfig = null) {
     identity,
     capabilities,
     entities,
+    telemetry_entities: telemetryEntities.length > 0 ? telemetryEntities : entities,
     type,
     layout,
     specialPorts,

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -4,6 +4,7 @@ import {
   formatState,
   formatUptimeState,
   getDeviceContext,
+  getDeviceTelemetry,
   getPoeStatus,
   getPortSpeedText,
   hasTraffic,
@@ -230,9 +231,30 @@ class UnifiDeviceCard extends HTMLElement {
     this._hass = hass;
     this._ensureLoaded();
     this._log("trace", "hass update");
-    if (!previousHass || !this._ctx || this._hasRelevantStateChanges(previousHass, hass)) {
+    const telemetrySelectionChanged = this._refreshTelemetrySelection(previousHass);
+    if (!previousHass || !this._ctx || telemetrySelectionChanged || this._hasRelevantStateChanges(previousHass, hass)) {
       this._render();
     }
+  }
+
+  _refreshTelemetrySelection(previousHass = null) {
+    const candidates = this._ctx?.telemetry_entities;
+    if (!Array.isArray(candidates) || !candidates.length) return false;
+    if (
+      previousHass &&
+      !candidates.some((entity) => previousHass.states?.[entity.entity_id] !== this._hass?.states?.[entity.entity_id])
+    ) {
+      return false;
+    }
+
+    const telemetry = getDeviceTelemetry(candidates, this._hass);
+    let changed = false;
+    for (const [key, entityId] of Object.entries(telemetry)) {
+      if (this._ctx[key] === entityId) continue;
+      this._ctx[key] = entityId;
+      changed = true;
+    }
+    return changed;
   }
 
   getCardSize() {


### PR DESCRIPTION
### Motivation
- Prevent the card from sticking to an initially selected telemetry sensor that becomes unavailable by re-evaluating duplicate telemetry candidates when Home Assistant state updates occur.
- Preserve the full list of telemetry candidates in the device context so the card can choose an alternate usable entity after initial load.

### Description
- Add `telemetry_entities` to the object returned by `buildDeviceContext` so the full set of telemetry candidates is available later. 
- Import and use `getDeviceTelemetry` in `unifi-device-card.js` and implement `_refreshTelemetrySelection(previousHass)` to re-run telemetry selection against current HA states. 
- Call `_refreshTelemetrySelection` from the `set hass` handler and trigger a re-render when telemetry selection changes. 
- Update `CHANGELOG.md` to note the behavior change for duplicate telemetry sensor selection.

### Testing
- Ran `npm run build` and the package built successfully. 
- Ran the lint step with `npm run lint` and no lint errors were reported. 
- Ran the test suite with `npm test` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a818fffca948333a198433fb970705e)