### PR TITLE
Fix UniFi 5G display scaling and uptime layout; responsive CSS adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v0.8.03-dev]
+
+### 🐛 Bug Fixes
+- Fix the UniFi 5G device display content scaling when compact AP cards are narrowed, and place its uptime value below the label so it fits the display.
+
 ## [v0.8.02-dev]
 
 ### 🐛 Bug Fixes

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -1928,9 +1928,9 @@ class UnifiDeviceCard extends HTMLElement {
 
       .ap-5g-device {
         width: calc(132px * var(--udc-ap-scale));
-        height: calc(320px * var(--udc-ap-scale));
-        aspect-ratio: auto;
-        border-radius: calc(32px * var(--udc-ap-scale));
+        height: auto;
+        aspect-ratio: 132 / 320;
+        border-radius: 24.24% / 10%;
         background: linear-gradient(90deg, #383b3e 0 13%, #f7f8f8 13% 87%, #383b3e 87% 100%);
         box-shadow:
           inset 11px 0 14px rgba(255,255,255,.5),
@@ -1938,12 +1938,13 @@ class UnifiDeviceCard extends HTMLElement {
           0 16px 28px rgba(0,0,0,.24);
         position: relative;
         overflow: hidden;
+        container-type: inline-size;
       }
 
       .ap-5g-face {
         position: absolute;
         inset: 0 15%;
-        border-radius: calc(24px * var(--udc-ap-scale));
+        border-radius: 18.18cqw;
         background: linear-gradient(90deg, #f2f4f4 0%, #ffffff 44%, #eff2f2 100%);
         box-shadow:
           inset 8px 0 14px rgba(255,255,255,.68),
@@ -1957,7 +1958,7 @@ class UnifiDeviceCard extends HTMLElement {
         width: 44%;
         aspect-ratio: .74 / 1;
         transform: translate(-50%, -50%);
-        border-radius: calc(7px * var(--udc-ap-scale));
+        border-radius: 5.3cqw;
         background: linear-gradient(180deg, #071128 0%, #0d1733 64%, #07101f 100%);
         box-shadow:
           inset 0 1px 0 rgba(255,255,255,.22),
@@ -1965,8 +1966,8 @@ class UnifiDeviceCard extends HTMLElement {
         color: #eaf3ff;
         display: grid;
         grid-template-rows: auto auto 1fr auto;
-        gap: calc(4px * var(--udc-ap-scale));
-        padding: calc(6px * var(--udc-ap-scale));
+        gap: 3.03cqw;
+        padding: 4.55cqw;
         font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
         font-weight: 700;
         line-height: 1;
@@ -1974,15 +1975,15 @@ class UnifiDeviceCard extends HTMLElement {
       }
 
       .ap-5g-display-top {
-        font-size: calc(13px * var(--udc-ap-scale));
+        font-size: 9.85cqw;
       }
 
       .ap-5g-bars {
         display: grid;
         grid-template-columns: repeat(5, 1fr);
         align-items: end;
-        gap: calc(1px * var(--udc-ap-scale));
-        height: calc(18px * var(--udc-ap-scale));
+        gap: .76cqw;
+        height: 13.64cqw;
       }
 
       .ap-5g-bars span {
@@ -2005,8 +2006,15 @@ class UnifiDeviceCard extends HTMLElement {
 
       .ap-5g-uptime {
         color: #c6d8ed;
-        font-size: calc(6px * var(--udc-ap-scale));
+        display: grid;
+        gap: .76cqw;
+        font-size: 3.79cqw;
+        line-height: 1;
         text-align: center;
+      }
+
+      .ap-5g-uptime-value {
+        color: #eaf3ff;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
@@ -2015,20 +2023,20 @@ class UnifiDeviceCard extends HTMLElement {
       .ap-5g-metrics {
         align-self: end;
         display: grid;
-        gap: calc(3px * var(--udc-ap-scale));
+        gap: 2.27cqw;
       }
 
       .ap-5g-metric {
         display: grid;
-        grid-template-columns: calc(13px * var(--udc-ap-scale)) 1fr;
+        grid-template-columns: 9.85cqw 1fr;
         align-items: center;
-        gap: calc(3px * var(--udc-ap-scale));
+        gap: 2.27cqw;
         color: #c6d8ed;
-        font-size: calc(5px * var(--udc-ap-scale));
+        font-size: 3.79cqw;
       }
 
       .ap-5g-meter {
-        height: calc(4px * var(--udc-ap-scale));
+        height: 3.03cqw;
         border-radius: 999px;
         background: rgba(255,255,255,.18);
         overflow: hidden;
@@ -2052,7 +2060,7 @@ class UnifiDeviceCard extends HTMLElement {
         top: 78%;
         transform: translateX(-50%);
         color: rgba(210,215,218,.58);
-        font-size: calc(10px * var(--udc-ap-scale));
+        font-size: 7.58cqw;
         white-space: nowrap;
       }
 
@@ -2835,7 +2843,10 @@ class UnifiDeviceCard extends HTMLElement {
                 <div class="ap-5g-display">
                   <div class="ap-5g-display-top">5G</div>
                   <div class="ap-5g-bars">${[1, 2, 3, 4, 5].map((bar) => `<span class="${bar <= 4 ? "" : "inactive"}"></span>`).join("")}</div>
-                  <div class="ap-5g-uptime">${this._escapeHtml(`${this._t("uptime")} ${fiveGDisplay.uptime}`)}</div>
+                  <div class="ap-5g-uptime">
+                    <span>${this._escapeHtml(`${this._t("uptime")}:`)}</span>
+                    <span class="ap-5g-uptime-value">${this._escapeHtml(fiveGDisplay.uptime)}</span>
+                  </div>
                   <div class="ap-5g-metrics">
                     <div class="ap-5g-metric"><span>CPU</span><div class="ap-5g-meter"><span style="--ap-5g-meter-value: ${this._escapeAttr(`${fiveGDisplay.cpuBar}%`)}"></span></div></div>
                     <div class="ap-5g-metric"><span>RAM</span><div class="ap-5g-meter memory"><span style="--ap-5g-meter-value: ${this._escapeAttr(`${fiveGDisplay.memoryBar}%`)}"></span></div></div>


### PR DESCRIPTION
### Motivation
- Resolve layout and scaling issues for the UniFi 5G backup AP when the card is rendered narrow or in compact AP views so uptime and metrics remain legible.
- Convert pixel/scale-based sizing to container-aware and viewport-relative units to make the AP rendering responsive to varying card widths.

### Description
- Update `src/unifi-device-card.js` CSS for the 5G AP (`.ap-5g-device`, `.ap-5g-display`, metrics, bars, labels) replacing `calc(... * var(--udc-ap-scale))` sizing with `cqw`/relative units, add `container-type: inline-size`, and set explicit `aspect-ratio`/`height: auto` for better scaling.
- Move the uptime text into a two-line layout by creating `ap-5g-uptime` as a grid and adding an `ap-5g-uptime-value` element so the uptime value is placed below the label and avoids truncation.
- Adjust gaps, paddings, font sizes, radii, and meter heights to match the new responsive sizing model.
- Add an entry to `CHANGELOG.md` for `v0.8.03-dev` documenting the bug fix for the UniFi 5G display scaling and uptime placement.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a841bdf4c308333963c8af631e41779)