### PR TITLE
Normalize U7 legacy identifiers to UAP AC models and add explicit U7 keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [v0.8.04-dev]
 
 ### 🐛 Bug Fixes
+- Correct the legacy UniFi board identifiers `U7LR`, `U7IW`, and `U7MSH` to UAP AC LR, UAP AC In-Wall, and UAP AC Mesh, while keeping the current U7 LR (`G7LR`), U7 In-Wall (`UAPA6A5`), and descriptive U7 Mesh model on their own designs.
 - Fix the UniFi 5G device display content scaling when compact AP cards are narrowed, and place its uptime value below the label so it fits the display.
 - Resolve the descriptive `UAP AC Mesh Pro` model name before the broader AC Mesh alias so it keeps the outdoor-panel design.
 - Resolve the descriptive `Device Bridge Switch` model name to `UDBSWITCH` instead of falling through to the base Device Bridge enclosure.

--- a/src/model-registry.js
+++ b/src/model-registry.js
@@ -167,9 +167,12 @@ export const MODEL_REGISTRY = {
   U7PRO: apModel("U7 Pro"),
   U7PROMAX: apModel("U7 Pro Max"),
   U7PROWALL: apModel("U7 Pro Wall", { frontStyle: "ap-in-wall" }),
-  U7IW: apModel("U7 In-Wall", { frontStyle: "ap-in-wall", supportsIntegratedPorts: true }),
-  U7LR: apModel("U7 LR"),
-  U7MSH: apModel("U7 Mesh", { frontStyle: "ap-mesh-column" }),
+  U7IW: apModel("UAP AC In-Wall", { frontStyle: "ap-in-wall", supportsIntegratedPorts: true }),
+  U7LR: apModel("UAP AC LR"),
+  U7MSH: apModel("UAP AC Mesh", { frontStyle: "ap-ac-mesh" }),
+  G7LR: apModel("U7 LR"),
+  UAPA6A5: apModel("U7 In-Wall", { frontStyle: "ap-in-wall", supportsIntegratedPorts: true }),
+  U7MESH: apModel("U7 Mesh", { frontStyle: "ap-mesh-column" }),
   U7LITE: apModel("U7 Lite"),
   U7OUTDOOR: apModel("U7 Outdoor", { frontStyle: "ap-u7-outdoor" }),
   UKPW: apModel("U7 Outdoor", { frontStyle: "ap-u7-outdoor" }),
@@ -1149,12 +1152,12 @@ export function resolveModelKey(device) {
     if (candidate.includes("U6MESHPRO"))          return "U6MESHPRO";
     if (candidate.includes("U7MP"))               return "UAPACMPRO";
     if (candidate.includes("U7IW"))               return "U7IW";
-    if (candidate.includes("U7INWALL"))           return "U7IW";
-    if (candidate.includes("UAPA6A5"))            return "U7IW";
-    if (candidate.includes("G7LR"))               return "U7LR";
+    if (candidate.includes("U7INWALL"))           return "UAPA6A5";
+    if (candidate.includes("UAPA6A5"))            return "UAPA6A5";
+    if (candidate.includes("G7LR"))               return "G7LR";
     if (candidate.includes("U7LR"))               return "U7LR";
     if (candidate.includes("U7MSH"))              return "U7MSH";
-    if (candidate.includes("U7MESH"))             return "U7MSH";
+    if (candidate.includes("U7MESH"))             return "U7MESH";
     if (candidate.includes("U7LITE"))             return "U7LITE";
     if (candidate.includes("U7ULTRA"))            return "U7LITE";
     if (candidate.includes("U7UKU"))              return "UKULTRA";


### PR DESCRIPTION
### Motivation
- Correct legacy/unified board identifiers that were being resolved to incorrect or ambiguous AP models so shaped enclosures and display labels render consistently.

### Description
- Update `MODEL_REGISTRY` to map legacy keys `U7IW`, `U7LR`, and `U7MSH` to the UAP AC variants (`UAP AC In-Wall`, `UAP AC LR`, and `UAP AC Mesh`) and add explicit keys `G7LR`, `UAPA6A5`, and `U7MESH` for the current U7 device designs.
- Adjust the `resolveModelKey` logic to return the new explicit keys for `U7INWALL`, `UAPA6A5`, `G7LR`, and to treat `U7MESH` separately from the broader AC Mesh alias.
- Add a changelog entry documenting the identifier corrections and the impact on enclosure rendering and model resolution behavior.

### Testing
- Ran the project unit test suite and focused model resolution tests locally, and they all passed.
- Ran the linter and static checks, and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8577bb85f88333afeec4d1678d4e24)