### PR TITLE
Support 4 SFP+ ports on USW Pro HD 24 (registry, README, changelog)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [v0.8.2]
+
+### 🐛 Bug Fixes
+- Show all four SFP+ ports on the USW Pro HD 24 and USW Pro HD 24 PoE.
+
+### ✨ Hints
+
+I try to save money to get an Cloud Gateway Max in future to replace my Cloud Gateway Ultra, maybe then i could be able to add more feature to the card.
+
+If you see improvements, issues, or fixes, feel free to open an issue or create a pull request.
+
+If you like this project and want to support my work, you can donate via PayPal.
+
+<a href="https://www.paypal.me/bluenazgul">
+  <img
+    src="https://raw.githubusercontent.com/stefan-niedermann/paypal-donate-button/master/paypal-donate-button.png"
+    alt="Donate with PayPal"
+    width="220"
+  />
+</a>
+
 ## [v0.8.1]
 
 ### 🐛 Bug Fixes

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ If you like this project and want to support my work, you can donate via PayPal.
 | USW Pro XG 10 PoE (`USWPROXG10POE`) | 10 + 2 SFP+ | Silver |
 | USW Pro XG 24 / 24 PoE (`USWPROXG24`, `USWPROXG24POE`) | 24 + 2 SFP+ | Silver |
 | USW Pro XG 48 / 48 PoE (`USWPROXG48`, `USWPROXG48POE`) | 48 + 4 SFP+ | Silver |
-| USW Pro HD 24 / 24 PoE (`USWPROHD24`, `USWPROHD24POE`) | 24 + 2 SFP+ | Silver |
+| USW Pro HD 24 / 24 PoE (`USWPROHD24`, `USWPROHD24POE`) | 24 + 4 SFP+ | Silver |
 | Enterprise Campus 24 PoE / 24S PoE (`ECS24POE`, `ECS24SPOE`) | 24 + 4 SFP28 | Silver |
 | Enterprise Campus 48 PoE / 48S PoE (`ECS48POE`, `ECS48SPOE`) | 48 + 4 SFP28 | Silver |
 | Enterprise Campus Aggregation (`ECSAGGREGATION`) | 32 SFP28 | Silver |

--- a/src/model-registry.js
+++ b/src/model-registry.js
@@ -766,20 +766,24 @@ export const MODEL_REGISTRY = {
   USWPROHD24: {
     kind: "switch", frontStyle: "eight-grid",
     rows: [range(1, 8), range(9, 16), range(17, 24)],
-    portCount: 26, displayModel: "USW Pro HD 24", theme: "silver",
+    portCount: 28, displayModel: "USW Pro HD 24", theme: "silver",
     specialSlots: [
       { key: "sfp_1", label: "SFP+ 1", port: 25 },
       { key: "sfp_2", label: "SFP+ 2", port: 26 },
+      { key: "sfp_3", label: "SFP+ 3", port: 27 },
+      { key: "sfp_4", label: "SFP+ 4", port: 28 },
     ],
   },
   USWPROHD24POE: {
     kind: "switch", frontStyle: "eight-grid",
     rows: [range(1, 8), range(9, 16), range(17, 24)],
-    portCount: 26, displayModel: "USW Pro HD 24 PoE", theme: "silver",
+    portCount: 28, displayModel: "USW Pro HD 24 PoE", theme: "silver",
     poePortRange: [1, 24],
     specialSlots: [
       { key: "sfp_1", label: "SFP+ 1", port: 25 },
       { key: "sfp_2", label: "SFP+ 2", port: 26 },
+      { key: "sfp_3", label: "SFP+ 3", port: 27 },
+      { key: "sfp_4", label: "SFP+ 4", port: 28 },
     ],
   },
   ECS24POE: {
@@ -1462,7 +1466,8 @@ export function inferPortCountFromModel(device) {
   if (text.includes("USXG24")   || text.includes("ENTERPRISEXG24"))                  return 26;
   if (text.includes("US68P")    || text.includes("ENTERPRISE8POE"))                  return 10;
   if (text.includes("USWPROXG48"))                                                   return 52;
-  if (text.includes("USWPROXG24") || text.includes("USWPROHD24"))                     return 26;
+  if (text.includes("USWPROHD24"))                                                    return 28;
+  if (text.includes("USWPROXG24"))                                                    return 26;
   if (text.includes("USWPROXG10POE"))                                                 return 12;
   if (text.includes("USWPROXG8POE"))                                                  return 10;
   if (text.includes("USWWANRJ45"))                                                     return 4;


### PR DESCRIPTION
### Motivation
- The USW Pro HD 24 / 24 PoE devices actually expose four SFP+ uplinks and the registry, UI rendering, and docs should reflect that.
- Update release notes and donation/info text to document the fix and release a new version entry.

### Description
- Update `MODEL_REGISTRY` entries `USWPROHD24` and `USWPROHD24POE` to set `portCount` to `28` and add `sfp_3` and `sfp_4` `specialSlots` so all four SFP+ ports are represented. 
- Adjust `inferPortCountFromModel` to return `28` for `USWPROHD24` and preserve the `USWPROXG24` branch correctly. 
- Update the `README.md` table row for `USW Pro HD 24 / 24 PoE` to list `24 + 4 SFP+` ports. 
- Add a `CHANGELOG.md` entry for `[v0.8.2]` describing the bug fix and include the donation/info blurb.

### Testing
- Ran the repository linting via `npm run lint`, which completed successfully. 
- Ran the test suite via `npm test`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a88c04644588333865bb55893dd7cf1)