### PR TITLE
Treat CPU and device temperature as alternative telemetry and centralize unavailable-telemetry logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🐛 Bug Fixes
 - Show all four SFP+ ports on the USW Pro HD 24 and USW Pro HD 24 PoE.
+- Treat CPU temperature and device temperature as alternative temperature telemetry in the editor, avoiding a missing-telemetry warning when either sensor is available.
 
 ### ✨ Hints
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -669,6 +669,18 @@ export function getDeviceTelemetry(entities, hass = null) {
   };
 }
 
+export function getUnavailableHeaderTelemetryKeys(deviceContext) {
+  if (!deviceContext) return [];
+
+  const unavailable = [];
+  if (!deviceContext.cpu_utilization_entity) unavailable.push("cpu_utilization");
+  if (!deviceContext.memory_utilization_entity) unavailable.push("memory_utilization");
+  if (!deviceContext.cpu_temperature_entity && !deviceContext.temperature_entity) {
+    unavailable.push("temperature");
+  }
+  return unavailable;
+}
+
 export function getDeviceOnlineEntity(entities) {
   for (const entity of entities || []) {
     const id = lower(entity.entity_id);

--- a/src/unifi-device-card-editor.js
+++ b/src/unifi-device-card-editor.js
@@ -1,6 +1,7 @@
 //unifi-device-card-editor.js
 import {
   getDeviceContext,
+  getUnavailableHeaderTelemetryKeys,
   getRelevantEntityWarningsForDevice,
   mergePortsWithLayout,
   getUnifiDevices,
@@ -847,14 +848,7 @@ class UnifiDeviceCardEditor extends HTMLElement {
   _unavailableTelemetryItems() {
     if (this._config?.show_telemetry === false || !this._deviceCtx || this._deviceCtxLoading) return [];
 
-    return [
-      ["cpu_utilization", "cpu_utilization_entity"],
-      ["cpu_temperature", "cpu_temperature_entity"],
-      ["memory_utilization", "memory_utilization_entity"],
-      ["temperature", "temperature_entity"],
-    ]
-      .filter(([, entityKey]) => !this._deviceCtx?.[entityKey])
-      .map(([labelKey]) => this._t(labelKey));
+    return getUnavailableHeaderTelemetryKeys(this._deviceCtx).map((labelKey) => this._t(labelKey));
   }
 
   _unavailableTelemetryHTML() {


### PR DESCRIPTION
### Motivation
- Avoid showing a missing-telemetry warning for temperature when either a CPU temperature sensor or a device temperature sensor is available, and centralize the logic for determining unavailable header telemetry.

### Description
- Add `getUnavailableHeaderTelemetryKeys` in `src/helpers.js` which returns unavailable header telemetry keys and treats `cpu_temperature` and `temperature` as alternatives so only one temperature warning is emitted when applicable.
- Replace the manual unavailable-telemetry check in `UnifiDeviceCardEditor._unavailableTelemetryItems` with a call to `getUnavailableHeaderTelemetryKeys(this._deviceCtx)` and map the results to localized labels.
- Update `CHANGELOG.md` to document the telemetry-editor change.

### Testing
- Ran unit tests with `npm test` which passed without failures.
- Ran linting with `npm run lint` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a89460009f08333ae75205260aad578)