### PR TITLE
feat: make model/firmware line open Home Assistant device page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Show all four SFP+ ports on the USW Pro HD 24 and USW Pro HD 24 PoE.
 - Treat CPU temperature and device temperature as alternative temperature telemetry in the editor, avoiding a missing-telemetry warning when either sensor is available.
 
+### ✨ Improvements
+- Open the selected Home Assistant device page when the model and firmware line is clicked, making disabled UniFi entities easier to access.
+
 ### ✨ Hints
 
 I try to save money to get an Cloud Gateway Max in future to replace my Cloud Gateway Ultra, maybe then i could be able to add more feature to the card.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ If you like this project and want to support my work, you can donate via PayPal.
 - **Device-accurate styling** — white panels for Lite / Flex / Ultra / Cloud Gateway style devices and silver/dark panels for rack devices and unknown switch fallbacks
 - **Per-port link and PoE indication** — visual port LEDs reflect link state, speed class, and active PoE
 - **Port detail panel** — click any port to see link status, speed, PoE state, PoE power draw, RX/TX values, and available actions; disabling a port requires confirmation
+- **Direct device access** — click the model and firmware line to open the selected device in Home Assistant, including its disabled entities
 - **PoE toggle & Power Cycle** — directly from the card when supported by Home Assistant entities
 - **Live port counter** — connected / total shown in the header chip
 - **Automatic device detection** — finds UniFi switches and gateways registered in Home Assistant

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -1346,6 +1346,27 @@ class UnifiDeviceCard extends HTMLElement {
     return fw ? `${model} · FW ${fw}` : model;
   }
 
+  _openDevicePage() {
+    const deviceId = this._config?.device_id;
+    if (!deviceId || this._ctx?.fake_device === true) return;
+
+    const path = `/config/devices/device/${encodeURIComponent(deviceId)}`;
+    window.history.pushState(null, "", path);
+    window.dispatchEvent(new Event("location-changed"));
+  }
+
+  _attachDeviceLinkHandler() {
+    const link = this.shadowRoot?.querySelector("[data-action='open-device']");
+    if (!link) return;
+
+    link.addEventListener("click", () => this._openDevicePage());
+    link.addEventListener("keydown", (event) => {
+      if (event.key !== "Enter" && event.key !== " ") return;
+      event.preventDefault();
+      this._openDevicePage();
+    });
+  }
+
   _headerMetrics() {
     if (!this._telemetryEnabled() || !this._ctx || !this._hass) return [];
 
@@ -1636,6 +1657,23 @@ class UnifiDeviceCard extends HTMLElement {
       .subtitle {
         font-size: 0.73rem;
         color: var(--udc-meta-color, var(--udc-muted));
+      }
+
+      .subtitle.device-link {
+        cursor: pointer;
+        width: fit-content;
+      }
+
+      .subtitle.device-link:hover,
+      .subtitle.device-link:focus-visible {
+        color: var(--primary-color, var(--udc-meta-color, var(--udc-muted)));
+        text-decoration: underline;
+      }
+
+      .subtitle.device-link:focus-visible {
+        outline: 2px solid var(--primary-color, currentColor);
+        outline-offset: 2px;
+        border-radius: 2px;
       }
 
       .meta-list {
@@ -3238,7 +3276,7 @@ class UnifiDeviceCard extends HTMLElement {
           <div class="header">
             <div class="header-info">
               ${headerTitle ? `<div class="title">${escapedHeaderTitle}</div>` : ""}
-              <div class="subtitle">${escapedSubtitle}</div>
+              <div class="subtitle device-link" data-action="open-device" role="link" tabindex="0">${escapedSubtitle}</div>
               ${headerMetrics.length ? `<div class="meta-list">${headerMetrics.map((item) => `
                 <div class="meta-row">
                   <div class="meta-label">${this._escapeHtml(item.label)}:</div>
@@ -3325,6 +3363,7 @@ class UnifiDeviceCard extends HTMLElement {
         </ha-card>`;
 
       this._attachPortActionHandlers(this._ctx);
+      this._attachDeviceLinkHandler();
       this.shadowRoot.querySelector("[data-action='toggle-led']")
         ?.addEventListener("click", () => this._toggleEntity(ledEntity));
 
@@ -3495,7 +3534,7 @@ class UnifiDeviceCard extends HTMLElement {
         <div class="header">
           <div class="header-info">
             ${headerTitle ? `<div class="title">${escapedHeaderTitle}</div>` : ""}
-            <div class="subtitle">${escapedSubtitle}</div>
+            <div class="subtitle device-link" data-action="open-device" role="link" tabindex="0">${escapedSubtitle}</div>
             ${headerMetrics.length ? `<div class="meta-list">${headerMetrics.map((item) => `
               <div class="meta-row">
                 <div class="meta-label">${this._escapeHtml(item.label)}:</div>
@@ -3518,6 +3557,8 @@ class UnifiDeviceCard extends HTMLElement {
 
     this.shadowRoot.querySelectorAll(".port")
       .forEach((btn) => btn.addEventListener("click", () => this._selectKey(btn.dataset.key)));
+
+    this._attachDeviceLinkHandler();
 
     this.shadowRoot.querySelector("[data-action='toggle-port']")
       ?.addEventListener("click", (e) => {


### PR DESCRIPTION
### Motivation
- Ermöglichen, dass ein Klick auf die zweite Zeile (Modell + Firmware) die zugehörige Home-Assistant-Geräteseite öffnet, um z.B. deaktivierte UniFi-Entitäten schneller zugänglich zu machen.
- Die Änderung soll barrierefrei funktionieren und Fake-Geräte ausnehmen, um unerwünschte Navigation zu vermeiden.

### Description
- Added an in-card link on the subtitle (model · FW) that navigates to `/config/devices/device/<device_id>` by calling `window.history.pushState` and dispatching `location-changed`, implemented in `src/unifi-device-card.js` via new methods `_openDevicePage()` and `_attachDeviceLinkHandler()` and guarded against `fake_device` contexts.
- Made the subtitle keyboard-accessible and semantic by adding `role="link"`, `tabindex="0"` and handling `Enter` / `Space` key events, and added visual focus/hover styles for `.subtitle.device-link` in the card CSS.
- Hooked the handler into every rendered header path (AP and non-AP flows) so the behavior is consistent across layouts, and preserved existing behavior for port actions and other header controls.
- Updated `README.md` and `CHANGELOG.md` to document the new direct device access feature.

### Testing
- Ran `git diff --check` with no reported issues. (passed)
- Performed a static syntax check with `node --check src/unifi-device-card.js`. (passed)
- Executed the project build with `npm run build` to ensure bundling still succeeds; the build completed successfully. (passed)
- No automated Home Assistant UI/browser tests were available in the repo, so manual UI verification in a running Home Assistant instance is recommended to confirm navigation and focus behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8949e437288333bb2b0ca7340826d7)