### PR TITLE
Expose PoE for Cloud Gateway Fiber port 4 and add v0.8.3 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [v0.8.3]
+
+### 🐛 Bug Fixes
+- Fix PoE controls and power telemetry being hidden for port 4 of the Cloud Gateway Fiber.
+
+### ✨ Hints
+
+I try to save money to get an Cloud Gateway Max in future to replace my Cloud Gateway Ultra, maybe then i could be able to add more feature to the card.
+
+If you see improvements, issues, or fixes, feel free to open an issue or create a pull request.
+
+If you like this project and want to support my work, you can donate via PayPal or buy me a coffee.
+
+<a href="https://www.paypal.me/bluenazgul">
+  <img
+    src="https://raw.githubusercontent.com/stefan-niedermann/paypal-donate-button/master/paypal-donate-button.png"
+    alt="Donate with PayPal"
+    width="220"
+  />
+</a>
+
+<a href="https://www.buymeacoffee.com/bluenazgul" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me a Coffee" style="height: 60px !important;width: 217px !important;" ></a>
+
 ## [v0.8.2]
 
 ### 🐛 Bug Fixes

--- a/src/model-registry.js
+++ b/src/model-registry.js
@@ -900,6 +900,7 @@ export const MODEL_REGISTRY = {
   UCGFIBER: {
     kind: "gateway", frontStyle: "gateway-single-row", rows: [[1, 2, 3, 4]],
     portCount: 7, displayModel: "Cloud Gateway Fiber", theme: "white",
+    poePortRange: [4, 4],
     specialSlots: [
       { key: "wan",   label: "WAN",      port: 5 },
       { key: "sfp_1", label: "SFP+ LAN", port: 6 },


### PR DESCRIPTION
### Motivation
- Ensure PoE controls and power telemetry are visible for port 4 of the Cloud Gateway Fiber model so the UI can show and control PoE for that port.
- Record the fix and some project support hints in the changelog under a new `v0.8.3` entry.

### Description
- Add `poePortRange: [4, 4]` to the `UCGFIBER` model in `src/model-registry.js` to mark port 4 as PoE-capable.
- Add a `v0.8.3` section to `CHANGELOG.md` documenting the bug fix and including the existing donation/hints content.

### Testing
- Ran the project's automated test suite and linter; all tests and lint checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8b415312e08333a93ae60b6da33ae2)