### PR TITLE
Map UACCMPOEAF to Device Bridge and enable integrated port support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [v0.8.4]
+
+### 🐛 Bug Fixes
+- Recognize the `UACCMPOEAF` model identifier reported by the UniFi Network integration as a Device Bridge (`UDB`) instead of rendering it as a generic round access point, and expose its discovered Ethernet/PoE port controls.
+
+### ✨ Hints
+
+I try to save money to get an Cloud Gateway Max in future to replace my Cloud Gateway Ultra, maybe then i could be able to add more feature to the card.
+
+If you see improvements, issues, or fixes, feel free to open an issue or create a pull request.
+
+If you like this project and want to support my work, you can donate via PayPal or buy me a coffee.
+
+<a href="https://www.paypal.me/bluenazgul">
+  <img
+    src="https://raw.githubusercontent.com/stefan-niedermann/paypal-donate-button/master/paypal-donate-button.png"
+    alt="Donate with PayPal"
+    width="220"
+  />
+</a>
+
+<a href="https://www.buymeacoffee.com/bluenazgul" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me a Coffee" style="height: 60px !important;width: 217px !important;" ></a>
+
 ## [v0.8.3]
 
 ### 🐛 Bug Fixes

--- a/src/model-registry.js
+++ b/src/model-registry.js
@@ -190,7 +190,7 @@ export const MODEL_REGISTRY = {
   UBBXG: apModel("UBB XG", { frontStyle: "ap-building-bridge", apEdgeGlow: true }),
   UMBBE634: apModel("UniFi 5G Backup", { frontStyle: "ap-5g-backup" }),
   UAIRWIRE: apModel("U-AirWire", { frontStyle: "ap-bridge" }),
-  UDB: apModel("Device Bridge", { frontStyle: "ap-device-bridge" }),
+  UDB: apModel("Device Bridge", { frontStyle: "ap-device-bridge", supportsIntegratedPorts: true }),
   UDBIOT: apModel("Device Bridge IoT", { frontStyle: "ap-device-bridge-iot" }),
   UDBSWITCH: apModel("Device Bridge Switch", { frontStyle: "ap-bridge" }),
   UDBPRO: apModel("Device Bridge Pro", { frontStyle: "ap-device-bridge-pro", apEdgeGlow: true }),
@@ -1121,6 +1121,7 @@ export function resolveModelKey(device) {
     if (candidate === "U7HD")                     return "UAPHD";
     if (candidate.includes("UMBBE634"))           return "UMBBE634";
     if (candidate.includes("UNIFI5GBACKUP"))      return "UMBBE634";
+    if (candidate.includes("UACCMPOEAF"))         return "UDB";
     if (candidate.includes("UAPACPRO"))           return "UAPACPRO";
     if (candidate.includes("UAPACIWPRO") || candidate.includes("UAPACINWALLPRO")) return "UAPACIWPRO";
     if (candidate.includes("UAPACIW"))            return "UAPACIW";


### PR DESCRIPTION
### Motivation
- UniFi devices reporting the `UACCMPOEAF` model identifier were rendered as a generic AP and did not expose discovered Ethernet/PoE port controls, so the model needs to be recognized as a Device Bridge (`UDB`).
- The changelog should record the fix and provide the usual release hints and donation links.

### Description
- Set `supportsIntegratedPorts: true` on the `UDB` entry in `src/model-registry.js` to enable integrated port support for Device Bridge models.
- Add a mapping in `resolveModelKey` to return `"UDB"` when the device candidate includes `"UACCMPOEAF"` so the device is resolved to the Device Bridge model.
- Update `CHANGELOG.md` to add a `v0.8.4` entry describing the bug fix and include the existing hints/donation content.

### Testing
- Ran project linting and the existing automated unit test suite; all checks passed.
- Verified no other model mappings or switch definitions were altered by the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8c9230f1508333bd678f4c0fab1943)