### PR TITLE
HACS-Validierung: Lesezugriff erlauben und automatische Kommentare deaktivieren

### DIFF
--- a/.github/workflows/hacs-validate.yml
+++ b/.github/workflows/hacs-validate.yml
@@ -5,7 +5,8 @@ on:
   pull_request:
   workflow_dispatch:
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   validate-hacs:
@@ -19,3 +20,4 @@ jobs:
         uses: hacs/action@main
         with:
           category: plugin
+          comment: false


### PR DESCRIPTION
### Motivation
- Die HACS-Validierung schlug fehl, weil `permissions: {}` dem `GITHUB_TOKEN` alle Berechtigungen entzog und die Action keinen Repository-Inhalt lesen konnte.
- Automatische PR-Kommentare sollen vermieden werden, damit der Workflow auch bei Fork-PRs ohne Schreibrechte am Token zuverlässig läuft.

### Description
- Aktualisiert `.github/workflows/hacs-validate.yml`, um `permissions: contents: read` zu setzen, damit die HACS-Action den Repository-Inhalt lesen kann.
- Deaktiviert automatische Kommentare der HACS Action durch Hinzufügen von `comment: false` zu den Action-Inputs.
- Es wurden keine Änderungen an `/src`, `/dist`, Dokumentation oder Screenshots vorgenommen.

### Testing
- `npm run build` wurde ausgeführt und erfolgreich beendet.
- `npm test --if-present` wurde ausgeführt und es sind keine Tests definiert, der Befehl endete erfolgreich.
- Alle Workflow-YAMLs wurden mit Rubys YAML-Parser geladen und validiert, was erfolgreich war.
- `git diff --check` zeigte keine Probleme; die geänderte Workflow-Datei wurde geprüft und ist syntaktisch korrekt.
- Ein Python-basierter YAML-Check mit `PyYAML` konnte nicht ausgeführt werden, da das `yaml`-Modul in der Umgebung fehlte (prüfen/Installieren ggf. notwendig).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8c9b07502083339b9168e2dce598c6)