### PR TITLE
CI: avoid HACS validation on feature-branch pushes and update checkout action

### DIFF
--- a/.github/workflows/hacs-validate.yml
+++ b/.github/workflows/hacs-validate.yml
@@ -2,6 +2,9 @@ name: HACS Validation
 
 on:
   push:
+    branches:
+      - main
+      - develop
   pull_request:
   workflow_dispatch:
 
@@ -14,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: HACS validation
         uses: hacs/action@main


### PR DESCRIPTION
### Motivation
- Prevent HACS validation from failing on feature-branch pushes (e.g. refs that HACS cannot read) by limiting push-triggered validation to release branches while keeping PR/manual validation available.

### Description
- Updated `.github/workflows/hacs-validate.yml` to restrict the `push` trigger to `main` and `develop` and to use `actions/checkout@v5` for compatibility with the runner environment, keeping the change scoped to the workflow only.

### Testing
- Ran `git diff --check` (passed), validated the workflow YAML with `ruby -e 'require "yaml"; YAML.parse_file(".github/workflows/hacs-validate.yml")'` (valid YAML), executed `npm run build` (succeeded), and verified there were no unintended changes to the committed `dist/unifi-device-card.js` file (no diff).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8c9c9818b08333a68b23bdbc4db844)