### PR TITLE
Improve spacing between card editor options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add an optional, collapsible editor setting for purely visual connected-port LED blinking with a configurable interval and no effect on link detection or controls.
 - Allow RJ45 and SFP link LEDs to be enabled independently and use separate sliders from 1 to 10 blinks per second (default 5); disabling both also disables the main blink option, while the shared legacy speed setting remains supported.
 - Translate all port LED animation controls into every language currently available in the card.
+- Restore consistent vertical spacing between editor fields, including the port LED animation and 10 Mbit/s link-speed options.
 
 ### ✨ Hints
 

--- a/src/unifi-device-card-editor.js
+++ b/src/unifi-device-card-editor.js
@@ -1062,6 +1062,12 @@ class UnifiDeviceCardEditor extends HTMLElement {
         gap: 14px;
       }
 
+      .main-step,
+      .color-step {
+        display: grid;
+        gap: 14px;
+      }
+
       .hidden {
         display: none;
       }


### PR DESCRIPTION
### Motivation
- The editor options for the 10 Mbit/s trust selector and the port LED blink controls appeared visually cramped in the editor; this change restores consistent vertical spacing so those options are clearer and less crowded.

### Description
- Add explicit grid layout and vertical gap for the editor step containers by updating `src/unifi-device-card-editor.js` to include `.main-step, .color-step { display: grid; gap: 14px; }`.
- Update `CHANGELOG.md` to document the visible editor spacing improvement.
- Only `/src` and the changelog were changed; no `/dist` or screenshot assets were modified.

### Testing
- Ran syntax check with `node --check src/unifi-device-card-editor.js` and it reported no errors.
- Ran the test runner with `node --test`, which completed with no failing tests (the repository contains no automated tests).
- Executed the build with `npm run build` and the build completed successfully.
- Performed repository verification checks and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8d83b9228c8333858fc422c6bf101e)