### PR TITLE
Prefer Home Assistant `model_id` and support singular config-entry fields (v0.8.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [v0.8.5]
+
+### ✨ Improvements
+- Support Home Assistant's singular device config-entry registry fields while retaining compatibility with older Home Assistant versions.
+- Prefer Home Assistant's stable device model identifier when recognizing supported UniFi access points, switches, gateways, and bridges.
+
+### ✨ Hints
+
+I try to save money to get an Cloud Gateway Max in future to replace my Cloud Gateway Ultra, maybe then i could be able to add more feature to the card.
+
+If you see improvements, issues, or fixes, feel free to open an issue or create a pull request.
+
+If you like this project and want to support my work, you can donate via PayPal or buy me a coffee.
+
+<a href="https://www.paypal.me/bluenazgul">
+  <img
+    src="https://raw.githubusercontent.com/stefan-niedermann/paypal-donate-button/master/paypal-donate-button.png"
+    alt="Donate with PayPal"
+    width="220"
+  />
+</a>
+
+<a href="https://www.buymeacoffee.com/bluenazgul" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me a Coffee" style="height: 60px !important;width: 217px !important;" ></a>
+
 ## [v0.8.4]
 
 ### 🐛 Bug Fixes

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -331,10 +331,10 @@ function isUnifiDevice(device, unifiEntryIds, entities) {
   if (isVirtualControllerDevice(device)) return false;
   const hasInfraSignals = hasInfrastructureEntitySignals(entities);
   const configEntryId = normalize(device?.config_entry_id);
-  const belongsToUnifiEntry = configEntryId
-    ? unifiEntryIds.has(configEntryId)
-    : Array.isArray(device?.config_entries) &&
-      device.config_entries.some((id) => unifiEntryIds.has(id));
+  const belongsToUnifiEntry =
+    unifiEntryIds.has(configEntryId) ||
+    (Array.isArray(device?.config_entries) &&
+      device.config_entries.some((id) => unifiEntryIds.has(id)));
 
   if (belongsToUnifiEntry) {
     if (hasInfraSignals || !!resolveModelKey(device)) return true;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -133,7 +133,7 @@ function hasIndexedPortId(entityId) {
 }
 
 function modelStartsWith(device, prefixes) {
-  const candidates = [device?.model, device?.hw_version]
+  const candidates = [device?.model_id, device?.model, device?.hw_version]
     .filter(Boolean)
     .map(normalizeModelStr);
 
@@ -330,11 +330,13 @@ export async function getAllData(hass) {
 function isUnifiDevice(device, unifiEntryIds, entities) {
   if (isVirtualControllerDevice(device)) return false;
   const hasInfraSignals = hasInfrastructureEntitySignals(entities);
+  const configEntryId = normalize(device?.config_entry_id);
+  const belongsToUnifiEntry = configEntryId
+    ? unifiEntryIds.has(configEntryId)
+    : Array.isArray(device?.config_entries) &&
+      device.config_entries.some((id) => unifiEntryIds.has(id));
 
-  if (
-    Array.isArray(device?.config_entries) &&
-    device.config_entries.some((id) => unifiEntryIds.has(id))
-  ) {
+  if (belongsToUnifiEntry) {
     if (hasInfraSignals || !!resolveModelKey(device)) return true;
 
     if (

--- a/src/identity.js
+++ b/src/identity.js
@@ -52,12 +52,15 @@ export function extractPrimaryMacFromConnections(connections) {
 export function buildNormalizedDeviceIdentity(device) {
   return {
     device_id: device?.id || null,
+    model_id: normalizeText(device?.model_id),
     model: normalizeText(device?.model),
     manufacturer: normalizeText(device?.manufacturer),
     name: normalizeText(device?.name_by_user || device?.name),
     hw_version: normalizeText(device?.hw_version),
     sw_version: normalizeText(device?.sw_version),
     primary_mac: extractPrimaryMacFromConnections(device?.connections),
+    config_entry_id: device?.config_entry_id || null,
+    config_subentry_id: device?.config_subentry_id || null,
     config_entries: Array.isArray(device?.config_entries) ? device.config_entries : [],
   };
 }

--- a/src/model-registry.js
+++ b/src/model-registry.js
@@ -40,7 +40,7 @@ export const AP_FRONT_STYLES = new Set([
 ]);
 
 function modelStartsWith(device, prefixes) {
-  const candidates = [device?.model, device?.hw_version]
+  const candidates = [device?.model_id, device?.model, device?.hw_version]
     .filter(Boolean)
     .map(normalizeModelKey);
 
@@ -48,7 +48,7 @@ function modelStartsWith(device, prefixes) {
 }
 
 function isAccessPointLikeModel(device) {
-  const candidates = [device?.model, device?.hw_version]
+  const candidates = [device?.model_id, device?.model, device?.hw_version]
     .filter(Boolean)
     .map(normalizeModelKey);
 
@@ -1085,7 +1085,7 @@ export function validateModelRegistry() {
 }
 
 export function resolveModelKey(device) {
-  const candidates = [device?.model, device?.hw_version, device?.name, device?.name_by_user]
+  const candidates = [device?.model_id, device?.model, device?.hw_version, device?.name, device?.name_by_user]
     .filter(Boolean)
     .map(normalizeModelKey);
 


### PR DESCRIPTION
### Motivation
- Home Assistant can expose a stable `model_id` and singular `config_entry_id` fields on device registry entries, which improves device recognition reliability.
- Keep backward compatibility with older HA versions that only expose arrays like `config_entries` while improving model/device identification for UniFi devices.

### Description
- Prefer `model_id` as a candidate in model normalization and matching in `model-registry.js` and `helpers.js` so model lookups detect the HA stable identifier. 
- Include `model_id`, `config_entry_id`, and `config_subentry_id` in the normalized device identity in `identity.js` and keep `config_entries` array handling for compatibility. 
- Update `isUnifiDevice` in `helpers.js` to accept both singular `config_entry_id` and array `config_entries` when deciding whether a device belongs to a UniFi config entry, and use that membership when combining infra signals and model resolution. 
- Add changelog entry for `v0.8.5` with release notes and donation hints in `CHANGELOG.md`.

### Testing
- Ran the test suite with `npm test`, and all tests completed successfully. 
- Built the project with `npm run build` to verify bundling/type checks, and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a92926422708333903f81af338b5842)