### PR TITLE
Harden develop for HA child devices and automated scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    target-branch: develop
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    target-branch: develop
+    open-pull-requests-limit: 5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,36 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - develop
+  schedule:
+    - cron: "23 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: javascript-typescript
+          queries: security-extended
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'schedule' && 'develop' || github.ref }}
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/compatibility-tests.yml
+++ b/.github/workflows/compatibility-tests.yml
@@ -1,0 +1,29 @@
+name: Registry Compatibility Tests
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - develop
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  child-device-regression:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+
+      - name: Run child-device compatibility test
+        run: node tests/child-device.mjs

--- a/.github/workflows/hacs-validate.yml
+++ b/.github/workflows/hacs-validate.yml
@@ -6,6 +6,8 @@ on:
       - main
       - develop
   pull_request:
+  schedule:
+    - cron: "17 2 * * *"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,29 @@
+name: ESLint
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - develop
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+
+      - name: Run ESLint
+        run: npx --yes eslint@9 src build.js

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,24 @@
+export default [
+  {
+    files: ["src/**/*.js", "build.js"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+    },
+    rules: {
+      "no-dupe-args": "error",
+      "no-dupe-else-if": "error",
+      "no-dupe-keys": "error",
+      "no-duplicate-case": "error",
+      "no-func-assign": "error",
+      "no-import-assign": "error",
+      "no-obj-calls": "error",
+      "no-unreachable": "error",
+      "no-unreachable-loop": "error",
+      "no-unsafe-finally": "error",
+      "no-unsafe-negation": "error",
+      "use-isnan": "error",
+      "valid-typeof": "error"
+    }
+  }
+];

--- a/src/classify.js
+++ b/src/classify.js
@@ -25,6 +25,14 @@ function fromModel(model) {
 }
 
 export function classifyDeviceType(identity, capabilities, entities = [], device = null) {
+  // HA 2026.9+ returns logical child devices in config/device_registry/list.
+  // They belong to the same config entry as their parent but intentionally do
+  // not carry their own hardware identity. Do not classify them as standalone
+  // UniFi infrastructure devices, even if their entities look port-like.
+  if (identity?.is_child_device || identity?.parent_device_id || device?.parent_device_id) {
+    return "unknown";
+  }
+
   const model = normalizeModel(identity?.model || identity?.hw_version || "");
   const manufacturer = String(identity?.manufacturer || "").toLowerCase();
   const name = String(identity?.name || "").toLowerCase();

--- a/src/identity.js
+++ b/src/identity.js
@@ -50,8 +50,11 @@ export function extractPrimaryMacFromConnections(connections) {
 }
 
 export function buildNormalizedDeviceIdentity(device) {
+  const parentDeviceId = device?.parent_device_id || null;
   return {
     device_id: device?.id || null,
+    parent_device_id: parentDeviceId,
+    is_child_device: !!parentDeviceId,
     model_id: normalizeText(device?.model_id),
     model: normalizeText(device?.model),
     manufacturer: normalizeText(device?.manufacturer),
@@ -90,6 +93,10 @@ export function findDeviceByMac(devices, mac) {
   if (!normalized) return null;
 
   for (const device of devices || []) {
+    // Home Assistant child devices are logical parts of a physical parent and
+    // do not carry their own hardware identity. Never resolve them as the
+    // physical UniFi device for a MAC-based lookup.
+    if (device?.parent_device_id) continue;
     const macs = extractDeviceMacs(device);
     if (macs.has(normalized)) return device;
   }

--- a/tests/child-device.mjs
+++ b/tests/child-device.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+
+import { classifyDeviceType } from "../src/classify.js";
+import {
+  buildNormalizedDeviceIdentity,
+  findDeviceByMac,
+} from "../src/identity.js";
+
+const parentId = "unifi-switch-parent";
+const child = {
+  id: "child-client-or-logical-part",
+  parent_device_id: parentId,
+  config_entry_id: "unifi-config-entry",
+  name: "Child device",
+  identifiers: [["unifi", "aa:bb:cc:dd:ee:ff"]],
+};
+
+const identity = buildNormalizedDeviceIdentity(child);
+assert.equal(identity.parent_device_id, parentId);
+assert.equal(identity.is_child_device, true);
+assert.equal(
+  classifyDeviceType(
+    identity,
+    { ports: true, port_control: true, poe_power: true },
+    [
+      {
+        entity_id: "switch.child_port_1",
+        translation_key: "port_control",
+      },
+    ],
+    child
+  ),
+  "unknown",
+  "Home Assistant child devices must never be classified as standalone UniFi infrastructure"
+);
+
+const physicalDevice = {
+  id: "physical-unifi-device",
+  connections: [["mac", "aa:bb:cc:dd:ee:ff"]],
+};
+
+assert.equal(
+  findDeviceByMac([child, physicalDevice], "aa:bb:cc:dd:ee:ff")?.id,
+  physicalDevice.id,
+  "MAC lookup must prefer/return a physical device and skip child devices"
+);
+
+console.log("Child-device registry compatibility checks passed.");


### PR DESCRIPTION
### Motivation
Home Assistant 2026.9 adds child devices to `config/device_registry/list`. These logical entries share their parent's config entry but must not be treated as standalone UniFi infrastructure devices. The repository also benefits from broader automated validation beyond the existing build/HACS check.

### Changes
- carry `parent_device_id` / `is_child_device` in normalized device identity
- classify HA child devices as `unknown`, even when their entities look port-like
- skip child devices during MAC-based physical-device resolution
- add a regression test for child-device classification and MAC lookup
- add CodeQL `security-extended` scanning for JavaScript
- add lightweight ESLint correctness checks
- add Dependabot updates for npm and GitHub Actions targeting `develop`
- run HACS validation daily in addition to push/PR/manual runs

### Notes
- SonarQube/SonarCloud intentionally not added.
- `esbuild` is not changed manually in this PR because `package-lock.json` must stay consistent; the new Dependabot npm configuration will propose the dependency update against `develop` with a correctly regenerated lockfile.
- OpenSSF Scorecard is intentionally not added to this develop-targeted PR because its supported push/schedule mode is for the repository default branch (`main`). It can be added once the workflow is intended to live on the default branch.

### Validation
The PR adds dedicated CI for the child-device regression, ESLint, CodeQL, and keeps the existing HACS/build checks active.