### PR TITLE
Reject child devices early in isUnifiDevice()

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -328,6 +328,7 @@ export async function getAllData(hass) {
 }
 
 function isUnifiDevice(device, unifiEntryIds, entities) {
+  if (device.parent_device_id) return false;
   if (isVirtualControllerDevice(device)) return false;
   const hasInfraSignals = hasInfrastructureEntitySignals(entities);
   const configEntryId = normalize(device?.config_entry_id);


### PR DESCRIPTION
### Motivation
- Make child-device filtering explicit and fail-fast by rejecting devices that have a `parent_device_id` at the earliest discovery entry point to avoid relying solely on later identity/classification rules.

### Description
- Add a fail-fast guard `if (device.parent_device_id) return false;` at the top of `isUnifiDevice()` in `src/helpers.js` to immediately exclude Home Assistant child devices.

### Testing
- Ran `node tests/child-device.mjs` which passed. 
- Ran lint with `npx --yes eslint@9 src build.js` which passed. 
- Ran the build with `npm run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a94016a3960833387b50f6507fd5d84)