### PR TITLE
docs: clarify Home Assistant registry compatibility in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@
 ## [v0.8.5]
 
 ### 🐛 Bug Fixes
-- Exclude logical Home Assistant child devices from standalone UniFi device discovery.
+- Adapt standalone UniFi device discovery to the Home Assistant 2026.9 device-registry changes by excluding logical child devices.
 
 ### ✨ Improvements
-- Support Home Assistant's singular device config-entry registry fields while retaining compatibility with older Home Assistant versions.
-- Prefer Home Assistant's stable device model identifier when recognizing supported UniFi access points, switches, gateways, and bridges.
+- Adapt device recognition to the Home Assistant 2026.9 registry changes by preferring Home Assistant's stable device model identifier for supported UniFi access points, switches, gateways, and bridges.
+- Prepare for the Home Assistant 2027.8 removal of `config_entries` by using `config_entry_id` as its replacement, while retaining `config_entries` as a fallback for older Home Assistant versions.
 
 ### ✨ Hints
 


### PR DESCRIPTION
### Motivation
- Clarify that the standalone-device discovery bugfix and device-recognition improvements target Home Assistant 2026.9 registry changes and that the project is preparing for Home Assistant 2027.8 where `config_entry_id` replaces `config_entries` while keeping `config_entries` as a fallback.

### Description
- Update `CHANGELOG.md` to explicitly state the adaptation to Home Assistant 2026.9 device-registry behavior and the upcoming 2027.8 transition from `config_entries` to `config_entry_id`, with no code changes in `/src` or generated artifacts in `/dist`.

### Testing
- Ran `git diff --check` which reported no issues, and this is a documentation-only change so project build/lint/tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a940b0c39188333885d5257264b884c)