### PR TITLE
 Add YAML-only LAG groups support with visual badges and normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [v0.8.6]
+
+### ✨ Improvements
+- Add optional YAML-only `lag_groups` configuration for visually identifying manually grouped LAG member ports without changing their individual telemetry-derived states.
+
+### ✨ Hints
+
+If you see improvements, issues, or fixes, feel free to open an issue or create a pull request.
+
+If you like this project and want to support my work, you can donate via PayPal or buy me a coffee.
+
+<a href="https://www.paypal.me/bluenazgul">
+  <img
+    src="https://raw.githubusercontent.com/stefan-niedermann/paypal-donate-button/master/paypal-donate-button.png"
+    alt="Donate with PayPal"
+    width="220"
+  />
+</a>
+
+<a href="https://www.buymeacoffee.com/bluenazgul" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me a Coffee" style="height: 60px !important;width: 217px !important;" ></a>
+
 ## [v0.8.5]
 
 ### 🐛 Bug Fixes

--- a/README.md
+++ b/README.md
@@ -312,6 +312,11 @@ trust_link_speed_ports:        # optional (switch/gateway and compatible integra
 port_name:                     # optional custom names for tooltips and port details
   1: Uplink
   3: AP
+lag_groups:                    # optional YAML-only visual LAG grouping
+  - name: NAS
+    ports:
+      - 11
+      - 12
 wan_port: auto                # optional (gateway only)
 wan2_port: none               # optional (gateway only)
 ```
@@ -367,6 +372,7 @@ wan2_port: none               # optional (gateway only)
 | `special_ports` | array<number> | auto | Switch/Gateway only: explicit port numbers shown in the top special row; non-selected ports render in the normal grid. |
 | `trust_link_speed_ports` | array<number> | `[]` | Ports whose positive link-speed value is trusted even at 10 Mbit/s. By default, the RJ45 ghost-link guard treats speeds up to and including 10 Mbit/s as disconnected when no link, traffic, client, or PoE signal confirms the connection. Select only ports with a genuine 10 Mbit/s link; `0`, `unknown`, and `unavailable` remain disconnected. |
 | `port_name` | object | `{}` | Optional port-number-to-name mapping for tooltips and detail headings. Front-panel port numbers remain unchanged. |
+| `lag_groups` | array<object> | `[]` | YAML-only visual grouping for LAG members. Each group requires at least two unique positive port numbers and may have a `name`; configured members receive a `LAG` badge and group name without changing their independently detected link, speed, traffic, or PoE states. A port can belong to only the first valid configured group. |
 | `wan_port` | string | auto | Gateway only: assign WAN role (`auto`, slot key like `wan`, or `port_<n>`). |
 | `wan2_port` | string | auto | Gateway only: assign WAN2 role (`auto`, `none`, slot key, or `port_<n>`). |
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -51,6 +51,46 @@ export function normalizePortNames(value) {
   return normalized;
 }
 
+export function normalizeLagGroups(value) {
+  if (!Array.isArray(value)) return [];
+
+  const assignedPorts = new Set();
+  const groups = [];
+
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
+
+    const ports = normalizePositivePortNumbers(entry.ports)
+      .filter((port) => !assignedPorts.has(port));
+    if (ports.length < 2) continue;
+
+    const name = typeof entry.name === "string" ? entry.name.trim() : "";
+    const normalized = { name: name || `LAG ${groups.length + 1}`, ports };
+    groups.push(normalized);
+    ports.forEach((port) => assignedPorts.add(port));
+  }
+
+  return groups;
+}
+
+export function applyLagGroups(slotData, lagGroups) {
+  const groupsByPort = new Map();
+  normalizeLagGroups(lagGroups).forEach((group, index) => {
+    const metadata = { ...group, index: index + 1 };
+    group.ports.forEach((port) => groupsByPort.set(port, metadata));
+  });
+
+  const apply = (slots) => (slots || []).map((slot) => {
+    const lag_group = groupsByPort.get(slot?.port);
+    return lag_group ? { ...slot, lag_group } : slot;
+  });
+
+  return {
+    specials: apply(slotData?.specials),
+    numbered: apply(slotData?.numbered),
+  };
+}
+
 export function applyPortNames(slotData, portNames) {
   const normalized = normalizePortNames(portNames);
   const apply = (slots) => (slots || []).map((slot) => {

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -1,4 +1,5 @@
 import {
+  applyLagGroups,
   applyPortNames,
   applyGatewayPortOverrides,
   discoverSpecialPorts,
@@ -18,6 +19,7 @@ import {
   mergePortsWithLayout,
   mergeSpecialsWithLayout,
   normalizePositivePortNumbers,
+  normalizeLagGroups,
   normalizePortNames,
   parseLinkSpeedMbit,
   stateObj,
@@ -211,6 +213,12 @@ class UnifiDeviceCard extends HTMLElement {
       newConfig.port_name = portNames;
     } else {
       delete newConfig.port_name;
+    }
+    const lagGroups = normalizeLagGroups(newConfig.lag_groups);
+    if (lagGroups.length) {
+      newConfig.lag_groups = lagGroups;
+    } else {
+      delete newConfig.lag_groups;
     }
     const newDeviceId = newConfig?.device_id || null;
     const newFakeMode = newConfig?.fake_device === true;
@@ -974,15 +982,18 @@ class UnifiDeviceCard extends HTMLElement {
     this._applyManualPortSensorOverrides(numberedRaw, specialsRaw);
 
     if (ctx?.type === "gateway") {
-      return applyPortNames(applyGatewayPortOverrides(
+      return applyLagGroups(applyPortNames(applyGatewayPortOverrides(
         this._config,
         specialsRaw,
         numberedRaw,
         ctx?.layout
-      ), this._config?.port_name);
+      ), this._config?.port_name), this._config?.lag_groups);
     }
 
-    return applyPortNames({ specials: specialsRaw, numbered: numberedRaw }, this._config?.port_name);
+    return applyLagGroups(
+      applyPortNames({ specials: specialsRaw, numbered: numberedRaw }, this._config?.port_name),
+      this._config?.lag_groups
+    );
   }
 
   _relevantStateEntityIds() {
@@ -1588,6 +1599,7 @@ class UnifiDeviceCard extends HTMLElement {
     const mergedCount = Math.max(clientInfo?.count || 0, indexedCount);
     const tooltip = [
       slot.port_label || (isSpecial ? slot.label : `${this._t("port_label")} ${slot.label}`),
+      slot.lag_group ? `LAG: ${slot.lag_group.name}` : null,
       this._translateState(linkUp ? "connected" : "no_link"),
       linkUp ? getPortSpeedText(this._hass, slot) : null,
       poeOn ? `${this._t("poe")}${poeStatus.power ? ` ${poeStatus.power}` : " ON"}` : null,
@@ -1640,6 +1652,7 @@ class UnifiDeviceCard extends HTMLElement {
     return `<button class="${this._escapeAttr(classes)}" data-key="${this._escapeAttr(slot.key)}" title="${this._escapeAttr(tooltip)}">
       <div class="port-housing">
         ${housing}
+        ${slot.lag_group ? `<span class="lag-badge" aria-label="${this._escapeAttr(`LAG: ${slot.lag_group.name}`)}">LAG${slot.lag_group.index}</span>` : ""}
       </div>
       <div class="port-num">${this._escapeHtml(slot.label)}</div>
     </button>`;
@@ -2715,11 +2728,29 @@ class UnifiDeviceCard extends HTMLElement {
       }
 
       .port-housing {
+        position: relative;
         width: 100%;
         display: flex;
         justify-content: center;
         align-items: flex-start;
         transition: opacity .15s ease, filter .15s ease;
+      }
+
+      .lag-badge {
+        position: absolute;
+        top: -3px;
+        right: -2px;
+        z-index: 8;
+        padding: 1px 2px;
+        border-radius: 2px;
+        background: var(--udc-accent);
+        color: #fff;
+        font-size: 5px;
+        font-weight: 800;
+        line-height: 1.2;
+        letter-spacing: .15px;
+        box-shadow: 0 0 0 1px rgba(0,0,0,.35);
+        pointer-events: none;
       }
 
       .port.rotated180 .port-housing {
@@ -3060,6 +3091,18 @@ class UnifiDeviceCard extends HTMLElement {
         color: var(--udc-special-port-label-color, var(--primary-text-color, var(--udc-text)));
       }
 
+      .detail-lag-badge {
+        display: inline-block;
+        margin-left: 5px;
+        padding: 2px 5px;
+        border-radius: 3px;
+        background: var(--udc-accent);
+        color: #fff;
+        font-size: .62rem;
+        line-height: 1.2;
+        vertical-align: 1px;
+      }
+
       .detail-grid {
         display: grid;
         grid-template-columns: 1fr 1fr;
@@ -3207,7 +3250,7 @@ class UnifiDeviceCard extends HTMLElement {
       || (selected.kind === "special" ? selected.label : `${this._t("port_label")} ${selected.label}`);
 
     return `
-      <div class="detail-title">${this._escapeHtml(portTitle)}</div>
+      <div class="detail-title">${this._escapeHtml(portTitle)}${selected.lag_group ? ` <span class="detail-lag-badge">LAG · ${this._escapeHtml(selected.lag_group.name)}</span>` : ""}</div>
       <div class="detail-grid">
         <div class="detail-item">
           <div class="detail-label">${this._escapeHtml(this._t("link_status"))}</div>
@@ -3558,7 +3601,7 @@ class UnifiDeviceCard extends HTMLElement {
         || (selected.kind === "special" ? selected.label : `${this._t("port_label")} ${selected.label}`);
 
       detail = `
-        <div class="detail-title">${this._escapeHtml(portTitle)}</div>
+        <div class="detail-title">${this._escapeHtml(portTitle)}${selected.lag_group ? ` <span class="detail-lag-badge">LAG · ${this._escapeHtml(selected.lag_group.name)}</span>` : ""}</div>
         <div class="detail-grid">
           <div class="detail-item">
             <div class="detail-label">${this._escapeHtml(this._t("link_status"))}</div>

--- a/src/unifi-device-card.js
+++ b/src/unifi-device-card.js
@@ -2757,6 +2757,10 @@ class UnifiDeviceCard extends HTMLElement {
         transform: rotate(180deg);
       }
 
+      .port.rotated180 .lag-badge {
+        transform: rotate(180deg);
+      }
+
       .port.down .port-housing {
         opacity: .42;
         filter: saturate(.45) brightness(.78);

--- a/tests/lag-groups.mjs
+++ b/tests/lag-groups.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+
+import { applyLagGroups, normalizeLagGroups } from "../src/helpers.js";
+
+assert.deepEqual(
+  normalizeLagGroups([{ name: " NAS ", ports: [12, 11, 11, 0, "invalid"] }]),
+  [{ name: "NAS", ports: [11, 12] }],
+  "LAG groups should normalize names and unique positive port numbers"
+);
+
+assert.deepEqual(
+  normalizeLagGroups([
+    { ports: [1, 2] },
+    { name: "Duplicate", ports: [2, 3] },
+    { name: "Second", ports: [3, 4] },
+  ]),
+  [
+    { name: "LAG 1", ports: [1, 2] },
+    { name: "Second", ports: [3, 4] },
+  ],
+  "a port should only belong to the first valid configured group"
+);
+
+assert.deepEqual(normalizeLagGroups(null), [], "non-array configuration should be ignored");
+assert.deepEqual(normalizeLagGroups([{ name: "Solo", ports: [1] }]), [], "single-port groups should be ignored");
+
+const slots = applyLagGroups(
+  {
+    specials: [{ port: 10, key: "sfp_1" }],
+    numbered: [{ port: 1, key: "port-1" }, { port: 2, key: "port-2" }, { port: 3, key: "port-3" }],
+  },
+  [{ name: "NAS", ports: [1, 2] }]
+);
+
+assert.equal(slots.numbered[0].lag_group.name, "NAS");
+assert.deepEqual(slots.numbered[1].lag_group.ports, [1, 2]);
+assert.equal(slots.numbered[2].lag_group, undefined);
+assert.equal(slots.specials[0].lag_group, undefined);
+
+console.log("LAG group tests passed.");


### PR DESCRIPTION
### Motivation

- Provide an optional YAML-only way to visually identify manually grouped LAG member ports without changing runtime telemetry-derived states. 
- Surface group metadata in the UI so users can see LAG assignment as a badge on front-panel ports and in port details.

### Description

- Add `lag_groups` documentation to `README.md` and a changelog entry in `CHANGELOG.md` describing the feature and behavior. 
- Implement `normalizeLagGroups` and `applyLagGroups` in `src/helpers.js` to validate, deduplicate, and assign LAG metadata while preventing a port from belonging to multiple groups. 
- Wire normalization into `setConfig` and apply groups in `_buildSlotData` so `lag_group` metadata is merged with port slots for both gateway and non-gateway devices. 
- Render a compact `LAG` badge on port buttons and a larger badge in the detail view, and add associated CSS styles in `src/unifi-device-card.js`.

### Testing

- Added `tests/lag-groups.mjs` unit tests validating `normalizeLagGroups` and `applyLagGroups`. 
- Ran `node tests/lag-groups.mjs` and the tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a948a071f988333820ffa739b4a6e14)