### PR TITLE
Recognize Home Assistant `UHDIW` as UAP In‑Wall HD and add layout/tests

### DIFF
--- a/.github/workflows/compatibility-tests.yml
+++ b/.github/workflows/compatibility-tests.yml
@@ -27,3 +27,6 @@ jobs:
 
       - name: Run child-device compatibility test
         run: node tests/child-device.mjs
+
+      - name: Run model-alias compatibility test
+        run: node tests/model-aliases.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [v0.8.7]
 
+### 🐛 Bug Fixes
+- Recognize the `UHDIW` model identifier reported by Home Assistant as a UAP In-Wall HD, with PoE output on port 1 and the uplink/PoE input assigned to port 4.
+
 ### ✨ Improvements
 - Extend initial port selection to compatible access points with integrated switches and translate the related editor controls into every language available in the card.
 

--- a/src/classify.js
+++ b/src/classify.js
@@ -1,6 +1,7 @@
 import {
   AP_MODEL_PREFIXES,
   GATEWAY_MODEL_PREFIXES,
+  MODEL_REGISTRY,
   resolveModelKey,
   SWITCH_MODEL_PREFIXES,
 } from "./model-registry.js";
@@ -59,6 +60,11 @@ export function classifyDeviceType(identity, capabilities, entities = [], device
   const hasPortSignals = !!(capabilities?.ports || capabilities?.port_control || capabilities?.poe_power);
 
   if (modelKey) {
+    const resolvedModelType = MODEL_REGISTRY[modelKey]?.kind;
+    if (["gateway", "switch", "access_point"].includes(resolvedModelType)) {
+      return resolvedModelType;
+    }
+
     if (gatewayModelKeys.includes(modelKey)) {
       return "gateway";
     }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1725,6 +1725,15 @@ function stripPoeEntities(port) {
   };
 }
 
+function hasKnownPoeRange(layout) {
+  return (
+    Array.isArray(layout?.poePortRange) &&
+    layout.poePortRange.length === 2 &&
+    Number.isInteger(layout.poePortRange[0]) &&
+    Number.isInteger(layout.poePortRange[1])
+  );
+}
+
 export function mergePortsWithLayout(layout, discoveredPorts) {
   const byPort = new Map(discoveredPorts.map((p) => [p.port, p]));
   const layoutPorts = (layout?.rows || []).flat();
@@ -1734,11 +1743,7 @@ export function mergePortsWithLayout(layout, discoveredPorts) {
   );
 
   const merged = [];
-  const hasKnownPoeRange =
-    Array.isArray(layout?.poePortRange) &&
-    layout.poePortRange.length === 2 &&
-    Number.isInteger(layout.poePortRange[0]) &&
-    Number.isInteger(layout.poePortRange[1]);
+  const hasDeclaredPoeRange = hasKnownPoeRange(layout);
 
   for (const portNumber of layoutPorts) {
     if (specialPortNumbers.has(portNumber)) continue;
@@ -1763,7 +1768,7 @@ export function mergePortsWithLayout(layout, discoveredPorts) {
       port_label: null,
     };
 
-    merged.push(hasKnownPoeRange && !hasPoe ? stripPoeEntities(port) : port);
+    merged.push(hasDeclaredPoeRange && !hasPoe ? stripPoeEntities(port) : port);
   }
 
   for (const port of discoveredPorts) {
@@ -1784,12 +1789,17 @@ export function mergeSpecialsWithLayout(layout, discoveredSpecials, discoveredPo
   const byPort = new Map(discoveredPorts.map((p) => [p.port, p]));
   const layoutSpecials = layout?.specialSlots || [];
 
+  const applyPoeCapabilities = (slot, port) =>
+    hasKnownPoeRange(layout) && !portHasPoe(slot.port ?? port.port, layout)
+      ? stripPoeEntities(port)
+      : port;
+
   const merged = layoutSpecials.map((slot) => {
     const discoveryPort = slot.apiPort ?? slot.port;
     if (discoveryPort != null) {
       const portData = byPort.get(discoveryPort);
       if (portData) {
-        return {
+        return applyPoeCapabilities(slot, {
           ...portData,
           key: slot.key,
           physical_key: slot.key,
@@ -1798,13 +1808,13 @@ export function mergeSpecialsWithLayout(layout, discoveredSpecials, discoveredPo
           row: slot.row,
           kind: "special",
           port: slot.port ?? portData.port,
-        };
+        });
       }
     }
 
     const keyData = byKey.get(slot.key);
     if (keyData) {
-      return {
+      return applyPoeCapabilities(slot, {
         ...keyData,
         key: slot.key,
         physical_key: slot.key,
@@ -1813,7 +1823,7 @@ export function mergeSpecialsWithLayout(layout, discoveredSpecials, discoveredPo
         row: slot.row,
         kind: "special",
         port: slot.port ?? keyData.port ?? null,
-      };
+      });
     }
 
     return {

--- a/src/model-registry.js
+++ b/src/model-registry.js
@@ -146,7 +146,14 @@ export const MODEL_REGISTRY = {
   UAPIW: apModel("UniFi AP In-Wall", { frontStyle: "ap-in-wall", supportsIntegratedPorts: true }),
   UAPACIW: apModel("UAP AC In-Wall", { frontStyle: "ap-in-wall", supportsIntegratedPorts: true }),
   UAPACIWPRO: apModel("UAP AC In-Wall Pro", { frontStyle: "ap-in-wall", supportsIntegratedPorts: true }),
-  UAPIWHD: apModel("UAP In-Wall HD", { frontStyle: "ap-in-wall", supportsIntegratedPorts: true }),
+  UAPIWHD: apModel("UAP In-Wall HD", {
+    frontStyle: "ap-in-wall",
+    rows: [range(1, 3)],
+    portCount: 4,
+    poePortRange: [1, 1],
+    specialSlots: [{ key: "uplink", label: "Uplink / PoE-In", port: 4, media: "rj45" }],
+    supportsIntegratedPorts: true,
+  }),
   UAPACM: apModel("UAP AC Mesh", { frontStyle: "ap-ac-mesh" }),
   UAPACMPRO: apModel("UAP AC Mesh Pro", { frontStyle: "ap-outdoor-panel" }),
   UAPNANOHD: apModel("UAP nanoHD"),
@@ -1125,7 +1132,7 @@ export function resolveModelKey(device) {
     if (candidate.includes("UAPACPRO"))           return "UAPACPRO";
     if (candidate.includes("UAPACIWPRO") || candidate.includes("UAPACINWALLPRO")) return "UAPACIWPRO";
     if (candidate.includes("UAPACIW"))            return "UAPACIW";
-    if (candidate.includes("UAPIWHD") || candidate.includes("UAPINWALLHD")) return "UAPIWHD";
+    if (candidate === "UHDIW" || candidate.includes("UAPIWHD") || candidate.includes("UAPINWALLHD")) return "UAPIWHD";
     if (candidate === "UAPIW" || candidate.includes("UNIFIAPINWALL")) return "UAPIW";
     if (candidate.includes("UAPAC"))              return "UAPAC";
     if (candidate.includes("UAPNANOHD"))          return "UAPNANOHD";

--- a/tests/model-aliases.mjs
+++ b/tests/model-aliases.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+
+import { mergePortsWithLayout, mergeSpecialsWithLayout } from "../src/helpers.js";
+import { getDeviceLayout, resolveModelKey } from "../src/model-registry.js";
+
+const inWallHd = {
+  model_id: "UHDIW",
+  model: "UniFi Access Point",
+  name: "IW HD",
+};
+
+assert.equal(
+  resolveModelKey(inWallHd),
+  "UAPIWHD",
+  "Home Assistant's UHDIW identifier must resolve to the UAP In-Wall HD registry entry"
+);
+
+assert.deepEqual(
+  getDeviceLayout(inWallHd),
+  {
+    kind: "access_point",
+    frontStyle: "ap-in-wall",
+    rows: [[1, 2, 3]],
+    portCount: 4,
+    displayModel: "UAP In-Wall HD",
+    theme: "white",
+    specialSlots: [{ key: "uplink", label: "Uplink / PoE-In", port: 4, media: "rj45" }],
+    poePortRange: [1, 1],
+    supportsIntegratedPorts: true,
+    modelKey: "UAPIWHD",
+    rj45_odd_even: false,
+  },
+  "UHDIW must retain the UAP In-Wall HD layout and integrated-port support"
+);
+
+const layout = getDeviceLayout(inWallHd);
+const discoveredPorts = [1, 2, 3, 4].map((port) => ({
+  key: `port-${port}`,
+  port,
+  label: String(port),
+  poe_switch_entity: `switch.iw_hd_data_${port}_poe`,
+  poe_power_entity: `sensor.iw_hd_data_${port}_poe_power`,
+}));
+const mergedPorts = mergePortsWithLayout(layout, discoveredPorts);
+const mergedSpecials = mergeSpecialsWithLayout(layout, [], discoveredPorts);
+
+assert.deepEqual(
+  mergedPorts.map((port) => port.port),
+  [1, 2, 3],
+  "Ports 1 through 3 must remain numbered LAN ports"
+);
+assert.equal(mergedPorts[0].poe_switch_entity, "switch.iw_hd_data_1_poe");
+assert.equal(mergedPorts[0].poe_power_entity, "sensor.iw_hd_data_1_poe_power");
+for (const port of mergedPorts.slice(1)) {
+  assert.equal(port.poe_switch_entity, null, `Port ${port.port} must not expose PoE output controls`);
+  assert.equal(port.poe_power_entity, null, `Port ${port.port} must not expose PoE output power`);
+}
+assert.equal(mergedSpecials.length, 1);
+assert.equal(mergedSpecials[0].key, "uplink");
+assert.equal(mergedSpecials[0].port, 4);
+assert.equal(mergedSpecials[0].label, "Uplink / PoE-In");
+assert.equal(mergedSpecials[0].media, "rj45");
+
+console.log("Model alias compatibility checks passed.");

--- a/tests/model-aliases.mjs
+++ b/tests/model-aliases.mjs
@@ -47,6 +47,7 @@ const discoveredPorts = [1, 2, 3, 4].map((port) => ({
   label: String(port),
   poe_switch_entity: `switch.iw_hd_data_${port}_poe`,
   poe_power_entity: `sensor.iw_hd_data_${port}_poe_power`,
+  power_cycle_entity: `button.iw_hd_data_${port}_power_cycle`,
 }));
 const mergedPorts = mergePortsWithLayout(layout, discoveredPorts);
 const mergedSpecials = mergeSpecialsWithLayout(layout, [], discoveredPorts);
@@ -67,5 +68,8 @@ assert.equal(mergedSpecials[0].key, "uplink");
 assert.equal(mergedSpecials[0].port, 4);
 assert.equal(mergedSpecials[0].label, "Uplink / PoE-In");
 assert.equal(mergedSpecials[0].media, "rj45");
+assert.equal(mergedSpecials[0].poe_switch_entity, null);
+assert.equal(mergedSpecials[0].poe_power_entity, null);
+assert.equal(mergedSpecials[0].power_cycle_entity, null);
 
 console.log("Model alias compatibility checks passed.");

--- a/tests/model-aliases.mjs
+++ b/tests/model-aliases.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 
+import { classifyDeviceType } from "../src/classify.js";
 import { mergePortsWithLayout, mergeSpecialsWithLayout } from "../src/helpers.js";
 import { getDeviceLayout, resolveModelKey } from "../src/model-registry.js";
 
@@ -13,6 +14,12 @@ assert.equal(
   resolveModelKey(inWallHd),
   "UAPIWHD",
   "Home Assistant's UHDIW identifier must resolve to the UAP In-Wall HD registry entry"
+);
+
+assert.equal(
+  classifyDeviceType(inWallHd, { ports: true }),
+  "access_point",
+  "UHDIW must remain an access point when integrated ports are its only detected capability"
 );
 
 assert.deepEqual(


### PR DESCRIPTION
### Motivation
- Home Assistant reports some UAP In‑Wall HD devices with the `UHDIW` identifier and those devices need the same layout and integrated‑port/PoE handling as the registry entry for `UAPIWHD`.
- The device exposes PoE output only on port 1 while the uplink/PoE input is on port 4, so the layout and special slot mapping must reflect that.

### Description
- Enhance the `UAPIWHD` model entry in `src/model-registry.js` to include `rows`, `portCount`, `poePortRange`, and a `specialSlots` entry mapping the uplink to port `4`, while keeping `supportsIntegratedPorts` enabled. 
- Update `resolveModelKey` to treat the `UHDIW` identifier as an alias for `UAPIWHD` by returning `UAPIWHD` when `candidate === "UHDIW"`.
- Add `tests/model-aliases.mjs` to assert that `UHDIW` resolves to `UAPIWHD`, that the layout matches the updated registry entry, and that merged port and special slot behavior (PoE output only on port 1 and uplink on port 4) is correct.
- Add a bug fix note to `CHANGELOG.md` documenting recognition of the `UHDIW` identifier and the port/PoE behavior.

### Testing
- Ran the new unit checks with `node tests/model-aliases.mjs`, which executed the layout resolution and merge assertions and completed successfully. 
- Ran the existing test suite with `npm test`, and all tests including the new alias checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa3fa7692988333bc1b3cb16c72b2c9)