### PR TITLE
Map USG-PRO model identifier to existing UGW4 (USG Pro 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [v0.8.7]
 
 ### 🐛 Bug Fixes
+- Recognize the `USG-PRO` model identifier as the existing USG Pro 4 (`UGW4`) gateway.
 - Recognize the `UHDIW` model identifier reported by Home Assistant as a UAP In-Wall HD, with PoE output on port 1 and the uplink/PoE input assigned to port 4.
 
 ### ✨ Improvements

--- a/src/model-registry.js
+++ b/src/model-registry.js
@@ -1235,6 +1235,7 @@ export function resolveModelKey(device) {
     if (candidate.includes("USG3P"))              return "UGW3";
     if (candidate.includes("USG3"))               return "UGW3";
     if (candidate === "UGW4")                     return "UGW4";
+    if (candidate === "USGPRO")                   return "UGW4";
     if (candidate.includes("USGPRO4"))            return "UGW4";
     if (candidate.includes("USG4"))               return "UGW4";
     if (candidate === "UGWXG")                    return "UGWXG";

--- a/tests/model-aliases.mjs
+++ b/tests/model-aliases.mjs
@@ -72,4 +72,30 @@ assert.equal(mergedSpecials[0].poe_switch_entity, null);
 assert.equal(mergedSpecials[0].poe_power_entity, null);
 assert.equal(mergedSpecials[0].power_cycle_entity, null);
 
+for (const identifier of ["UGW4", "USG-PRO", "USG-PRO-4", "USG Pro 4"]) {
+  const usgPro = {
+    model_id: identifier,
+    model: "UniFi Security Gateway",
+    name: "Gateway",
+  };
+
+  assert.equal(
+    resolveModelKey(usgPro),
+    "UGW4",
+    `${identifier} must resolve to the canonical aiounifi UGW4 registry entry`
+  );
+  assert.equal(classifyDeviceType(usgPro), "gateway");
+  assert.equal(
+    getDeviceLayout(usgPro).displayModel,
+    "USG Pro 4",
+    `${identifier} must use the existing six-port USG Pro 4 layout`
+  );
+}
+
+assert.equal(
+  resolveModelKey({ model_id: "S40Lite" }),
+  null,
+  "The unrelated S40Lite identifier must not resolve to a UniFi Dream Machine"
+);
+
 console.log("Model alias compatibility checks passed.");


### PR DESCRIPTION
### Motivation
- Ensure devices reporting the `USG-PRO` (and common variants) model identifier are treated as the existing six-port USG Pro 4 layout (`UGW4`) so classification, layout selection, and telemetry remain consistent.

### Description
- Add a model registry entry mapping `USGPRO` to the canonical `UGW4` key in `src/model-registry.js` so `USG-PRO` variants resolve to the existing layout.
- Add unit checks in `tests/model-aliases.mjs` to assert that identifiers `UGW4`, `USG-PRO`, `USG-PRO-4`, and `USG Pro 4` resolve to `UGW4`, classify as `gateway`, and use the `USG Pro 4` display layout, and to guard that unrelated identifiers like `S40Lite` do not resolve incorrectly.
- Update `CHANGELOG.md` to document recognition of the `USG-PRO` model identifier.

### Testing
- Ran `tests/model-aliases.mjs` which includes the new alias checks and compatibility assertions, and the script completed successfully with the log message indicating all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa4f5ee95c88333aafb5e1256fd4073)